### PR TITLE
docs(#6): Define personas for motor insurance domain

### DIFF
--- a/versioned_docs/version-phase-1/personas/anna-marcus-johansson.md
+++ b/versioned_docs/version-phase-1/personas/anna-marcus-johansson.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 3
+---
+
+# Anna & Marcus Johansson, 38/40 — Family with Multiple Vehicles
+
+> _"We just want one place to see both cars, both policies, and know that
+> everything is sorted. We don't have time to manage insurance separately."_
+
+## Avatar Description
+
+A couple in their late thirties, standing in front of a suburban house with a
+driveway containing two cars: a larger family SUV and a smaller commuter
+hatchback. They look busy but organized.
+
+## Demographics
+
+| Field      | Details                                                     |
+| ---------- | ----------------------------------------------------------- |
+| Ages       | Anna 38, Marcus 40                                          |
+| Location   | Suburban Stockholm (Täby)                                   |
+| Occupation | Anna: project manager at a consulting firm; Marcus: teacher |
+| Income     | Dual-income household, middle-to-upper range                |
+
+## Insurance Situation
+
+| Field            | Details                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| Current coverage | Two active policies with TryggFörsäkring                                                    |
+| Vehicle 1        | 2022 Volkswagen ID.4 (family SUV) — helförsäkring                                           |
+| Vehicle 2        | 2017 Toyota Yaris (commuter) — halvförsäkring                                               |
+| Bonus class      | Anna: class 6 (12 years claim-free); Marcus: class 5 (10 years claim-free)                  |
+| Coverage goal    | Keep helförsäkring on the newer car; evaluate if halvförsäkring is enough for the older car |
+
+## Goals
+
+- Manage both policies from a single household view — one login, one overview
+- Easily compare coverage levels and adjust if circumstances change (e.g., new
+  car, teenager starts driving)
+- Receive a single consolidated invoice or coordinated payment schedule
+- Retain their high bonus class and understand how a claim on one car affects
+  the other
+
+## Frustrations / Pain Points
+
+- **Fragmented experience** — each policy is managed independently with no
+  household concept; updating an address requires doing it twice
+- **Bonus class confusion** — unclear whether Marcus's bonus class is affected
+  if Anna has an accident in the shared vehicle
+- **Coverage comparison difficulty** — hard to see at a glance what each policy
+  covers and where the gaps are
+- **Renewal timing** — the two policies renew on different dates, making it easy
+  to miss a renewal or overlook a price increase
+
+## Tech Comfort Level
+
+**Medium-high.** Both Anna and Marcus are comfortable with digital services.
+They prefer self-service via a web portal or app but will call customer service
+for complex questions (e.g., adding a teenage driver to a policy). They
+authenticate with BankID and expect a responsive experience on both desktop and
+mobile.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Each policy change or new purchase requires a demands-and-needs assessment (IDD-001); the family's combined situation should inform recommendations. |
+| **IDD**    | IPIDs (IDD-002) must be provided for each coverage tier so Anna and Marcus can compare helförsäkring and halvförsäkring clearly.                     |
+| **FSA**    | Both vehicles must have valid trafikförsäkring at all times (FSA-007).                                                                               |
+| **FSA**    | Renewal terms and any premium changes must be communicated in advance (FSA-004).                                                                     |
+| **GDPR**   | Both Anna and Marcus are data subjects; if they share a login or household view, consent and data access rights apply to each individual (GDPR-001). |
+| **GDPR**   | Adding a teenage driver requires processing the child's personal data with appropriate legal basis (GDPR-001).                                       |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Anna
+  and Marcus are private customers with multiple policies.

--- a/versioned_docs/version-phase-1/personas/erik-lindstrom.md
+++ b/versioned_docs/version-phase-1/personas/erik-lindstrom.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 2
+---
+
+# Erik Lindström, 19 — New Young Driver
+
+> _"I just want the cheapest insurance so I can drive legally. Why is it so
+> expensive when I haven't even done anything wrong?"_
+
+## Avatar Description
+
+Young man, casually dressed, holding car keys with a slightly worried expression.
+Standing next to a used silver Volvo V40 in a suburban parking lot.
+
+## Demographics
+
+| Field      | Details                                               |
+| ---------- | ----------------------------------------------------- |
+| Age        | 19                                                    |
+| Location   | Örebro, Sweden                                        |
+| Occupation | University student (part-time job at a grocery store) |
+| Income     | Low — dependent on study grants and part-time wages   |
+
+## Insurance Situation
+
+| Field            | Details                                                      |
+| ---------------- | ------------------------------------------------------------ |
+| Current coverage | None — first-time buyer                                      |
+| Vehicle          | Used 2016 Volvo V40 (purchased from a relative)              |
+| Bonus class      | 0 (no claims history, starting at the lowest discount level) |
+| Coverage goal    | Trafikförsäkring (mandatory minimum) or halvförsäkring       |
+
+## Goals
+
+- Get legally insured as quickly and cheaply as possible
+- Understand the difference between trafikförsäkring, halvförsäkring, and
+  helförsäkring without insurance jargon
+- Complete the entire purchase process on his phone
+- Build up a bonus class over time to lower premiums
+
+## Frustrations / Pain Points
+
+- **High premiums** — young drivers in bonus class 0 pay the highest rates,
+  which feels unfair when he has no claims history at all
+- **Confusing terminology** — Swedish insurance terms are difficult to parse
+  without prior experience
+- **Lack of transparency** — unclear why the premium is so high or what factors
+  drive pricing
+- **Desktop-oriented flows** — if the quote-and-bind process requires a desktop
+  browser, he may abandon it
+
+## Tech Comfort Level
+
+**High (digital native).** Erik does everything on his smartphone. He expects a
+mobile-first experience with instant feedback, minimal form fields, and the
+ability to authenticate with BankID via the mobile app. He has no interest in
+calling a phone line or visiting a physical office.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Erik must receive a demands-and-needs assessment (IDD-001) and an IPID (IDD-002) before purchasing, even for the cheapest option.              |
+| **IDD**    | Pre-contractual information must be clear and not misleading (IDD-003), especially important for a first-time buyer.                           |
+| **FSA**    | Trafikförsäkring is mandatory for every registered vehicle (FSA-007); Erik must be insured before driving on public roads.                     |
+| **FSA**    | Erik has a 14-day cooling-off period (ångerrätt) after purchasing a distance-sold policy (FSA-013).                                            |
+| **GDPR**   | Erik's personal data (identity, driving license, vehicle ownership) requires lawful processing and transparent privacy information (GDPR-001). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Erik
+  is a private customer purchasing his first policy.

--- a/versioned_docs/version-phase-1/personas/fatima-al-rashid.md
+++ b/versioned_docs/version-phase-1/personas/fatima-al-rashid.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 4
+---
+
+# Fatima Al-Rashid, 45 — Small Business Fleet Manager
+
+> _"I need to know instantly which van is covered, who's driving it, and what
+> happens if one of my employees has an accident on the job."_
+
+## Avatar Description
+
+A professional woman in business attire, standing in front of a row of branded
+cleaning-company vans. She holds a tablet and looks focused, managing logistics.
+
+## Demographics
+
+| Field      | Details                                                |
+| ---------- | ------------------------------------------------------ |
+| Age        | 45                                                     |
+| Location   | Gothenburg (Göteborg), Sweden                          |
+| Occupation | Owner and manager of a cleaning company (Ren & Fin AB) |
+| Income     | Business income, mid-range (reinvesting in growth)     |
+
+## Insurance Situation
+
+| Field            | Details                                                           |
+| ---------------- | ----------------------------------------------------------------- |
+| Current coverage | Fleet policy covering 8 service vans                              |
+| Vehicles         | 8 × Volkswagen Caddy vans (2018–2023 models)                      |
+| Bonus class      | Fleet-level bonus; varies per vehicle based on claims history     |
+| Drivers          | 12 employees authorized to drive; drivers rotate between vehicles |
+| Coverage goal    | Commercial helförsäkring with liability coverage for business use |
+
+## Goals
+
+- Add or remove vehicles from the fleet without lengthy administrative processes
+- Track which employees are authorized drivers and update the list easily
+- Get a clear fleet-level overview: total premium, claims history per vehicle,
+  upcoming renewals
+- File claims quickly when an employee reports a vehicle incident
+- Understand how a claim on one vehicle affects the fleet's overall premium
+
+## Frustrations / Pain Points
+
+- **Administrative burden** — adding a new van or a new employee as a driver
+  requires multiple phone calls and forms; no self-service fleet management
+- **Driver tracking** — no clear view of which employee is assigned to which
+  vehicle; when a claim occurs, determining the responsible driver is manual
+- **Employee claims** — when an employee has an accident, the claims process is
+  confusing regarding liability (business vs. personal)
+- **Lack of fleet reporting** — no consolidated dashboard showing claims
+  frequency, cost per vehicle, or fleet-wide bonus status
+- **Multiple contacts** — different departments handle fleet policy changes vs.
+  claims, and they don't always share context
+
+## Tech Comfort Level
+
+**Medium.** Fatima uses a tablet and smartphone for day-to-day business
+management. She is comfortable with digital tools but prefers straightforward
+interfaces over complex dashboards. For complex fleet changes, she expects to
+speak to a dedicated business account manager. She authenticates with BankID for
+both personal and business matters.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GDPR**   | Fatima processes employee personal data (names, driving licenses, employment details) as a data controller; employee consent or legitimate interest is required (GDPR-001). |
+| **GDPR**   | Employee driver data shared with TryggFörsäkring requires a data processing agreement and transparent privacy information (GDPR-001, GDPR-004).                             |
+| **IDD**    | Demands-and-needs assessment (IDD-001) requirements may differ for commercial customers; Fatima's fleet needs must be documented.                                           |
+| **FSA**    | Every van in the fleet must have valid trafikförsäkring (FSA-007); adding a new vehicle must trigger immediate coverage.                                                    |
+| **FSA**    | Commercial fleet policies are subject to product oversight and governance (FSA-005).                                                                                        |
+
+## Related Actors
+
+- [Corporate Customer (Företagskund)](../actors/internal-actors#corporate-customer-företagskund)
+  — Fatima acts as the corporate customer managing fleet insurance for Ren &
+  Fin AB.

--- a/versioned_docs/version-phase-1/personas/gunnar-pettersson.md
+++ b/versioned_docs/version-phase-1/personas/gunnar-pettersson.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 5
+---
+
+# Gunnar Pettersson, 72 — Senior Renewing Long-Standing Policy
+
+> _"I've been with the same company for over twenty years. I just want fair
+> treatment and someone who explains things clearly — not a website."_
+
+## Avatar Description
+
+An older gentleman in a knitted sweater, sitting at a kitchen table with
+paperwork spread out. A classic dark-green Saab 900 is visible through the
+window. He looks thoughtful, reviewing an insurance renewal letter.
+
+## Demographics
+
+| Field      | Details                                                   |
+| ---------- | --------------------------------------------------------- |
+| Age        | 72                                                        |
+| Location   | Linköping, Sweden                                         |
+| Occupation | Retired (former mechanical engineer at Saab in Linköping) |
+| Income     | Pension income, stable but fixed                          |
+
+## Insurance Situation
+
+| Field            | Details                                                                |
+| ---------------- | ---------------------------------------------------------------------- |
+| Current coverage | Helförsäkring (comprehensive) — has been with TryggFörsäkring 22 years |
+| Vehicle          | 1993 Saab 900 Turbo (classic car, well-maintained, low mileage)        |
+| Bonus class      | Maximum (class 7) — over 20 years without a claim                      |
+| Annual mileage   | Approximately 5,000 km/year                                            |
+| Coverage goal    | Maintain helförsäkring with agreed-value coverage for the classic car  |
+
+## Goals
+
+- Keep his policy without unexpected premium increases at renewal
+- Receive clear, written communication about any changes to terms or pricing
+- Speak to a knowledgeable person when he has questions — not navigate a chatbot
+- Ensure his classic Saab is properly valued (agreed value, not market value)
+- Understand what he is actually paying for, in plain language
+
+## Frustrations / Pain Points
+
+- **Automatic renewals with hidden increases** — premiums have increased year
+  over year, but the renewal letter does not clearly highlight what changed or
+  why
+- **Digital-first bias** — the insurer pushes online self-service, but Gunnar
+  prefers phone calls and physical mail; online portals feel confusing
+- **Classic car valuation** — standard pricing models undervalue his
+  well-maintained Saab; he worries about receiving market value instead of
+  agreed value in a total loss
+- **Loyalty not rewarded** — after 22 years as a customer, he feels he should
+  receive better treatment, but there is no visible loyalty program or benefit
+- **Fine print** — policy documents are long and filled with legal language that
+  is hard to parse
+
+## Tech Comfort Level
+
+**Low.** Gunnar has a smartphone but uses it mainly for calls and SMS. He can
+log in with BankID but finds web portals stressful. He strongly prefers
+receiving paper letters and speaking to a human on the phone. If forced to use a
+digital channel, he needs large text, simple navigation, and clear instructions.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Renewal communications must include clear, non-misleading information about coverage and pricing changes (IDD-003).                                                 |
+| **IDD**    | Even at renewal, a demands-and-needs assessment should confirm that Gunnar's coverage still matches his situation (IDD-001).                                        |
+| **FSA**    | Consumer protection rules require fair treatment of long-standing customers; premium increases must be justified and communicated (FSA-004).                        |
+| **FSA**    | Gunnar has a right to cancel and switch insurer; the process must not create unfair barriers (FSA-013).                                                             |
+| **GDPR**   | Gunnar's long history with TryggFörsäkring means extensive personal data is stored; he has the right to access, correct, and request deletion (GDPR-001, GDPR-003). |
+| **GDPR**   | Communication preference (paper mail) must be respected and recorded (GDPR-001).                                                                                    |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) —
+  Gunnar is a long-standing private customer.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -4,6 +4,32 @@ sidebar_position: 1
 
 # Personas
 
-This section defines the personas for the TryggFörsäkring insurance platform.
+Personas bring actors to life with realistic profiles that help development teams
+understand user needs, motivations, and pain points. They are referenced
+throughout user stories to provide empathy and context for design and
+implementation decisions.
 
-_Content will be added in a subsequent issue._
+Each persona represents a key customer segment or internal user role within the
+motor insurance domain. Together they cover the range of interactions that the
+TryggFörsäkring platform must support.
+
+## Persona Summary
+
+| Persona                                          | Age   | Role                  | Key Need                                      |
+| ------------------------------------------------ | ----- | --------------------- | --------------------------------------------- |
+| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance         |
+| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies       |
+| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                |
+| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
+| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
+| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
+
+## How Personas Are Used
+
+- **User stories** reference personas by name to ground requirements in real
+  user context (e.g., _"As Erik, I want to compare trafikförsäkring and
+  halvförsäkring so I can choose the cheapest option that meets my needs."_)
+- **Acceptance criteria** consider each persona's tech comfort level and
+  communication preferences.
+- **Regulatory touchpoints** listed on each persona page highlight which
+  regulations are most relevant to that user segment.

--- a/versioned_docs/version-phase-1/personas/lars-svensson.md
+++ b/versioned_docs/version-phase-1/personas/lars-svensson.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 7
+---
+
+# Lars Svensson, 55 — Claims Handler (Internal)
+
+> _"I know every workaround in the old system. What I need is a new system that
+> doesn't require workarounds in the first place."_
+
+## Avatar Description
+
+A middle-aged man in a collared shirt, sitting at a desk with dual monitors
+showing a claims management interface. He has reading glasses pushed up on his
+forehead and a coffee mug nearby. His expression is focused and experienced.
+
+## Demographics
+
+| Field      | Details                                             |
+| ---------- | --------------------------------------------------- |
+| Age        | 55                                                  |
+| Location   | Stockholm, Sweden                                   |
+| Occupation | Senior claims handler at TryggFörsäkring (20 years) |
+| Income     | Mid-range, salaried employee                        |
+
+## Insurance Situation
+
+Lars is not a customer — he is an internal user of the insurance platform. His
+"insurance situation" is his professional context.
+
+| Field             | Details                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| Role              | Senior claims handler (skadereglerare)                         |
+| Daily volume      | Processes 15–20 claims per day                                 |
+| System experience | 20 years using the current legacy policy administration system |
+| Specialization    | Motor vehicle damage claims, total loss assessments            |
+
+## Goals
+
+- Process claims efficiently with fewer manual steps and less switching between
+  systems
+- Have all relevant information (policy details, customer history, vehicle data,
+  coverage limits) on one screen
+- Easily document decisions and rationale for audit trails
+- Reduce time spent on administrative tasks (data entry, form filling) and
+  increase time spent on actual claims assessment
+- Share knowledge with junior colleagues through structured processes rather
+  than tribal knowledge
+
+## Frustrations / Pain Points
+
+- **Tribal knowledge dependency** — critical business rules exist only in Lars's
+  head and those of a few senior colleagues; when he is on vacation, claims
+  processing slows down
+- **Legacy system workarounds** — the current system requires numerous manual
+  workarounds (e.g., overriding fields that should not exist, using comment
+  fields for structured data)
+- **System fragmentation** — claims handling requires switching between the
+  policy system, a separate claims system, email, Excel spreadsheets, and
+  sometimes paper files
+- **No decision support** — the system does not flag potential fraud indicators,
+  suggest similar past claims, or validate coverage automatically
+- **Training burden** — onboarding new claims handlers takes months because the
+  process is undocumented and dependent on shadowing experienced staff
+
+## Tech Comfort Level
+
+**Medium.** Lars is proficient with the current legacy system (having used it
+for 20 years) and standard office tools (Outlook, Excel). He is open to a new
+system if it genuinely makes his job easier, but he is skeptical of change for
+change's sake. He does not want a flashy interface — he wants a functional one
+that supports his workflow. He is not comfortable with mobile interfaces for
+work tasks and prefers a desktop application.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Lars must ensure fair and timely claims settlement in accordance with FSA requirements (FSA-010).                                                                    |
+| **FSA**    | Claims decisions and rationale must be documented for regulatory record-keeping (FSA-014).                                                                           |
+| **FSA**    | Complaints about claims decisions must be handled through the regulated complaints procedure (FSA-011).                                                              |
+| **GDPR**   | Lars processes sensitive personal data daily (injury details, police reports, medical records); data minimization and purpose limitation apply (GDPR-001, GDPR-004). |
+| **GDPR**   | Customers have the right to access their claims data and understand how decisions were made (GDPR-002).                                                              |
+| **IDD**    | Claims handling quality is part of the product oversight and governance framework (IDD-004).                                                                         |
+
+## Related Actors
+
+- [Claims Handler (Skadereglerare)](../actors/internal-actors#claims-handler-skadereglerare)
+  — Lars is the persona representing this actor role.
+- [Claims Adjuster (Värderare)](../actors/internal-actors#claims-adjuster-värderare)
+  — Lars coordinates with claims adjusters for damage assessments.
+- [Repair Shop (Verkstad)](../actors/external-actors#repair-shop-verkstad) —
+  Lars assigns repair work to authorized repair shops.

--- a/versioned_docs/version-phase-1/personas/sofia-chen.md
+++ b/versioned_docs/version-phase-1/personas/sofia-chen.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 6
+---
+
+# Sofia Chen, 32 — Recent Immigrant
+
+> _"I had excellent insurance in Germany with a high bonus class. Starting from
+> zero in Sweden feels wrong — there must be a way to transfer my history."_
+
+## Avatar Description
+
+A young professional woman standing near a parked car, holding both a German and
+a Swedish driving license. She looks determined but slightly frustrated, reading
+a document in Swedish with a translation app on her phone.
+
+## Demographics
+
+| Field      | Details                                      |
+| ---------- | -------------------------------------------- |
+| Age        | 32                                           |
+| Location   | Malmö, Sweden                                |
+| Occupation | Software engineer at a multinational company |
+| Income     | Upper-middle, professional salary            |
+
+## Insurance Situation
+
+| Field            | Details                                                                   |
+| ---------------- | ------------------------------------------------------------------------- |
+| Current coverage | None in Sweden — had helförsäkring in Germany for 7 years                 |
+| Vehicle          | 2021 BMW 3 Series (brought from Germany, re-registered in Sweden)         |
+| Bonus class      | Would be SF-Klasse 7 in Germany (roughly equivalent to Swedish class 5–6) |
+| Coverage goal    | Helförsäkring with transferred bonus class from German insurer            |
+
+## Goals
+
+- Transfer her German no-claims bonus (Schadenfreiheitsklasse) to a Swedish
+  bonus class so she does not start at class 0
+- Understand the Swedish insurance system — coverage tiers, terminology, and
+  regulatory requirements — without needing fluent Swedish
+- Complete the insurance purchase process in English or with clear bilingual
+  support
+- Re-register her German car in Sweden and get insured seamlessly as part of
+  that process
+
+## Frustrations / Pain Points
+
+- **Bonus class transfer** — the process for proving foreign claims history is
+  unclear; different insurers have different requirements for documentation
+  from the German insurer
+- **Language barrier** — policy documents, terms, and conditions are only
+  available in Swedish; online translation tools struggle with insurance
+  jargon
+- **System unfamiliarity** — the Swedish insurance tiers (trafikförsäkring,
+  halvförsäkring, helförsäkring) do not map directly to the German system
+  (Haftpflicht, Teilkasko, Vollkasko), causing confusion
+- **Re-registration complexity** — coordinating vehicle re-registration with
+  Transportstyrelsen and insurance purchase involves multiple steps with
+  different authorities
+- **Distrust of starting over** — being offered class 0 pricing despite 7
+  years of claim-free driving feels punitive and may push her to competitors
+  who accept foreign history
+
+## Tech Comfort Level
+
+**High.** Sofia is a software engineer and comfortable with any digital
+interface. She prefers online self-service and expects a modern, well-designed
+experience. She authenticates with BankID (obtained after receiving her Swedish
+personnummer). Language toggle or English-language support is important.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Demands-and-needs assessment (IDD-001) must account for Sofia's existing coverage history and specific situation as a new entrant to the Swedish market.               |
+| **IDD**    | Pre-contractual information (IDD-003) should be comprehensible; providing information in English supports the "clear, fair, and not misleading" requirement.           |
+| **FSA**    | Trafikförsäkring is mandatory (FSA-007); Sofia must be insured before driving her re-registered vehicle on Swedish roads.                                              |
+| **FSA**    | TFF manages the bonus class transfer process between insurers, including cross-border transfers (FSA-008).                                                             |
+| **GDPR**   | Sofia's personal data includes foreign documents (German driving license, insurance history); processing requires lawful basis and transparent information (GDPR-001). |
+| **GDPR**   | Cross-border data transfer from the German insurer must comply with GDPR data transfer rules (GDPR-001).                                                               |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Sofia
+  is a new private customer entering the Swedish insurance market.
+- [Transportstyrelsen](../actors/external-actors#transportstyrelsen) — involved
+  in vehicle re-registration.
+- [TFF](../actors/external-actors#trafikförsäkringsföreningen-tff) — manages
+  cross-border bonus class transfer.


### PR DESCRIPTION
## Summary
- Add 6 detailed personas covering key motor insurance customer segments and one internal user role
- Each persona includes avatar description, demographics, insurance situation, goals, frustrations, tech comfort level, and regulatory touchpoints (FSA/GDPR/IDD)
- Updated personas index page with summary table and navigation links to individual persona pages

## Changes
- `versioned_docs/version-phase-1/personas/index.md` — Replaced placeholder with summary table linking to all 6 personas
- `versioned_docs/version-phase-1/personas/erik-lindstrom.md` — New young driver persona (age 19)
- `versioned_docs/version-phase-1/personas/anna-marcus-johansson.md` — Family with multiple vehicles persona (age 38/40)
- `versioned_docs/version-phase-1/personas/fatima-al-rashid.md` — Small business fleet manager persona (age 45)
- `versioned_docs/version-phase-1/personas/gunnar-pettersson.md` — Senior long-standing policyholder persona (age 72)
- `versioned_docs/version-phase-1/personas/sofia-chen.md` — Recent immigrant persona (age 32)
- `versioned_docs/version-phase-1/personas/lars-svensson.md` — Internal claims handler persona (age 55)

## Testing
- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files pass
- [x] `npm run build` — builds successfully with no broken links

Closes #6

🤖 Generated with Claude Code