### PR TITLE
docs(#5): Define actors for motor insurance domain

### DIFF
--- a/docs/actors/external-actors.md
+++ b/docs/actors/external-actors.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 3
+---
+
+# External Actors
+
+External actors are systems, organizations, and third parties that the
+TryggFörsäkring platform integrates with. They participate in insurance business
+processes through APIs, file exchanges, or manual interactions but do not log in
+to the platform directly.
+
+## Transportstyrelsen
+
+- **Swedish term:** Transportstyrelsen
+- **English name:** Swedish Transport Agency
+- **Description:** The government agency that manages the national vehicle
+  registry (fordonsregistret). All registered vehicles in Sweden are recorded
+  in this registry, including ownership, technical specifications, and
+  insurance status. Transportstyrelsen is a critical integration point for
+  motor insurance operations.
+- **Responsibilities:**
+  - Maintain the vehicle registry with ownership and technical data
+  - Receive and publish insurance status notifications from insurers
+  - Provide vehicle data lookups for quoting and policy issuance
+  - Monitor that all registered vehicles have valid trafikförsäkring
+  - Issue trafikförsäkringsavgift (penalty fee) for uninsured vehicles
+- **Key interactions:** Quote and bind (vehicle data lookup), policy
+  administration (insurance status notification), trafikförsäkring
+  verification
+- **Regulatory relevance:**
+  - FSA — insurers must notify Transportstyrelsen of policy changes within
+    regulated timeframes (FSA-009)
+  - FSA — mandatory trafikförsäkring status is verified through
+    Transportstyrelsen (FSA-007)
+
+## Trafikförsäkringsföreningen (TFF)
+
+- **Swedish term:** Trafikförsäkringsföreningen (TFF)
+- **English name:** Swedish Motor Insurers
+- **Description:** The industry organization for all companies that sell
+  trafikförsäkring in Sweden. Membership in TFF is mandatory for any insurer
+  offering motor third-party liability insurance. TFF handles claims involving
+  uninsured vehicles, manages the central claims database, and coordinates
+  industry-wide processes.
+- **Responsibilities:**
+  - Provide trafikförsäkring for uninsured and unidentified vehicles
+  - Manage the central claims database (skaderegister)
+  - Coordinate inter-company claims settlement (regressrätt)
+  - Maintain industry statistics and risk data
+  - Administer the bonus class transfer process between insurers
+- **Key interactions:** Claims handling (inter-company settlement),
+  trafikförsäkring (uninsured vehicle claims), bonus class transfers,
+  industry reporting
+- **Regulatory relevance:**
+  - FSA — membership is mandatory for trafikförsäkring sellers (FSA-008)
+  - FSA — TFF provides trafikförsäkring for uninsured vehicles as required by
+    Trafikskadelagen (FSA-007)
+
+## BankID
+
+- **Swedish term:** BankID
+- **English name:** BankID (Electronic Identification)
+- **Description:** The leading electronic identification and digital signing
+  service in Sweden, used by the vast majority of the adult population. BankID
+  provides strong authentication (two-factor) and legally binding digital
+  signatures, making it the standard for identity verification in Swedish
+  insurance.
+- **Responsibilities:**
+  - Authenticate customers and intermediaries during platform login
+  - Provide digital signing for policy documents and applications
+  - Verify identity during claims reporting and sensitive operations
+  - Support age and identity verification for regulatory compliance
+- **Key interactions:** Quote and bind (identity verification, policy signing),
+  claims reporting (identity verification), policy administration (change
+  authorization)
+- **Regulatory relevance:**
+  - IDD — supports customer identification requirements for demands-and-needs
+    assessments (IDD-001) and record keeping (IDD-008)
+  - GDPR — strong authentication supports data protection obligations; identity
+    verification for data subject rights requests (GDPR-001, GDPR-006)
+  - FSA — supports know-your-customer obligations and contract signing
+    requirements (FSA-012)
+
+## Repair Shop (Verkstad)
+
+- **Swedish term:** Verkstad
+- **English name:** Authorized Repair Shop
+- **Description:** Vehicle repair facilities authorized by TryggFörsäkring to
+  perform repairs on insured vehicles. Authorized repair shops have agreements
+  with the insurer covering repair quality standards, pricing, and direct
+  billing. Customers may also choose non-authorized shops, but the claims
+  process differs.
+- **Responsibilities:**
+  - Receive repair assignments from TryggFörsäkring
+  - Provide repair cost estimates for claims assessment
+  - Perform vehicle repairs according to agreed quality standards
+  - Submit invoices directly to TryggFörsäkring (direct settlement)
+  - Report repair completion and return vehicle to customer
+- **Key interactions:** Claims handling (repair assignment, cost estimation,
+  invoicing), claims adjustment (coordinated assessments)
+- **Regulatory relevance:**
+  - FSA — repair quality and cost management support fair claims settlement
+    obligations (FSA-010)
+  - GDPR — receives limited personal data (vehicle owner, contact details)
+    necessary for repair coordination; subject to data processing agreements
+    (GDPR-001)
+
+## Police (Polis)
+
+- **Swedish term:** Polis
+- **English name:** Swedish Police Authority
+- **Description:** The national police authority involved in motor insurance
+  through traffic accident investigations, accident reports, and fraud
+  investigations. Police reports are an important source of evidence in claims
+  handling, particularly for liability determination and fraud detection.
+- **Responsibilities:**
+  - Investigate traffic accidents and produce accident reports
+  - Provide accident reports to insurers upon request
+  - Investigate suspected insurance fraud
+  - Issue reports for vehicle theft and vandalism
+- **Key interactions:** Claims handling (accident reports, liability
+  determination), fraud detection (fraud investigation reports)
+- **Regulatory relevance:**
+  - FSA — police reports support fair and evidence-based claims settlement
+    (FSA-010)
+  - GDPR — exchange of personal data between police and insurer must have a
+    legal basis; data minimization applies (GDPR-001)
+
+## Medical Provider (Vårdgivare)
+
+- **Swedish term:** Vårdgivare
+- **English name:** Medical Provider / Healthcare Provider
+- **Description:** Hospitals, clinics, and healthcare professionals who treat
+  injuries resulting from traffic accidents. Medical providers supply injury
+  reports and treatment documentation needed for personal injury claims under
+  trafikförsäkring. The exchange of medical information is subject to strict
+  confidentiality and data protection rules.
+- **Responsibilities:**
+  - Treat injuries resulting from traffic accidents
+  - Provide medical certificates and treatment reports for claims
+  - Assess injury severity and expected recovery for claims valuation
+  - Supply documentation for permanent disability assessments
+- **Key interactions:** Claims handling (personal injury claims, medical
+  documentation), trafikförsäkring (injury compensation)
+- **Regulatory relevance:**
+  - GDPR — medical data is special category personal data requiring explicit
+    consent or legal basis for processing (GDPR-001, GDPR-004)
+  - FSA — medical documentation supports fair personal injury claims settlement
+    (FSA-010)
+  - Swedish patient data legislation (Patientdatalagen 2008:355) governs
+    healthcare providers' data sharing with insurers
+
+## Payment Provider
+
+- **Swedish term:** Betalningsleverantör
+- **English name:** Payment Provider / Payment Service Provider
+- **Description:** External payment processing services that handle premium
+  collection and claims disbursement for TryggFörsäkring. Payment providers
+  support various payment methods including direct debit (autogiro), card
+  payments, and bank transfers (Swish, bankgiro).
+- **Responsibilities:**
+  - Process premium payments (recurring and one-time)
+  - Handle claims disbursements to policyholders and third parties
+  - Manage direct debit mandates (autogiro agreements)
+  - Provide payment status notifications and reconciliation data
+  - Support refund processing for cancellations and overpayments
+- **Key interactions:** Quote and bind (initial premium payment), policy
+  administration (recurring premium collection), claims handling (claims
+  disbursement), cancellations (refund processing)
+- **Regulatory relevance:**
+  - GDPR — processes personal data (payment details, bank accounts) under data
+    processing agreements (GDPR-001)
+  - PSD2 (Payment Services Directive) — payment processing must comply with
+    strong customer authentication requirements
+  - FSA — premium collection and claims payment are regulated insurance
+    activities

--- a/docs/actors/index.md
+++ b/docs/actors/index.md
@@ -4,6 +4,40 @@ sidebar_position: 1
 
 # Actors
 
-This section defines the actors that interact with the TryggFörsäkring insurance platform.
+Actors represent the roles and external systems that interact with the
+TryggFörsäkring insurance platform. They are referenced by user stories and use
+cases throughout all delivery phases. Each actor definition includes the Swedish
+term, responsibilities, key interactions, and regulatory relevance.
 
-_Content will be added in a subsequent issue._
+## Actor Summary
+
+| Actor                                                                                        | Type     | Primary Role                                          |
+| -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
+| [Customer (Privatkund)](internal-actors#customer-privatkund)                                 | Internal | Private individual seeking or holding motor insurance |
+| [Corporate Customer (Företagskund)](internal-actors#corporate-customer-företagskund)         | Internal | Business entity with fleet or commercial vehicles     |
+| [Insurance Agent (Försäkringsagent)](internal-actors#insurance-agent-försäkringsagent)       | Internal | Represents insurers and sells policies                |
+| [Insurance Broker (Försäkringsmäklare)](internal-actors#insurance-broker-försäkringsmäklare) | Internal | Independent advisor representing customer interests   |
+| [Claims Handler (Skadereglerare)](internal-actors#claims-handler-skadereglerare)             | Internal | Assesses, investigates, and settles claims            |
+| [Claims Adjuster (Värderare)](internal-actors#claims-adjuster-värderare)                     | Internal | Specialized vehicle damage assessor                   |
+| [Underwriter (Riskbedömare)](internal-actors#underwriter-riskbedömare)                       | Internal | Assesses risk, sets premiums and terms                |
+| [Actuary](internal-actors#actuary)                                                           | Internal | Develops pricing models and analyzes claims data      |
+| [Compliance Officer](internal-actors#compliance-officer)                                     | Internal | Ensures regulatory adherence                          |
+| [System Administrator](internal-actors#system-administrator)                                 | Internal | Manages platform configuration and access             |
+| [Transportstyrelsen](external-actors#transportstyrelsen)                                     | External | Swedish Transport Agency — vehicle registry           |
+| [TFF](external-actors#trafikförsäkringsföreningen-tff)                                       | External | Swedish Motor Insurers — uninsured claims             |
+| [BankID](external-actors#bankid)                                                             | External | Electronic identification and signing                 |
+| [Repair Shop (Verkstad)](external-actors#repair-shop-verkstad)                               | External | Authorized vehicle repair network                     |
+| [Police (Polis)](external-actors#police-polis)                                               | External | Accident reports and fraud investigation              |
+| [Medical Provider (Vårdgivare)](external-actors#medical-provider-vårdgivare)                 | External | Injury treatment and medical reports                  |
+| [Payment Provider](external-actors#payment-provider)                                         | External | Payment processing for premiums and claims            |
+
+## Internal vs External Actors
+
+**Internal actors** are people within TryggFörsäkring or its distribution
+network who use the platform directly. They authenticate via BankID or
+organizational credentials and have role-based access to platform functionality.
+
+**External actors** are systems, organizations, or third parties that the
+platform integrates with through APIs, file exchanges, or manual processes. They
+do not log in to the platform directly but are essential participants in
+insurance business processes.

--- a/docs/actors/internal-actors.md
+++ b/docs/actors/internal-actors.md
@@ -1,0 +1,244 @@
+---
+sidebar_position: 2
+---
+
+# Internal Actors
+
+Internal actors are people within TryggFörsäkring or its authorized distribution
+network who interact directly with the insurance platform. Each actor has
+role-based access to specific platform functionality.
+
+## Customer (Privatkund)
+
+- **Swedish term:** Privatkund
+- **Description:** A private individual who seeks, purchases, or holds a motor
+  insurance policy with TryggFörsäkring. Customers interact with the platform
+  through self-service channels (web, mobile) and through agents or brokers.
+- **Responsibilities:**
+  - Request and compare motor insurance quotes
+  - Purchase and sign insurance policies (via BankID)
+  - Report claims (skadeanmälan) and track claim status
+  - Manage policy details (vehicle changes, address updates, coverage
+    adjustments)
+  - Pay premiums and manage payment methods
+  - Exercise cooling-off rights (ångerrätt) and request cancellations
+- **Key interactions:** Quote and bind, policy administration, claims reporting,
+  renewals, cancellations
+- **Regulatory relevance:**
+  - GDPR — data subject with rights to access, rectification, erasure, and
+    portability (GDPR-001 to GDPR-006)
+  - IDD — entitled to demands-and-needs assessment before purchase (IDD-001),
+    IPID document (IDD-002), and pre-contractual information (IDD-003)
+  - FSA — protected by consumer protection rules (FSA-004), cooling-off rights
+    (FSA-013), and fair claims settlement (FSA-010)
+
+## Corporate Customer (Företagskund)
+
+- **Swedish term:** Företagskund
+- **Description:** A business entity (company, organization, or sole proprietor)
+  that holds motor insurance for one or more vehicles. Corporate customers
+  typically manage fleet policies and have different needs than private
+  individuals.
+- **Responsibilities:**
+  - Request fleet insurance quotes covering multiple vehicles
+  - Manage fleet policy administration (add/remove vehicles, adjust coverage)
+  - Designate authorized contacts for policy and claims management
+  - Report and track claims for fleet vehicles
+  - Review fleet-level reporting and premium summaries
+- **Key interactions:** Quote and bind (fleet), policy administration, claims
+  reporting, renewals, fleet management
+- **Regulatory relevance:**
+  - GDPR — data controller for employee data; employees who are named drivers
+    are data subjects (GDPR-001)
+  - IDD — entitled to demands-and-needs assessment (IDD-001), though
+    requirements differ for professional vs. non-professional customers
+  - FSA — mandatory trafikförsäkring for every registered vehicle in the fleet
+    (FSA-007)
+
+## Insurance Agent (Försäkringsagent)
+
+- **Swedish term:** Försäkringsagent
+- **Description:** A licensed intermediary who represents one or more insurance
+  companies and sells their products. Agents act on behalf of the insurer and
+  are registered with Finansinspektionen. In the Swedish market, agents are
+  tied to the insurers they represent.
+- **Responsibilities:**
+  - Conduct demands-and-needs assessments for customers
+  - Present quotes and recommend appropriate coverage tiers
+  - Bind policies on behalf of TryggFörsäkring
+  - Provide pre-contractual information (IPID, disclosure documents)
+  - Maintain competence through ongoing training
+  - Record all advisory interactions
+- **Key interactions:** Quote and bind, demands-and-needs assessment, policy
+  administration
+- **Regulatory relevance:**
+  - IDD — must perform demands-and-needs assessment (IDD-001), provide IPID
+    (IDD-002), disclose distribution status and remuneration (IDD-005), and
+    maintain professional competence (IDD-009)
+  - FSA — must be registered with Finansinspektionen; subject to consumer
+    protection rules (FSA-004)
+  - IDD — advisory records must be retained (IDD-008)
+
+## Insurance Broker (Försäkringsmäklare)
+
+- **Swedish term:** Försäkringsmäklare
+- **Description:** An independent intermediary who represents the customer's
+  interests, not the insurer's. Brokers are licensed by Finansinspektionen and
+  must provide impartial advice based on a sufficiently large number of
+  insurance products available on the market.
+- **Responsibilities:**
+  - Conduct independent demands-and-needs assessments
+  - Compare products across multiple insurers on behalf of the customer
+  - Provide personalized recommendations with documented rationale
+  - Submit policy applications and bind coverage through the platform
+  - Disclose remuneration and potential conflicts of interest
+- **Key interactions:** Quote and bind, demands-and-needs assessment, policy
+  administration
+- **Regulatory relevance:**
+  - IDD — must perform demands-and-needs assessment (IDD-001), provide
+    personalized advice (IDD-006), disclose conflicts of interest (IDD-005),
+    and maintain competence (IDD-009)
+  - FSA — must be registered with Finansinspektionen; held to a higher
+    impartiality standard than agents (FSA-004)
+  - IDD — all advisory and recommendation records must be retained (IDD-008)
+
+## Claims Handler (Skadereglerare)
+
+- **Swedish term:** Skadereglerare
+- **Description:** An employee of TryggFörsäkring responsible for the end-to-end
+  handling of insurance claims. Claims handlers receive first notifications of
+  loss (FNOL), investigate claim circumstances, determine coverage and
+  liability, and authorize settlements.
+- **Responsibilities:**
+  - Receive and register claims (skadeanmälan)
+  - Investigate claim circumstances and verify coverage
+  - Determine liability and assess claim value
+  - Coordinate with claims adjusters, repair shops, and medical providers
+  - Authorize claim payments and settlements
+  - Handle disputes and escalate to complaints procedures when needed
+  - Detect and flag potential fraud
+- **Key interactions:** Claims handling, fraud detection, settlement processing
+- **Regulatory relevance:**
+  - FSA — must ensure fair and timely claims settlement (FSA-010); adhere to
+    complaints handling procedures (FSA-011)
+  - GDPR — processes sensitive personal data (injury details, police reports);
+    must follow data minimization and purpose limitation (GDPR-001, GDPR-004)
+  - FSA — claims records must be retained per record-keeping requirements
+    (FSA-014)
+
+## Claims Adjuster (Värderare)
+
+- **Swedish term:** Värderare
+- **Description:** A specialized assessor who evaluates vehicle damage following
+  an insured event. Claims adjusters may be internal employees or contracted
+  external specialists. They determine repair costs, total loss valuations,
+  and whether damage is consistent with reported circumstances.
+- **Responsibilities:**
+  - Inspect damaged vehicles (on-site or via photographs/video)
+  - Estimate repair costs using industry-standard valuation tools
+  - Determine whether a vehicle is repairable or a total loss
+  - Verify that reported damage is consistent with the incident description
+  - Provide assessment reports to claims handlers
+  - Coordinate with authorized repair shops on repair scope
+- **Key interactions:** Claims handling, repair shop coordination, fraud
+  detection
+- **Regulatory relevance:**
+  - FSA — assessments support fair claims settlement obligations (FSA-010)
+  - GDPR — may access personal data related to the claim; subject to purpose
+    limitation (GDPR-001)
+
+## Underwriter (Riskbedömare)
+
+- **Swedish term:** Riskbedömare
+- **Description:** An insurance professional responsible for evaluating risk and
+  determining the terms, conditions, and pricing of insurance policies.
+  Underwriters apply risk models, bonus class rules, and company guidelines
+  to decide whether to accept, modify, or decline insurance applications.
+- **Responsibilities:**
+  - Evaluate insurance applications against risk criteria
+  - Set premium levels based on risk factors (vehicle type, driver history,
+    bonus class, geographic area)
+  - Define policy terms and conditions, including exclusions
+  - Apply bonus class rules and no-claims discount schedules
+  - Approve or decline high-risk or non-standard applications
+  - Maintain and update underwriting guidelines
+- **Key interactions:** Quote and bind, underwriting and bonus management,
+  renewals, policy administration
+- **Regulatory relevance:**
+  - FSA — pricing must comply with consumer protection and fair treatment rules
+    (FSA-004); products must be governed by product oversight processes
+    (FSA-005)
+  - IDD — products must have defined target markets and be monitored
+    post-launch (IDD-004)
+  - GDPR — risk assessments may process personal data; automated decisions must
+    allow for human review (GDPR-001)
+
+## Actuary
+
+- **Swedish term:** Aktuarie
+- **Description:** A professional who applies mathematical and statistical
+  methods to assess risk, develop pricing models, and analyze claims data.
+  Actuaries ensure that premium levels are adequate to cover expected claims
+  while remaining competitive. They also support solvency calculations and
+  regulatory reporting.
+- **Responsibilities:**
+  - Develop and maintain motor insurance pricing models
+  - Analyze claims frequency, severity, and trends
+  - Calculate technical provisions and reserves
+  - Support Solvency II capital adequacy calculations (FSA-003)
+  - Provide data-driven input to underwriting guidelines
+  - Monitor loss ratios and recommend pricing adjustments
+- **Key interactions:** Underwriting and bonus management, regulatory reporting,
+  pricing model development
+- **Regulatory relevance:**
+  - FSA — supports Solvency II compliance (FSA-003) and supervisory reporting
+    (FSA-006)
+  - GDPR — works with aggregated and anonymized claims data; must ensure
+    personal data is properly anonymized before analysis (GDPR-001)
+
+## Compliance Officer
+
+- **Swedish term:** Regelefterlevnadsansvarig
+- **Description:** An employee responsible for ensuring that TryggFörsäkring's
+  operations comply with all applicable regulations, including FSA rules,
+  GDPR, and IDD. The compliance officer monitors regulatory changes, conducts
+  internal audits, and advises the business on compliance matters.
+- **Responsibilities:**
+  - Monitor regulatory changes from FSA, IMY, and EU institutions
+  - Conduct internal compliance audits and gap analyses
+  - Review new products and processes for regulatory compliance
+  - Manage complaints handling procedures (FSA-011, IDD-010)
+  - Oversee GDPR compliance including data protection impact assessments
+  - Ensure IDD distribution requirements are met across all channels
+  - Report compliance status to management and board
+- **Key interactions:** Regulatory reporting, product governance, complaints
+  handling, audit
+- **Regulatory relevance:**
+  - FSA — oversees compliance with all FSA requirements (FSA-001 through
+    FSA-014)
+  - GDPR — ensures data protection obligations are met (GDPR-001 through
+    GDPR-006)
+  - IDD — monitors distribution compliance (IDD-001 through IDD-010)
+
+## System Administrator
+
+- **Swedish term:** Systemadministratör
+- **Description:** An IT professional responsible for managing the technical
+  configuration, user access, and operational health of the insurance
+  platform. System administrators do not make business decisions but ensure
+  the platform is available, secure, and properly configured.
+- **Responsibilities:**
+  - Manage user accounts, roles, and access permissions
+  - Configure platform settings (product parameters, workflow rules, integration
+    endpoints)
+  - Monitor system health, performance, and availability
+  - Manage integrations with external systems (Transportstyrelsen, BankID, TFF)
+  - Execute data retention and archival procedures
+  - Support incident response and disaster recovery
+- **Key interactions:** Platform configuration, user management, system
+  integration, data retention
+- **Regulatory relevance:**
+  - GDPR — responsible for implementing technical measures for data protection,
+    access control, and data retention/deletion (GDPR-001, GDPR-005)
+  - FSA — supports record-keeping obligations through system configuration
+    (FSA-014)

--- a/versioned_docs/version-phase-1/actors/external-actors.md
+++ b/versioned_docs/version-phase-1/actors/external-actors.md
@@ -1,0 +1,176 @@
+---
+sidebar_position: 3
+---
+
+# External Actors
+
+External actors are systems, organizations, and third parties that the
+TryggFörsäkring platform integrates with. They participate in insurance business
+processes through APIs, file exchanges, or manual interactions but do not log in
+to the platform directly.
+
+## Transportstyrelsen
+
+- **Swedish term:** Transportstyrelsen
+- **English name:** Swedish Transport Agency
+- **Description:** The government agency that manages the national vehicle
+  registry (fordonsregistret). All registered vehicles in Sweden are recorded
+  in this registry, including ownership, technical specifications, and
+  insurance status. Transportstyrelsen is a critical integration point for
+  motor insurance operations.
+- **Responsibilities:**
+  - Maintain the vehicle registry with ownership and technical data
+  - Receive and publish insurance status notifications from insurers
+  - Provide vehicle data lookups for quoting and policy issuance
+  - Monitor that all registered vehicles have valid trafikförsäkring
+  - Issue trafikförsäkringsavgift (penalty fee) for uninsured vehicles
+- **Key interactions:** Quote and bind (vehicle data lookup), policy
+  administration (insurance status notification), trafikförsäkring
+  verification
+- **Regulatory relevance:**
+  - FSA — insurers must notify Transportstyrelsen of policy changes within
+    regulated timeframes (FSA-009)
+  - FSA — mandatory trafikförsäkring status is verified through
+    Transportstyrelsen (FSA-007)
+
+## Trafikförsäkringsföreningen (TFF)
+
+- **Swedish term:** Trafikförsäkringsföreningen (TFF)
+- **English name:** Swedish Motor Insurers
+- **Description:** The industry organization for all companies that sell
+  trafikförsäkring in Sweden. Membership in TFF is mandatory for any insurer
+  offering motor third-party liability insurance. TFF handles claims involving
+  uninsured vehicles, manages the central claims database, and coordinates
+  industry-wide processes.
+- **Responsibilities:**
+  - Provide trafikförsäkring for uninsured and unidentified vehicles
+  - Manage the central claims database (skaderegister)
+  - Coordinate inter-company claims settlement (regressrätt)
+  - Maintain industry statistics and risk data
+  - Administer the bonus class transfer process between insurers
+- **Key interactions:** Claims handling (inter-company settlement),
+  trafikförsäkring (uninsured vehicle claims), bonus class transfers,
+  industry reporting
+- **Regulatory relevance:**
+  - FSA — membership is mandatory for trafikförsäkring sellers (FSA-008)
+  - FSA — TFF provides trafikförsäkring for uninsured vehicles as required by
+    Trafikskadelagen (FSA-007)
+
+## BankID
+
+- **Swedish term:** BankID
+- **English name:** BankID (Electronic Identification)
+- **Description:** The leading electronic identification and digital signing
+  service in Sweden, used by the vast majority of the adult population. BankID
+  provides strong authentication (two-factor) and legally binding digital
+  signatures, making it the standard for identity verification in Swedish
+  insurance.
+- **Responsibilities:**
+  - Authenticate customers and intermediaries during platform login
+  - Provide digital signing for policy documents and applications
+  - Verify identity during claims reporting and sensitive operations
+  - Support age and identity verification for regulatory compliance
+- **Key interactions:** Quote and bind (identity verification, policy signing),
+  claims reporting (identity verification), policy administration (change
+  authorization)
+- **Regulatory relevance:**
+  - IDD — supports customer identification requirements for demands-and-needs
+    assessments (IDD-001) and record keeping (IDD-008)
+  - GDPR — strong authentication supports data protection obligations; identity
+    verification for data subject rights requests (GDPR-001, GDPR-006)
+  - FSA — supports know-your-customer obligations and contract signing
+    requirements (FSA-012)
+
+## Repair Shop (Verkstad)
+
+- **Swedish term:** Verkstad
+- **English name:** Authorized Repair Shop
+- **Description:** Vehicle repair facilities authorized by TryggFörsäkring to
+  perform repairs on insured vehicles. Authorized repair shops have agreements
+  with the insurer covering repair quality standards, pricing, and direct
+  billing. Customers may also choose non-authorized shops, but the claims
+  process differs.
+- **Responsibilities:**
+  - Receive repair assignments from TryggFörsäkring
+  - Provide repair cost estimates for claims assessment
+  - Perform vehicle repairs according to agreed quality standards
+  - Submit invoices directly to TryggFörsäkring (direct settlement)
+  - Report repair completion and return vehicle to customer
+- **Key interactions:** Claims handling (repair assignment, cost estimation,
+  invoicing), claims adjustment (coordinated assessments)
+- **Regulatory relevance:**
+  - FSA — repair quality and cost management support fair claims settlement
+    obligations (FSA-010)
+  - GDPR — receives limited personal data (vehicle owner, contact details)
+    necessary for repair coordination; subject to data processing agreements
+    (GDPR-001)
+
+## Police (Polis)
+
+- **Swedish term:** Polis
+- **English name:** Swedish Police Authority
+- **Description:** The national police authority involved in motor insurance
+  through traffic accident investigations, accident reports, and fraud
+  investigations. Police reports are an important source of evidence in claims
+  handling, particularly for liability determination and fraud detection.
+- **Responsibilities:**
+  - Investigate traffic accidents and produce accident reports
+  - Provide accident reports to insurers upon request
+  - Investigate suspected insurance fraud
+  - Issue reports for vehicle theft and vandalism
+- **Key interactions:** Claims handling (accident reports, liability
+  determination), fraud detection (fraud investigation reports)
+- **Regulatory relevance:**
+  - FSA — police reports support fair and evidence-based claims settlement
+    (FSA-010)
+  - GDPR — exchange of personal data between police and insurer must have a
+    legal basis; data minimization applies (GDPR-001)
+
+## Medical Provider (Vårdgivare)
+
+- **Swedish term:** Vårdgivare
+- **English name:** Medical Provider / Healthcare Provider
+- **Description:** Hospitals, clinics, and healthcare professionals who treat
+  injuries resulting from traffic accidents. Medical providers supply injury
+  reports and treatment documentation needed for personal injury claims under
+  trafikförsäkring. The exchange of medical information is subject to strict
+  confidentiality and data protection rules.
+- **Responsibilities:**
+  - Treat injuries resulting from traffic accidents
+  - Provide medical certificates and treatment reports for claims
+  - Assess injury severity and expected recovery for claims valuation
+  - Supply documentation for permanent disability assessments
+- **Key interactions:** Claims handling (personal injury claims, medical
+  documentation), trafikförsäkring (injury compensation)
+- **Regulatory relevance:**
+  - GDPR — medical data is special category personal data requiring explicit
+    consent or legal basis for processing (GDPR-001, GDPR-004)
+  - FSA — medical documentation supports fair personal injury claims settlement
+    (FSA-010)
+  - Swedish patient data legislation (Patientdatalagen 2008:355) governs
+    healthcare providers' data sharing with insurers
+
+## Payment Provider
+
+- **Swedish term:** Betalningsleverantör
+- **English name:** Payment Provider / Payment Service Provider
+- **Description:** External payment processing services that handle premium
+  collection and claims disbursement for TryggFörsäkring. Payment providers
+  support various payment methods including direct debit (autogiro), card
+  payments, and bank transfers (Swish, bankgiro).
+- **Responsibilities:**
+  - Process premium payments (recurring and one-time)
+  - Handle claims disbursements to policyholders and third parties
+  - Manage direct debit mandates (autogiro agreements)
+  - Provide payment status notifications and reconciliation data
+  - Support refund processing for cancellations and overpayments
+- **Key interactions:** Quote and bind (initial premium payment), policy
+  administration (recurring premium collection), claims handling (claims
+  disbursement), cancellations (refund processing)
+- **Regulatory relevance:**
+  - GDPR — processes personal data (payment details, bank accounts) under data
+    processing agreements (GDPR-001)
+  - PSD2 (Payment Services Directive) — payment processing must comply with
+    strong customer authentication requirements
+  - FSA — premium collection and claims payment are regulated insurance
+    activities

--- a/versioned_docs/version-phase-1/actors/index.md
+++ b/versioned_docs/version-phase-1/actors/index.md
@@ -4,6 +4,40 @@ sidebar_position: 1
 
 # Actors
 
-This section defines the actors that interact with the TryggFörsäkring insurance platform.
+Actors represent the roles and external systems that interact with the
+TryggFörsäkring insurance platform. They are referenced by user stories and use
+cases throughout all delivery phases. Each actor definition includes the Swedish
+term, responsibilities, key interactions, and regulatory relevance.
 
-_Content will be added in a subsequent issue._
+## Actor Summary
+
+| Actor                                                                                        | Type     | Primary Role                                          |
+| -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
+| [Customer (Privatkund)](internal-actors#customer-privatkund)                                 | Internal | Private individual seeking or holding motor insurance |
+| [Corporate Customer (Företagskund)](internal-actors#corporate-customer-företagskund)         | Internal | Business entity with fleet or commercial vehicles     |
+| [Insurance Agent (Försäkringsagent)](internal-actors#insurance-agent-försäkringsagent)       | Internal | Represents insurers and sells policies                |
+| [Insurance Broker (Försäkringsmäklare)](internal-actors#insurance-broker-försäkringsmäklare) | Internal | Independent advisor representing customer interests   |
+| [Claims Handler (Skadereglerare)](internal-actors#claims-handler-skadereglerare)             | Internal | Assesses, investigates, and settles claims            |
+| [Claims Adjuster (Värderare)](internal-actors#claims-adjuster-värderare)                     | Internal | Specialized vehicle damage assessor                   |
+| [Underwriter (Riskbedömare)](internal-actors#underwriter-riskbedömare)                       | Internal | Assesses risk, sets premiums and terms                |
+| [Actuary](internal-actors#actuary)                                                           | Internal | Develops pricing models and analyzes claims data      |
+| [Compliance Officer](internal-actors#compliance-officer)                                     | Internal | Ensures regulatory adherence                          |
+| [System Administrator](internal-actors#system-administrator)                                 | Internal | Manages platform configuration and access             |
+| [Transportstyrelsen](external-actors#transportstyrelsen)                                     | External | Swedish Transport Agency — vehicle registry           |
+| [TFF](external-actors#trafikförsäkringsföreningen-tff)                                       | External | Swedish Motor Insurers — uninsured claims             |
+| [BankID](external-actors#bankid)                                                             | External | Electronic identification and signing                 |
+| [Repair Shop (Verkstad)](external-actors#repair-shop-verkstad)                               | External | Authorized vehicle repair network                     |
+| [Police (Polis)](external-actors#police-polis)                                               | External | Accident reports and fraud investigation              |
+| [Medical Provider (Vårdgivare)](external-actors#medical-provider-vårdgivare)                 | External | Injury treatment and medical reports                  |
+| [Payment Provider](external-actors#payment-provider)                                         | External | Payment processing for premiums and claims            |
+
+## Internal vs External Actors
+
+**Internal actors** are people within TryggFörsäkring or its distribution
+network who use the platform directly. They authenticate via BankID or
+organizational credentials and have role-based access to platform functionality.
+
+**External actors** are systems, organizations, or third parties that the
+platform integrates with through APIs, file exchanges, or manual processes. They
+do not log in to the platform directly but are essential participants in
+insurance business processes.

--- a/versioned_docs/version-phase-1/actors/internal-actors.md
+++ b/versioned_docs/version-phase-1/actors/internal-actors.md
@@ -1,0 +1,244 @@
+---
+sidebar_position: 2
+---
+
+# Internal Actors
+
+Internal actors are people within TryggFörsäkring or its authorized distribution
+network who interact directly with the insurance platform. Each actor has
+role-based access to specific platform functionality.
+
+## Customer (Privatkund)
+
+- **Swedish term:** Privatkund
+- **Description:** A private individual who seeks, purchases, or holds a motor
+  insurance policy with TryggFörsäkring. Customers interact with the platform
+  through self-service channels (web, mobile) and through agents or brokers.
+- **Responsibilities:**
+  - Request and compare motor insurance quotes
+  - Purchase and sign insurance policies (via BankID)
+  - Report claims (skadeanmälan) and track claim status
+  - Manage policy details (vehicle changes, address updates, coverage
+    adjustments)
+  - Pay premiums and manage payment methods
+  - Exercise cooling-off rights (ångerrätt) and request cancellations
+- **Key interactions:** Quote and bind, policy administration, claims reporting,
+  renewals, cancellations
+- **Regulatory relevance:**
+  - GDPR — data subject with rights to access, rectification, erasure, and
+    portability (GDPR-001 to GDPR-006)
+  - IDD — entitled to demands-and-needs assessment before purchase (IDD-001),
+    IPID document (IDD-002), and pre-contractual information (IDD-003)
+  - FSA — protected by consumer protection rules (FSA-004), cooling-off rights
+    (FSA-013), and fair claims settlement (FSA-010)
+
+## Corporate Customer (Företagskund)
+
+- **Swedish term:** Företagskund
+- **Description:** A business entity (company, organization, or sole proprietor)
+  that holds motor insurance for one or more vehicles. Corporate customers
+  typically manage fleet policies and have different needs than private
+  individuals.
+- **Responsibilities:**
+  - Request fleet insurance quotes covering multiple vehicles
+  - Manage fleet policy administration (add/remove vehicles, adjust coverage)
+  - Designate authorized contacts for policy and claims management
+  - Report and track claims for fleet vehicles
+  - Review fleet-level reporting and premium summaries
+- **Key interactions:** Quote and bind (fleet), policy administration, claims
+  reporting, renewals, fleet management
+- **Regulatory relevance:**
+  - GDPR — data controller for employee data; employees who are named drivers
+    are data subjects (GDPR-001)
+  - IDD — entitled to demands-and-needs assessment (IDD-001), though
+    requirements differ for professional vs. non-professional customers
+  - FSA — mandatory trafikförsäkring for every registered vehicle in the fleet
+    (FSA-007)
+
+## Insurance Agent (Försäkringsagent)
+
+- **Swedish term:** Försäkringsagent
+- **Description:** A licensed intermediary who represents one or more insurance
+  companies and sells their products. Agents act on behalf of the insurer and
+  are registered with Finansinspektionen. In the Swedish market, agents are
+  tied to the insurers they represent.
+- **Responsibilities:**
+  - Conduct demands-and-needs assessments for customers
+  - Present quotes and recommend appropriate coverage tiers
+  - Bind policies on behalf of TryggFörsäkring
+  - Provide pre-contractual information (IPID, disclosure documents)
+  - Maintain competence through ongoing training
+  - Record all advisory interactions
+- **Key interactions:** Quote and bind, demands-and-needs assessment, policy
+  administration
+- **Regulatory relevance:**
+  - IDD — must perform demands-and-needs assessment (IDD-001), provide IPID
+    (IDD-002), disclose distribution status and remuneration (IDD-005), and
+    maintain professional competence (IDD-009)
+  - FSA — must be registered with Finansinspektionen; subject to consumer
+    protection rules (FSA-004)
+  - IDD — advisory records must be retained (IDD-008)
+
+## Insurance Broker (Försäkringsmäklare)
+
+- **Swedish term:** Försäkringsmäklare
+- **Description:** An independent intermediary who represents the customer's
+  interests, not the insurer's. Brokers are licensed by Finansinspektionen and
+  must provide impartial advice based on a sufficiently large number of
+  insurance products available on the market.
+- **Responsibilities:**
+  - Conduct independent demands-and-needs assessments
+  - Compare products across multiple insurers on behalf of the customer
+  - Provide personalized recommendations with documented rationale
+  - Submit policy applications and bind coverage through the platform
+  - Disclose remuneration and potential conflicts of interest
+- **Key interactions:** Quote and bind, demands-and-needs assessment, policy
+  administration
+- **Regulatory relevance:**
+  - IDD — must perform demands-and-needs assessment (IDD-001), provide
+    personalized advice (IDD-006), disclose conflicts of interest (IDD-005),
+    and maintain competence (IDD-009)
+  - FSA — must be registered with Finansinspektionen; held to a higher
+    impartiality standard than agents (FSA-004)
+  - IDD — all advisory and recommendation records must be retained (IDD-008)
+
+## Claims Handler (Skadereglerare)
+
+- **Swedish term:** Skadereglerare
+- **Description:** An employee of TryggFörsäkring responsible for the end-to-end
+  handling of insurance claims. Claims handlers receive first notifications of
+  loss (FNOL), investigate claim circumstances, determine coverage and
+  liability, and authorize settlements.
+- **Responsibilities:**
+  - Receive and register claims (skadeanmälan)
+  - Investigate claim circumstances and verify coverage
+  - Determine liability and assess claim value
+  - Coordinate with claims adjusters, repair shops, and medical providers
+  - Authorize claim payments and settlements
+  - Handle disputes and escalate to complaints procedures when needed
+  - Detect and flag potential fraud
+- **Key interactions:** Claims handling, fraud detection, settlement processing
+- **Regulatory relevance:**
+  - FSA — must ensure fair and timely claims settlement (FSA-010); adhere to
+    complaints handling procedures (FSA-011)
+  - GDPR — processes sensitive personal data (injury details, police reports);
+    must follow data minimization and purpose limitation (GDPR-001, GDPR-004)
+  - FSA — claims records must be retained per record-keeping requirements
+    (FSA-014)
+
+## Claims Adjuster (Värderare)
+
+- **Swedish term:** Värderare
+- **Description:** A specialized assessor who evaluates vehicle damage following
+  an insured event. Claims adjusters may be internal employees or contracted
+  external specialists. They determine repair costs, total loss valuations,
+  and whether damage is consistent with reported circumstances.
+- **Responsibilities:**
+  - Inspect damaged vehicles (on-site or via photographs/video)
+  - Estimate repair costs using industry-standard valuation tools
+  - Determine whether a vehicle is repairable or a total loss
+  - Verify that reported damage is consistent with the incident description
+  - Provide assessment reports to claims handlers
+  - Coordinate with authorized repair shops on repair scope
+- **Key interactions:** Claims handling, repair shop coordination, fraud
+  detection
+- **Regulatory relevance:**
+  - FSA — assessments support fair claims settlement obligations (FSA-010)
+  - GDPR — may access personal data related to the claim; subject to purpose
+    limitation (GDPR-001)
+
+## Underwriter (Riskbedömare)
+
+- **Swedish term:** Riskbedömare
+- **Description:** An insurance professional responsible for evaluating risk and
+  determining the terms, conditions, and pricing of insurance policies.
+  Underwriters apply risk models, bonus class rules, and company guidelines
+  to decide whether to accept, modify, or decline insurance applications.
+- **Responsibilities:**
+  - Evaluate insurance applications against risk criteria
+  - Set premium levels based on risk factors (vehicle type, driver history,
+    bonus class, geographic area)
+  - Define policy terms and conditions, including exclusions
+  - Apply bonus class rules and no-claims discount schedules
+  - Approve or decline high-risk or non-standard applications
+  - Maintain and update underwriting guidelines
+- **Key interactions:** Quote and bind, underwriting and bonus management,
+  renewals, policy administration
+- **Regulatory relevance:**
+  - FSA — pricing must comply with consumer protection and fair treatment rules
+    (FSA-004); products must be governed by product oversight processes
+    (FSA-005)
+  - IDD — products must have defined target markets and be monitored
+    post-launch (IDD-004)
+  - GDPR — risk assessments may process personal data; automated decisions must
+    allow for human review (GDPR-001)
+
+## Actuary
+
+- **Swedish term:** Aktuarie
+- **Description:** A professional who applies mathematical and statistical
+  methods to assess risk, develop pricing models, and analyze claims data.
+  Actuaries ensure that premium levels are adequate to cover expected claims
+  while remaining competitive. They also support solvency calculations and
+  regulatory reporting.
+- **Responsibilities:**
+  - Develop and maintain motor insurance pricing models
+  - Analyze claims frequency, severity, and trends
+  - Calculate technical provisions and reserves
+  - Support Solvency II capital adequacy calculations (FSA-003)
+  - Provide data-driven input to underwriting guidelines
+  - Monitor loss ratios and recommend pricing adjustments
+- **Key interactions:** Underwriting and bonus management, regulatory reporting,
+  pricing model development
+- **Regulatory relevance:**
+  - FSA — supports Solvency II compliance (FSA-003) and supervisory reporting
+    (FSA-006)
+  - GDPR — works with aggregated and anonymized claims data; must ensure
+    personal data is properly anonymized before analysis (GDPR-001)
+
+## Compliance Officer
+
+- **Swedish term:** Regelefterlevnadsansvarig
+- **Description:** An employee responsible for ensuring that TryggFörsäkring's
+  operations comply with all applicable regulations, including FSA rules,
+  GDPR, and IDD. The compliance officer monitors regulatory changes, conducts
+  internal audits, and advises the business on compliance matters.
+- **Responsibilities:**
+  - Monitor regulatory changes from FSA, IMY, and EU institutions
+  - Conduct internal compliance audits and gap analyses
+  - Review new products and processes for regulatory compliance
+  - Manage complaints handling procedures (FSA-011, IDD-010)
+  - Oversee GDPR compliance including data protection impact assessments
+  - Ensure IDD distribution requirements are met across all channels
+  - Report compliance status to management and board
+- **Key interactions:** Regulatory reporting, product governance, complaints
+  handling, audit
+- **Regulatory relevance:**
+  - FSA — oversees compliance with all FSA requirements (FSA-001 through
+    FSA-014)
+  - GDPR — ensures data protection obligations are met (GDPR-001 through
+    GDPR-006)
+  - IDD — monitors distribution compliance (IDD-001 through IDD-010)
+
+## System Administrator
+
+- **Swedish term:** Systemadministratör
+- **Description:** An IT professional responsible for managing the technical
+  configuration, user access, and operational health of the insurance
+  platform. System administrators do not make business decisions but ensure
+  the platform is available, secure, and properly configured.
+- **Responsibilities:**
+  - Manage user accounts, roles, and access permissions
+  - Configure platform settings (product parameters, workflow rules, integration
+    endpoints)
+  - Monitor system health, performance, and availability
+  - Manage integrations with external systems (Transportstyrelsen, BankID, TFF)
+  - Execute data retention and archival procedures
+  - Support incident response and disaster recovery
+- **Key interactions:** Platform configuration, user management, system
+  integration, data retention
+- **Regulatory relevance:**
+  - GDPR — responsible for implementing technical measures for data protection,
+    access control, and data retention/deletion (GDPR-001, GDPR-005)
+  - FSA — supports record-keeping obligations through system configuration
+    (FSA-014)


### PR DESCRIPTION
## Summary
- Define 17 actors (10 internal, 7 external) for the motor insurance domain
- Each actor documented with Swedish term, description, responsibilities, key interactions, and regulatory relevance
- Cross-references to FSA, GDPR, and IDD requirement IDs throughout

## Changes
- `docs/actors/index.md` — Overview page with summary table and internal/external classification
- `docs/actors/internal-actors.md` — 10 internal actors (Customer, Corporate Customer, Agent, Broker, Claims Handler, Claims Adjuster, Underwriter, Actuary, Compliance Officer, System Administrator)
- `docs/actors/external-actors.md` — 7 external actors (Transportstyrelsen, TFF, BankID, Repair Shop, Police, Medical Provider, Payment Provider)
- Mirrored to `versioned_docs/version-phase-1/actors/`

## Testing
- [x] markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] `npm run build` succeeds with no broken links

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)