### PR TITLE
docs(#28): Enable draft version for Phase 2 planning in version dropdown

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -39,8 +39,14 @@ const config: Config = {
           editUrl:
             "https://github.com/Agentic-software-factory/insurance-platform-requirements/edit/main/",
           lastVersion: "phase-1",
-          includeCurrentVersion: false,
+          includeCurrentVersion: true,
           versions: {
+            current: {
+              label: "Phase 2 — Home & Property (Draft)",
+              path: "next",
+              banner: "unreleased",
+              badge: true,
+            },
             "phase-1": {
               label: "Phase 1 — Motor Insurance",
               path: "",


### PR DESCRIPTION
## Summary
- Enables the `docs/` directory as a draft "Phase 2 — Home & Property (Draft)" version in the Docusaurus version dropdown
- Phase 1 remains the default stable version; Phase 2 draft pages show an "unreleased" banner
- Draft content is served under the `/next/` URL path

## Changes
- `docusaurus.config.ts`: Set `includeCurrentVersion: true` and added `current` version configuration with draft label, `/next/` path, and `unreleased` banner

## Testing
- [x] `npm run build` — zero errors
- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files formatted

Closes #28

🤖 Generated with Claude Code