### PR TITLE
docs(#21): Deploy Docusaurus site to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pages-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-lint:
     name: Build & Lint
@@ -36,3 +40,30 @@ jobs:
 
       - name: Check formatting
         run: npx prettier --check .
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [build-and-lint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout and build
+        run: |
+          git init
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git fetch --depth 1 origin "${{ github.sha }}"
+          git checkout FETCH_HEAD
+          npm ci
+          npm run build
+
+      - name: Deploy to gh-pages
+        run: |
+          cd build
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy to GitHub Pages from ${{ github.sha }}"
+          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:gh-pages


### PR DESCRIPTION
## Summary
- Add deploy job to CI workflow that pushes built site to `gh-pages` branch on push to main
- Uses only inline `run:` commands (no external marketplace actions) per org policy
- Add concurrency group to prevent overlapping deployments

## Changes
- `.github/workflows/ci.yml`: Added `deploy` job with checkout/build and git-push-to-gh-pages steps, plus concurrency config

## Testing
- [x] Build passes locally (`npm run build`)
- [x] Markdown lint passes (`npx markdownlint docs/`)
- [x] Prettier passes (`npx prettier --check .`)

## Manual Steps Required
After the first merge to main creates the `gh-pages` branch, GitHub Pages must be configured:
- **Settings → Pages → Source**: Deploy from a branch
- **Branch**: `gh-pages`, `/ (root)`

Closes #21

🤖 Generated with Claude Code