### PR TITLE
docs(#28): Enable draft version for Phase 2 planning in version dropdown

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -39,8 +39,14 @@ const config: Config = {
           editUrl:
             "https://github.com/Agentic-software-factory/insurance-platform-requirements/edit/main/",
           lastVersion: "phase-1",
-          includeCurrentVersion: false,
+          includeCurrentVersion: true,
           versions: {
+            current: {
+              label: "Phase 2 — Home & Property (Draft)",
+              path: "next",
+              banner: "unreleased",
+              badge: true,
+            },
             "phase-1": {
               label: "Phase 1 — Motor Insurance",
               path: "",


### PR DESCRIPTION
## Summary
- Enable Phase 2 (Home & Property) as a draft version visible in the documentation version dropdown
- Phase 1 remains the stable default; Phase 2 shows an "unreleased" banner on every page
- URLs for Phase 2 draft use the `/next/` path prefix

## Changes
- `docusaurus.config.ts`: Set `includeCurrentVersion: true` and added `current` version config with draft label and unreleased banner

## Testing
- [x] `npm run build` — zero errors
- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files formatted
- [x] Build output verified: `/docs/next/` path exists with Phase 2 draft content

Closes #28

🤖 Generated with Claude Code