### PR TITLE
docs(#10): Add quote-and-bind user stories and use case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 # Logs
 /logs
+.factory-workers/

--- a/versioned_docs/version-phase-1/phase-1-motor/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/index.md
@@ -4,16 +4,31 @@ sidebar_position: 1
 
 # Phase 1 — Motor Insurance
 
-Personal motor insurance policies including trafikförsäkring (mandatory third-party liability), halvförsäkring (partial comprehensive), and helförsäkring (full comprehensive).
+Personal motor insurance policies including trafikförsäkring (mandatory
+third-party liability), halvförsäkring (partial comprehensive), and
+helförsäkring (full comprehensive).
 
 ## Scope
 
-- Quote and bind
-- Policy administration
-- Claims handling
-- Renewals
-- Cancellations
-- Trafikförsäkring compliance
-- Underwriting and bonus (bonusklass)
+| Epic                        | Status     | Description                                    |
+| --------------------------- | ---------- | ---------------------------------------------- |
+| Quote and Bind              | Documented | Customer inquiry through policy issuance       |
+| Policy Administration       | Planned    | Mid-term adjustments, endorsements, renewals   |
+| Claims Handling             | Planned    | FNOL through settlement                        |
+| Renewals                    | Planned    | Annual renewal and huvudförfallodag processing |
+| Cancellations               | Planned    | Customer and insurer-initiated cancellations   |
+| Trafikförsäkring Compliance | Planned    | Mandatory insurance monitoring and reporting   |
+| Underwriting and Bonus      | Planned    | Bonus class management and risk assessment     |
 
-_Detailed user stories and use cases will be added in subsequent issues._
+## Documentation
+
+### User Stories
+
+- [Quote and Bind](user-stories/quote-and-bind.md) — 8 user stories covering
+  the end-to-end quote and bind flow (QNB-01 through QNB-08)
+
+### Use Cases
+
+- [Quote and Bind Motor Insurance](use-cases/quote-and-bind.md) — Complete
+  use case (UC-QNB-001) with main success scenario, alternative flows,
+  business rules, and regulatory compliance mapping

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
@@ -4,6 +4,20 @@ sidebar_position: 1
 
 # Use Cases
 
-Use cases for Phase 1 — Motor Insurance.
+Use cases for Phase 1 — Motor Insurance. Each use case describes an end-to-end
+business process with main success scenario, alternative flows, business rules,
+non-functional requirements, and regulatory compliance mapping.
 
-_Content will be added in subsequent issues._
+## Quote and Bind
+
+The [Quote and Bind Motor Insurance](quote-and-bind.md) use case (UC-QNB-001)
+describes the complete flow from customer identification through policy
+issuance and Transportstyrelsen notification. It covers:
+
+- Customer identification and vehicle data lookup
+- Demands-and-needs assessment (IDD-001)
+- Premium calculation and coverage comparison
+- BankID digital signing
+- Policy issuance and insurance certificate delivery
+- Transportstyrelsen notification
+- Agent-assisted and broker-assisted alternative flows

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/quote-and-bind.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/quote-and-bind.md
@@ -1,0 +1,272 @@
+---
+sidebar_position: 2
+---
+
+# Use Case: Quote and Bind Motor Insurance
+
+End-to-end use case for quoting and binding a motor insurance policy at
+TryggFörsäkring. Covers the complete flow from customer identification through
+policy issuance and Transportstyrelsen notification.
+
+## Use Case Summary
+
+| Field                | Value                                                            |
+| -------------------- | ---------------------------------------------------------------- |
+| **Use Case ID**      | UC-QNB-001                                                       |
+| **Name**             | Quote and Bind Motor Insurance                                   |
+| **Primary Actor**    | Private Customer (Privatkund)                                    |
+| **Secondary Actors** | Insurance Agent, Insurance Broker, Underwriter                   |
+| **Goal**             | Obtain a motor insurance quote and bind a policy                 |
+| **Preconditions**    | Customer has a Swedish personnummer and a registered vehicle     |
+| **Postconditions**   | Policy is bound, certificate issued, Transportstyrelsen notified |
+| **Trigger**          | Customer initiates a motor insurance quote request               |
+
+## Stakeholders and Interests
+
+| Stakeholder            | Interest                                                             |
+| ---------------------- | -------------------------------------------------------------------- |
+| Private Customer       | Quick, transparent quote; fair pricing; immediate proof of insurance |
+| Insurance Agent/Broker | Efficient tool for customer advisory; compliant workflow             |
+| Underwriter            | Correct risk assessment and bonus class application                  |
+| Compliance Officer     | IDD assessment completed; all records retained                       |
+| TryggFörsäkring        | New policy sale; regulatory compliance; accurate data                |
+| Transportstyrelsen     | Timely notification of insurance status changes                      |
+
+## Main Success Scenario
+
+### 1. Customer Identification
+
+1. Customer enters registreringsnummer (vehicle registration number)
+2. Customer enters personnummer (personal identity number)
+3. System verifies customer identity
+4. System retrieves vehicle data from Transportstyrelsen:
+   - Make, model, year, VIN
+   - Registered owner
+   - Current insurance status
+
+### 2. Customer Data Retrieval
+
+1. System retrieves the customer's current bonus class (bonusklass) from the
+   internal claims database
+2. If the customer is new, system assigns the default starting bonus class
+3. System retrieves any existing policies for the same vehicle
+
+### 3. Demands-and-Needs Assessment
+
+1. System presents the structured demands-and-needs assessment form
+   (krav- och behovsanalys)
+2. Customer completes the assessment:
+   - Vehicle usage pattern (commuting, business, leisure)
+   - Annual mileage estimate
+   - Parking situation (garage, carport, street)
+   - Deductible tolerance (low, medium, high)
+   - Need for add-on coverages
+3. System generates a coverage recommendation with rationale:
+   - Recommended coverage tier (trafik/halv/hel)
+   - Recommended deductible level
+   - Relevant add-ons
+
+### 4. Premium Calculation and Coverage Comparison
+
+1. System calculates premiums for all three coverage tiers using:
+   - Vehicle risk factors (make, model, year, value)
+   - Customer risk factors (age, driving history, bonus class)
+   - Geographic risk factors (postal code)
+   - Deductible levels
+2. System presents a side-by-side tier comparison showing:
+   - Coverage details per tier
+   - Premium per tier
+   - Deductible per tier
+   - IPID access link per tier
+3. System highlights the recommended tier from the assessment
+4. System presents available add-ons with individual pricing
+
+### 5. Coverage Selection
+
+1. Customer selects a coverage tier
+2. Customer selects a deductible level
+3. Customer selects or declines optional add-ons
+4. If the customer deviates from the recommendation, system records the
+   deviation
+5. System calculates the final premium (base + add-ons)
+
+### 6. Pre-contractual Review and Signing
+
+1. System presents the binding summary:
+   - Selected coverage tier and details
+   - Premium amount and payment frequency
+   - Deductible amount
+   - Policy effective date and huvudförfallodag (anniversary)
+   - Pre-contractual information (IDD-003):
+     - Insurer identity (TryggFörsäkring AB)
+     - FSA registration status
+     - Complaints handling procedures
+     - Dispute resolution options (ARN)
+   - IPID delivery confirmation (IDD-002)
+   - Demands-and-needs assessment reference (IDD-001)
+   - 14-day cooling-off right (ångerrätt) information (FSA-013)
+2. Customer initiates BankID signing
+3. System sends the policy document hash to BankID
+4. Customer completes BankID authentication and signing
+5. System records the BankID transaction reference and timestamp
+
+### 7. Policy Issuance
+
+1. System generates a unique policy number
+2. System creates the policy record with all binding details
+3. System generates the insurance certificate (försäkringsbevis)
+4. System initiates payment setup with the payment provider:
+   - Monthly autogiro setup, or
+   - Annual invoice generation
+5. System calculates the ångerrätt (cooling-off) expiry date (14 days)
+
+### 8. Transportstyrelsen Notification
+
+1. System sends insurance notification to Transportstyrelsen:
+   - Registreringsnummer
+   - Policy number
+   - Insurance company identifier
+   - Coverage start date
+   - Coverage type
+2. System records the Transportstyrelsen acknowledgement reference
+
+### 9. Confirmation
+
+1. System sends confirmation to the customer:
+   - Insurance certificate (PDF)
+   - Full policy document
+   - IPID for the selected tier
+   - Payment instructions
+   - Cooling-off information
+2. Policy documents are available in the self-service portal
+
+## Extensions (Alternative Flows)
+
+### 1a. Vehicle Not Found in Transportstyrelsen
+
+1. System displays a message that the vehicle was not found
+2. Customer is offered manual vehicle entry (make, model, year)
+3. Manual entry requires underwriter review before binding
+4. Flow continues from step 5
+
+### 2a. Customer Transferring Bonus from Another Insurer
+
+1. Customer indicates they have a bonus class from another insurer
+2. System allows manual entry of the transferred bonus class
+3. Customer provides supporting documentation (e.g., insurance certificate
+   from previous insurer)
+4. Transferred bonus is applied provisionally, subject to verification via
+   TFF
+5. Flow continues from step 8
+
+### 3a. Agent-Assisted Quote
+
+1. Agent authenticates via BankID
+2. System verifies the agent's competence certification (IDD-009)
+3. Agent enters the customer's registreringsnummer and personnummer
+4. Agent completes the demands-and-needs assessment on behalf of the
+   customer
+5. System records the agent's identity and distribution channel
+6. Agent provides a personal recommendation with documented rationale
+   (IDD-006)
+7. System records the distribution status disclosure (IDD-005)
+8. Flow continues from step 11 (Premium Calculation)
+9. At signing, the customer (not the agent) signs via BankID
+
+### 3b. Broker-Assisted Quote
+
+1. Broker authenticates via BankID
+2. Broker discloses independence, fee structure, and duty to act in the
+   customer's interest (IDD-005)
+3. Broker enters the customer's registreringsnummer and personnummer
+4. Broker conducts an independent demands-and-needs assessment
+5. Broker provides a personalized recommendation with documented rationale
+   (IDD-006)
+6. System records the broker's identity, distribution channel, and
+   disclosures
+7. Flow continues from step 11 (Premium Calculation)
+8. At signing, the customer signs via BankID
+
+### 6a. BankID Signing Fails
+
+1. System displays an error message indicating the signing failed
+2. The quote remains valid for the configured validity period
+3. Customer can retry signing without re-entering data
+4. If the failure persists, customer is offered to save the quote and
+   complete later
+
+### 8a. Transportstyrelsen Notification Fails
+
+1. System logs the failure and queues the notification for retry
+2. Automatic retry with exponential backoff
+3. After a configured number of failures, an alert is raised for
+   operations staff
+4. The policy remains valid regardless of notification status; the
+   notification is a post-binding obligation
+
+### 5a. Customer Selects Trafikförsäkring Only
+
+1. If the customer selects only trafikförsäkring (mandatory minimum)
+2. System presents a confirmation that this provides third-party liability
+   only and no own-damage coverage
+3. System records the customer's informed decision
+4. Flow continues from step 19
+
+## Business Rules
+
+| Rule ID | Rule                                                                                                    |
+| ------- | ------------------------------------------------------------------------------------------------------- |
+| BR-01   | The demands-and-needs assessment must be completed before any quote is finalized                        |
+| BR-02   | The IPID for the selected tier must be provided before binding                                          |
+| BR-03   | The customer must be informed of the 14-day cooling-off right (ångerrätt) before signing                |
+| BR-04   | Bonus class must be verified or defaulted before premium calculation                                    |
+| BR-05   | Transportstyrelsen must be notified within the same business day of policy binding                      |
+| BR-06   | Quotes have a configurable validity period (default: 30 days)                                           |
+| BR-07   | Minimum age for policyholder is 18 years (verified via personnummer)                                    |
+| BR-08   | All vehicles on Swedish roads must have at least trafikförsäkring                                       |
+| BR-09   | Add-on pricing must be itemized separately from the base premium                                        |
+| BR-10   | Agent/broker-assisted sales must record the distribution channel, advisor identity, and all disclosures |
+
+## Non-functional Requirements
+
+| Requirement                     | Target                                                      |
+| ------------------------------- | ----------------------------------------------------------- |
+| Vehicle data lookup             | Response within 3 seconds (Transportstyrelsen SLA)          |
+| Quote calculation               | Complete within 5 seconds                                   |
+| BankID signing                  | Timeout after 2 minutes; allow retry                        |
+| Transportstyrelsen notification | Sent within 1 hour of policy binding                        |
+| Quote validity                  | Configurable; default 30 days                               |
+| Audit trail                     | All steps logged with timestamps and actor identity         |
+| Availability                    | Quote-and-bind flow available 24/7 for digital self-service |
+
+## Regulatory Compliance Summary
+
+| Regulation   | Requirements Addressed                                                      |
+| ------------ | --------------------------------------------------------------------------- |
+| **FSA-004**  | Fair treatment through demands-and-needs assessment and transparent pricing |
+| **FSA-007**  | Mandatory trafikförsäkring verified and offered                             |
+| **FSA-009**  | Transportstyrelsen notification within regulated timeframes                 |
+| **FSA-012**  | Pre-contractual disclosure before binding                                   |
+| **FSA-013**  | Cooling-off right (ångerrätt) communicated at binding                       |
+| **GDPR-001** | Personal data collected under Article 6(1)(b) for quote generation          |
+| **GDPR-002** | Policy data processed under Article 6(1)(b) for contract performance        |
+| **GDPR-004** | Transportstyrelsen data sharing under legal obligation                      |
+| **IDD-001**  | Demands-and-needs assessment completed before quote finalization            |
+| **IDD-002**  | IPID provided for each tier before binding                                  |
+| **IDD-003**  | Pre-contractual information presented before signing                        |
+| **IDD-005**  | Distribution status disclosed for agent/broker channels                     |
+| **IDD-006**  | Advice documented with rationale for agent/broker channels                  |
+| **IDD-007**  | Add-on pricing itemized separately                                          |
+| **IDD-008**  | All distribution records retained per retention requirements                |
+| **IDD-009**  | Agent/broker competence verified before quote initiation                    |
+
+## Related User Stories
+
+- [QNB-01: Get a Quick Quote](../user-stories/quote-and-bind.md#qnb-01-get-a-quick-quote)
+- [QNB-02: Agent-Assisted Quote](../user-stories/quote-and-bind.md#qnb-02-agent-assisted-quote)
+- [QNB-03: Demands-and-Needs Assessment](../user-stories/quote-and-bind.md#qnb-03-demands-and-needs-assessment)
+- [QNB-04: Compare Coverage Tiers](../user-stories/quote-and-bind.md#qnb-04-compare-coverage-tiers)
+- [QNB-05: Sign Policy with BankID](../user-stories/quote-and-bind.md#qnb-05-sign-policy-with-bankid)
+- [QNB-06: Receive Insurance Certificate Immediately](../user-stories/quote-and-bind.md#qnb-06-receive-insurance-certificate-immediately)
+- [QNB-07: Automatic Bonus Class Calculation](../user-stories/quote-and-bind.md#qnb-07-automatic-bonus-class-calculation)
+- [QNB-08: Notify Transportstyrelsen of New Policy](../user-stories/quote-and-bind.md#qnb-08-notify-transportstyrelsen-of-new-policy)

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
@@ -4,6 +4,23 @@ sidebar_position: 1
 
 # User Stories
 
-User stories for Phase 1 — Motor Insurance.
+User stories for Phase 1 — Motor Insurance. Each user story follows the format
+"As a [actor], I want to [action], so that [benefit]" and includes acceptance
+criteria in Given/When/Then format, data requirements, external integration
+points, and regulatory traceability.
 
-_Content will be added in subsequent issues._
+## Quote and Bind
+
+The [quote-and-bind user stories](quote-and-bind.md) cover the primary sales
+flow from initial customer inquiry through policy issuance:
+
+| ID     | Actor            | Summary                                   |
+| ------ | ---------------- | ----------------------------------------- |
+| QNB-01 | Private Customer | Get a quick quote by registration number  |
+| QNB-02 | Insurance Agent  | Create a quote on behalf of a customer    |
+| QNB-03 | System           | Perform demands-and-needs assessment      |
+| QNB-04 | Private Customer | Compare coverage tiers side by side       |
+| QNB-05 | Private Customer | Sign policy with BankID                   |
+| QNB-06 | Private Customer | Receive insurance certificate immediately |
+| QNB-07 | Underwriter      | Apply bonus class rules automatically     |
+| QNB-08 | System           | Notify Transportstyrelsen of new policy   |

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/quote-and-bind.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/quote-and-bind.md
@@ -1,0 +1,680 @@
+---
+sidebar_position: 2
+---
+
+# Quote and Bind — User Stories
+
+User stories for the motor insurance quote-and-bind process. This is the primary
+sales flow where a customer (or agent/broker) provides vehicle and personal
+details, receives a premium quote, and binds a policy.
+
+## Overview
+
+| ID     | Actor            | Summary                                   |
+| ------ | ---------------- | ----------------------------------------- |
+| QNB-01 | Private Customer | Get a quick quote by registration number  |
+| QNB-02 | Insurance Agent  | Create a quote on behalf of a customer    |
+| QNB-03 | System           | Perform demands-and-needs assessment      |
+| QNB-04 | Private Customer | Compare coverage tiers side by side       |
+| QNB-05 | Private Customer | Sign policy with BankID                   |
+| QNB-06 | Private Customer | Receive insurance certificate immediately |
+| QNB-07 | Underwriter      | Apply bonus class rules automatically     |
+| QNB-08 | System           | Notify Transportstyrelsen of new policy   |
+
+---
+
+## QNB-01: Get a Quick Quote
+
+**As a** private customer (privatkund),
+**I want to** get a motor insurance quote by entering my registration number
+(registreringsnummer) and personnummer,
+**so that** I can see pricing quickly without manual data entry.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer enters a valid registreringsnummer
+  **WHEN** the system looks up the vehicle via Transportstyrelsen
+  **THEN** vehicle details (make, model, year, owner) are pre-populated
+  automatically
+
+- **GIVEN** the customer enters a valid personnummer
+  **WHEN** the system verifies identity
+  **THEN** the customer's existing bonus class (bonusklass) is retrieved from
+  the internal claims database
+
+- **GIVEN** vehicle and customer data are available
+  **WHEN** the system calculates the premium
+  **THEN** quotes are presented for all three coverage tiers:
+  trafikförsäkring, halvförsäkring, and helförsäkring
+
+- **GIVEN** the vehicle is not found in the Transportstyrelsen registry
+  **WHEN** the customer submits the registration number
+  **THEN** the system displays an error message and allows manual vehicle
+  entry as a fallback
+
+- **GIVEN** the customer is a new customer with no claims history
+  **WHEN** the premium is calculated
+  **THEN** the system applies the default starting bonus class per
+  underwriting guidelines
+
+### Data Requirements
+
+| Data Element        | Source             | Required |
+| ------------------- | ------------------ | -------- |
+| Registreringsnummer | Customer input     | Yes      |
+| Personnummer        | Customer input     | Yes      |
+| Vehicle make/model  | Transportstyrelsen | Yes      |
+| Vehicle year        | Transportstyrelsen | Yes      |
+| Vehicle owner       | Transportstyrelsen | Yes      |
+| Bonus class         | Internal database  | Yes      |
+| Driving history     | Internal database  | No       |
+
+### External Integrations
+
+- **Transportstyrelsen** — Vehicle data lookup via registreringsnummer
+- **BankID** — Customer identity verification (if strong auth is required at
+  quote stage)
+
+### Regulatory
+
+- **GDPR-001** — Personal data collection for quote generation; legal basis is
+  Article 6(1)(b) pre-contractual steps
+- **FSA-007** — System must verify that the vehicle requires trafikförsäkring
+- **IDD-001** — Demands-and-needs assessment must precede final quote
+  presentation (see QNB-03)
+
+---
+
+## QNB-02: Agent-Assisted Quote
+
+**As an** insurance agent (försäkringsagent),
+**I want to** create a motor insurance quote on behalf of a customer,
+**so that** I can advise them on the appropriate coverage level.
+
+### Acceptance Criteria
+
+- **GIVEN** the agent is authenticated and has valid competence certification
+  **WHEN** the agent enters the customer's registreringsnummer and
+  personnummer
+  **THEN** the system retrieves vehicle and customer data as in QNB-01
+
+- **GIVEN** the agent completes the demands-and-needs assessment (QNB-03) on
+  behalf of the customer
+  **WHEN** the assessment is submitted
+  **THEN** the system generates a coverage recommendation linked to the
+  assessment responses
+
+- **GIVEN** the agent creates a quote
+  **WHEN** the quote is saved
+  **THEN** the system records the agent's identity, the distribution channel
+  (agent-assisted), and a timestamp for IDD record-keeping
+
+- **GIVEN** the agent provides a personal recommendation to the customer
+  **WHEN** the recommendation is recorded
+  **THEN** the system captures the recommended tier, the rationale, and
+  whether the customer followed or deviated from the recommendation
+
+- **GIVEN** the agent's competence certification has expired
+  **WHEN** the agent attempts to initiate a new quote
+  **THEN** the system blocks access and displays a message requiring
+  certification renewal
+
+### Data Requirements
+
+| Data Element             | Source             | Required |
+| ------------------------ | ------------------ | -------- |
+| Agent identity           | Platform login     | Yes      |
+| Agent competence status  | HR/training system | Yes      |
+| Customer personnummer    | Customer/agent     | Yes      |
+| Distribution channel     | System (automatic) | Yes      |
+| Recommendation rationale | Agent input        | Yes      |
+
+### External Integrations
+
+- **Transportstyrelsen** — Vehicle data lookup (same as QNB-01)
+- **BankID** — Agent authentication
+
+### Regulatory
+
+- **IDD-001** — Agent must perform demands-and-needs assessment before
+  recommending a product
+- **IDD-005** — Agent must disclose distribution status and remuneration
+- **IDD-006** — Personalized recommendation must be documented with rationale
+- **IDD-008** — All distribution records must be retained for 5+ years
+- **IDD-009** — Agent must have current competence certification
+- **FSA-004** — Fair treatment of the customer
+- **GDPR-001** — Personal data collection; agent acts under TryggFörsäkring's
+  controllership
+
+---
+
+## QNB-03: Demands-and-Needs Assessment
+
+**As the** system,
+**I want to** perform a structured demands-and-needs assessment
+(krav- och behovsanalys) before presenting coverage options,
+**so that** we comply with IDD and recommend appropriate coverage.
+
+### Acceptance Criteria
+
+- **GIVEN** a customer (or agent on their behalf) has entered vehicle and
+  personal details
+  **WHEN** the quote flow proceeds to coverage selection
+  **THEN** the system presents the demands-and-needs assessment form before
+  any coverage options are shown
+
+- **GIVEN** the assessment form is presented
+  **WHEN** the customer completes all required fields
+  **THEN** the system captures responses covering:
+  - Vehicle usage pattern (commuting, business, leisure)
+  - Annual mileage estimate
+  - Parking situation (garage, street, carport)
+  - Financial situation regarding deductible (självrisk) tolerance
+  - Need for add-on coverages (rental car, roadside assistance, legal
+    protection)
+
+- **GIVEN** the assessment is completed
+  **WHEN** the system processes the responses
+  **THEN** a coverage recommendation is generated indicating:
+  - Recommended coverage tier (trafik/halv/hel) with rationale
+  - Recommended deductible level with rationale
+  - Relevant add-ons based on stated needs
+
+- **GIVEN** the customer deviates from the system recommendation
+  **WHEN** the customer selects a different tier or deductible
+  **THEN** the system records the deviation and any additional explanation
+  provided by the customer
+
+- **GIVEN** the assessment is completed
+  **WHEN** the quote is finalized
+  **THEN** the assessment record is stored with a unique reference ID and
+  linked to the resulting quote and policy
+
+### Data Requirements
+
+| Data Element          | Source         | Required |
+| --------------------- | -------------- | -------- |
+| Vehicle usage pattern | Customer input | Yes      |
+| Annual mileage        | Customer input | Yes      |
+| Parking situation     | Customer input | Yes      |
+| Deductible tolerance  | Customer input | Yes      |
+| Add-on needs          | Customer input | Yes      |
+| Recommendation result | System         | Yes      |
+| Deviation record      | Customer input | No       |
+
+### Regulatory
+
+- **IDD-001** — This story directly implements the demands-and-needs assessment
+  requirement; assessment must be completed before quote finalization
+- **IDD-006** — The generated recommendation constitutes advice and must be
+  documented per advice requirements
+- **IDD-008** — Assessment records must be retained for 5+ years after end of
+  customer relationship
+- **GDPR-001** — Assessment data is personal data collected under Article
+  6(1)(b) pre-contractual steps
+- **FSA-004** — Assessment ensures fair treatment by recommending suitable
+  products
+- **FSA-012** — Assessment is part of the pre-contractual disclosure obligation
+
+---
+
+## QNB-04: Compare Coverage Tiers
+
+**As a** private customer (privatkund),
+**I want to** compare trafikförsäkring, halvförsäkring, and helförsäkring
+coverage tiers side by side,
+**so that** I can make an informed choice about my coverage level.
+
+### Acceptance Criteria
+
+- **GIVEN** the demands-and-needs assessment (QNB-03) is completed
+  **WHEN** the system presents coverage options
+  **THEN** all three tiers are displayed in a side-by-side comparison with:
+  - What is covered in each tier
+  - What is not covered in each tier
+  - Premium (premie) for each tier
+  - Deductible (självrisk) amount for each tier
+
+- **GIVEN** the comparison is displayed
+  **WHEN** the customer views the options
+  **THEN** the system highlights the recommended tier based on the
+  demands-and-needs assessment (QNB-03)
+
+- **GIVEN** optional add-ons are available
+  **WHEN** the customer views the comparison
+  **THEN** each add-on (rental car, roadside assistance, legal protection)
+  is listed with its individual price, clearly separated from the base
+  premium
+
+- **GIVEN** the customer selects a coverage tier
+  **WHEN** the system updates the quote
+  **THEN** the total premium is recalculated including the selected tier and
+  any add-ons
+
+- **GIVEN** the IPID for each tier has been generated
+  **WHEN** the customer views a coverage tier
+  **THEN** the customer can access the corresponding IPID document for that
+  tier
+
+### Data Requirements
+
+| Data Element              | Source          | Required |
+| ------------------------- | --------------- | -------- |
+| Coverage details per tier | Product catalog | Yes      |
+| Premium per tier          | Rating engine   | Yes      |
+| Deductible per tier       | Product catalog | Yes      |
+| Add-on pricing            | Rating engine   | Yes      |
+| IPID per tier             | Document store  | Yes      |
+| Recommendation highlight  | QNB-03 output   | Yes      |
+
+### Regulatory
+
+- **IDD-002** — IPID must be provided for each product tier before binding
+- **IDD-007** — Add-ons must be presented with separate pricing; customer must
+  be informed they are optional
+- **IDD-001** — Comparison must follow from the demands-and-needs assessment
+- **FSA-004** — Comparison must support fair treatment and informed
+  decision-making
+- **FSA-012** — Coverage terms and exclusions must be clearly disclosed
+
+---
+
+## QNB-05: Sign Policy with BankID
+
+**As a** private customer (privatkund),
+**I want to** sign my insurance policy digitally using BankID,
+**so that** the process is fully digital and legally binding.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has selected a coverage tier, deductible, and add-ons
+  **WHEN** the customer proceeds to signing
+  **THEN** the system presents a binding summary showing:
+  - Selected coverage tier and coverage details
+  - Premium amount and payment frequency (monthly/annual)
+  - Deductible amount
+  - Policy effective date
+  - Pre-contractual information (IDD-003)
+  - Confirmation that the IPID has been provided (IDD-002)
+  - Confirmation that the demands-and-needs assessment is recorded (IDD-001)
+
+- **GIVEN** the binding summary is presented
+  **WHEN** the customer initiates signing
+  **THEN** the system triggers a BankID signing request with the policy
+  document hash
+
+- **GIVEN** the customer completes BankID signing
+  **WHEN** the signature is verified
+  **THEN** the policy is bound with the signing timestamp and BankID
+  transaction reference stored
+
+- **GIVEN** BankID signing fails or times out
+  **WHEN** the system detects the failure
+  **THEN** the customer is shown an error message and can retry without
+  re-entering data; the quote remains valid for the configured validity
+  period
+
+- **GIVEN** the customer is under 18 years of age
+  **WHEN** the system checks the customer's age from personnummer
+  **THEN** the system prevents policy binding and displays a message
+  indicating that a legal guardian must be the policyholder
+
+### Data Requirements
+
+| Data Element              | Source       | Required |
+| ------------------------- | ------------ | -------- |
+| BankID transaction ref    | BankID       | Yes      |
+| Signing timestamp         | BankID       | Yes      |
+| Policy document hash      | System       | Yes      |
+| Customer age verification | Personnummer | Yes      |
+| Binding summary content   | System       | Yes      |
+
+### External Integrations
+
+- **BankID** — Digital signing and identity verification
+
+### Regulatory
+
+- **IDD-003** — Pre-contractual information must be presented before signing
+- **IDD-002** — IPID delivery must be confirmed before signing
+- **IDD-001** — Demands-and-needs assessment must be completed before signing
+- **IDD-008** — Signing record must be retained as part of distribution records
+- **FSA-012** — Contract terms and conditions must be disclosed before binding
+- **FSA-013** — Customer must be informed of the 14-day cooling-off right
+  (ångerrätt) at the point of signing
+- **GDPR-001** — BankID transaction data is personal data; legal basis is
+  Article 6(1)(b) contract performance
+
+---
+
+## QNB-06: Receive Insurance Certificate Immediately
+
+**As a** private customer (privatkund),
+**I want to** receive my insurance certificate (försäkringsbevis) immediately
+after binding,
+**so that** I can prove I have valid insurance and drive legally.
+
+### Acceptance Criteria
+
+- **GIVEN** the policy has been bound successfully (QNB-05 completed)
+  **WHEN** the binding is confirmed
+  **THEN** the system generates a policy number in the format defined by
+  TryggFörsäkring's numbering convention
+
+- **GIVEN** the policy number has been assigned
+  **WHEN** the system generates confirmation documents
+  **THEN** the customer receives:
+  - Insurance certificate (försäkringsbevis) with policy number, coverage
+    dates, and vehicle details
+  - Full policy document with terms and conditions
+  - IPID for the selected coverage tier
+  - Payment instructions (first premium or direct debit setup)
+
+- **GIVEN** confirmation documents are generated
+  **WHEN** the documents are delivered
+  **THEN** they are sent via the customer's preferred channel (email,
+  digital portal, or both)
+
+- **GIVEN** the policy is bound
+  **WHEN** the system processes the new policy
+  **THEN** payment setup is initiated per the customer's selected payment
+  method (monthly autogiro or annual invoice)
+
+- **GIVEN** the insurance certificate is generated
+  **WHEN** the customer views their policy in the self-service portal
+  **THEN** the certificate is available for download as a PDF
+
+### Data Requirements
+
+| Data Element            | Source         | Required |
+| ----------------------- | -------------- | -------- |
+| Policy number           | System         | Yes      |
+| Coverage effective date | System/quote   | Yes      |
+| Coverage expiry date    | System/quote   | Yes      |
+| Vehicle details         | Quote data     | Yes      |
+| Customer contact info   | Customer data  | Yes      |
+| Payment method          | Customer input | Yes      |
+
+### External Integrations
+
+- **Payment Provider** — Set up recurring premium collection (autogiro) or
+  generate invoice
+
+### Regulatory
+
+- **FSA-012** — Policy documents must be provided to the customer after
+  binding
+- **FSA-007** — Insurance certificate proves the vehicle has valid
+  trafikförsäkring
+- **FSA-013** — Documents must include information about the 14-day
+  cooling-off right (ångerrätt)
+- **GDPR-002** — Policy data processing; legal basis is Article 6(1)(b)
+  contract performance
+
+---
+
+## QNB-07: Automatic Bonus Class Calculation
+
+**As an** underwriter (riskbedömare),
+**I want the** system to apply bonus class (bonusklass) rules automatically
+during quoting,
+**so that** premiums are calculated correctly based on the customer's
+claims-free driving history.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has an existing bonus class in the system
+  **WHEN** a new quote is generated
+  **THEN** the current bonus class is applied to the premium calculation
+
+- **GIVEN** the customer is transferring from another insurer
+  **WHEN** the customer provides proof of their current bonus class
+  **THEN** the system allows manual entry of the transferred bonus class
+  subject to verification
+
+- **GIVEN** a new customer with no previous insurance history
+  **WHEN** a quote is generated
+  **THEN** the system applies the starting bonus class per underwriting
+  guidelines
+
+- **GIVEN** the bonus class system uses a scale from 1 (highest premium) to
+  a configured maximum (lowest premium)
+  **WHEN** the premium is calculated
+  **THEN** the correct discount percentage is applied per the published
+  bonus table
+
+- **GIVEN** the customer has had claims in the current or previous policy
+  period
+  **WHEN** the system recalculates the bonus class
+  **THEN** the bonus class is reduced according to the claims penalty rules
+  defined in underwriting guidelines
+
+### Data Requirements
+
+| Data Element           | Source                | Required |
+| ---------------------- | --------------------- | -------- |
+| Current bonus class    | Internal database     | Yes      |
+| Claims history         | Internal database     | Yes      |
+| Transferred bonus      | Customer/prev insurer | No       |
+| Bonus scale definition | Underwriting rules    | Yes      |
+| Claims penalty rules   | Underwriting rules    | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Bonus class rules must be transparent and applied
+  consistently for fair treatment
+- **FSA-005** — Bonus rules are part of the product governance framework
+- **IDD-004** — Pricing logic including bonus must align with target market
+  definitions
+- **GDPR-001** — Claims history and bonus class are personal data; processing
+  based on Article 6(1)(b) contract performance
+
+---
+
+## QNB-08: Notify Transportstyrelsen of New Policy
+
+**As the** system,
+**I want to** notify Transportstyrelsen when a new motor insurance policy is
+bound,
+**so that** the vehicle registry reflects the current insurance status and the
+vehicle is legally insured.
+
+### Acceptance Criteria
+
+- **GIVEN** a new motor insurance policy has been bound (QNB-05 completed)
+  **WHEN** the system processes the policy binding event
+  **THEN** a notification is sent to Transportstyrelsen containing:
+  - Registreringsnummer
+  - Policy number
+  - Insurance company identifier (TryggFörsäkring)
+  - Coverage start date
+  - Coverage type (trafikförsäkring, halvförsäkring, or helförsäkring)
+
+- **GIVEN** the notification is sent
+  **WHEN** Transportstyrelsen acknowledges receipt
+  **THEN** the system records the acknowledgement reference and timestamp
+
+- **GIVEN** the notification fails (network error, validation error)
+  **WHEN** the system detects the failure
+  **THEN** the notification is queued for automatic retry with exponential
+  backoff, and an alert is raised for operations staff after a configured
+  number of failures
+
+- **GIVEN** the policy replaces an existing policy from another insurer
+  **WHEN** the notification is processed by Transportstyrelsen
+  **THEN** the previous insurer's coverage end date is updated in the
+  vehicle registry
+
+- **GIVEN** the notification must be sent within regulated timeframes
+  **WHEN** the policy is bound
+  **THEN** the notification is sent within the same business day or within
+  the timeframe specified by Transportstyrelsen's integration
+  requirements
+
+### Data Requirements
+
+| Data Element              | Source             | Required |
+| ------------------------- | ------------------ | -------- |
+| Registreringsnummer       | Policy data        | Yes      |
+| Policy number             | System             | Yes      |
+| Insurance company ID      | System config      | Yes      |
+| Coverage start date       | Policy data        | Yes      |
+| Coverage type             | Policy data        | Yes      |
+| Acknowledgement reference | Transportstyrelsen | Yes      |
+
+### External Integrations
+
+- **Transportstyrelsen** — Insurance status notification API
+
+### Regulatory
+
+- **FSA-009** — Insurers must notify Transportstyrelsen of policy changes
+  within regulated timeframes
+- **FSA-007** — Notification ensures the vehicle registry reflects valid
+  trafikförsäkring status
+- **GDPR-004** — Data sharing with Transportstyrelsen is based on legal
+  obligation under Trafikskadelagen
+
+---
+
+## Data Model
+
+The following data entities are central to the quote-and-bind process.
+
+### Quote
+
+| Attribute             | Type     | Description                                   |
+| --------------------- | -------- | --------------------------------------------- |
+| Quote ID              | String   | Unique identifier for the quote               |
+| Customer personnummer | String   | Swedish personal identity number              |
+| Registreringsnummer   | String   | Vehicle registration number                   |
+| Vehicle make          | String   | From Transportstyrelsen lookup                |
+| Vehicle model         | String   | From Transportstyrelsen lookup                |
+| Vehicle year          | Integer  | Model year from Transportstyrelsen            |
+| Coverage tier         | Enum     | Trafik / Halv / Hel                           |
+| Deductible amount     | Decimal  | Selected självrisk in SEK                     |
+| Base premium          | Decimal  | Annual premium before add-ons                 |
+| Add-ons               | List     | Selected optional coverages with pricing      |
+| Total premium         | Decimal  | Base premium + add-on premiums                |
+| Payment frequency     | Enum     | Monthly / Annual                              |
+| Bonus class applied   | Integer  | Bonus class used for premium calculation      |
+| Validity period       | Date     | Quote expiry date                             |
+| Assessment reference  | String   | Link to demands-and-needs assessment (QNB-03) |
+| IPID version          | String   | Version of IPID provided                      |
+| Created timestamp     | DateTime | When the quote was created                    |
+| Distribution channel  | Enum     | Digital / Agent / Broker                      |
+| Agent ID              | String   | If agent-assisted (nullable)                  |
+
+### Policy
+
+| Attribute              | Type     | Description                             |
+| ---------------------- | -------- | --------------------------------------- |
+| Policy number          | String   | Unique policy identifier                |
+| Quote ID               | String   | Reference to originating quote          |
+| Customer personnummer  | String   | Policyholder identity                   |
+| Registreringsnummer    | String   | Insured vehicle                         |
+| Coverage tier          | Enum     | Trafik / Halv / Hel                     |
+| Deductible amount      | Decimal  | Självrisk in SEK                        |
+| Total premium          | Decimal  | Bound premium amount                    |
+| Payment frequency      | Enum     | Monthly / Annual                        |
+| Effective date         | Date     | Coverage start date                     |
+| Expiry date            | Date     | Huvudförfallodag (policy anniversary)   |
+| Bonus class            | Integer  | Bonus class at time of binding          |
+| Status                 | Enum     | Active / Cancelled / Expired            |
+| BankID transaction ref | String   | Signing reference                       |
+| Signing timestamp      | DateTime | When the policy was signed              |
+| Transportstyrelsen ref | String   | Notification acknowledgement reference  |
+| Distribution channel   | Enum     | Digital / Agent / Broker                |
+| Agent ID               | String   | If agent-assisted (nullable)            |
+| Assessment reference   | String   | Link to demands-and-needs assessment    |
+| Cooling-off expiry     | Date     | Ångerrätt expiry (14 days from binding) |
+
+### Demands-and-Needs Assessment
+
+| Attribute                | Type     | Description                                   |
+| ------------------------ | -------- | --------------------------------------------- |
+| Assessment ID            | String   | Unique identifier                             |
+| Customer personnummer    | String   | Assessed customer                             |
+| Vehicle usage            | Enum     | Commuting / Business / Leisure                |
+| Annual mileage           | Integer  | Estimated yearly kilometers                   |
+| Parking situation        | Enum     | Garage / Carport / Street / Other             |
+| Deductible tolerance     | Enum     | Low / Medium / High                           |
+| Add-on needs             | List     | Stated needs for optional coverages           |
+| Recommended tier         | Enum     | System recommendation: Trafik / Halv / Hel    |
+| Recommended deductible   | Decimal  | Recommended självrisk in SEK                  |
+| Recommendation rationale | Text     | Why this tier and deductible were recommended |
+| Customer decision        | Enum     | Followed / Deviated                           |
+| Deviation explanation    | Text     | Customer's reason for deviating (nullable)    |
+| Completed by             | String   | Customer / Agent ID                           |
+| Completed timestamp      | DateTime | When the assessment was completed             |
+
+---
+
+## Process Flow
+
+The quote-and-bind process follows this sequence:
+
+1. **Customer identification** — Customer enters registreringsnummer and
+   personnummer; system verifies identity (QNB-01 or QNB-02)
+2. **Vehicle data lookup** — System retrieves vehicle details from
+   Transportstyrelsen
+3. **Bonus class retrieval** — System retrieves or calculates the customer's
+   current bonus class (QNB-07)
+4. **Demands-and-needs assessment** — System guides the customer through the
+   structured assessment (QNB-03)
+5. **Premium calculation** — System calculates premiums for all three tiers
+   using vehicle data, bonus class, and risk factors
+6. **Coverage comparison** — Customer reviews and compares tiers with IPID
+   access (QNB-04)
+7. **Coverage selection** — Customer selects tier, deductible, and optional
+   add-ons
+8. **Pre-contractual review** — System presents binding summary with all
+   required pre-contractual information (IDD-003)
+9. **BankID signing** — Customer signs the policy digitally (QNB-05)
+10. **Policy issuance** — System generates policy number and insurance
+    certificate (QNB-06)
+11. **Payment setup** — System initiates premium collection via payment
+    provider (QNB-06)
+12. **Transportstyrelsen notification** — System notifies the vehicle
+    registry (QNB-08)
+13. **Confirmation** — Customer receives policy documents, insurance
+    certificate, and IPID
+
+---
+
+## Regulatory Traceability Matrix
+
+| Requirement | QNB-01 | QNB-02 | QNB-03 | QNB-04 | QNB-05 | QNB-06 | QNB-07 | QNB-08 |
+| ----------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| FSA-004     |        | X      | X      | X      | X      |        | X      |        |
+| FSA-005     |        |        |        |        |        |        | X      |        |
+| FSA-007     | X      |        |        |        |        | X      |        | X      |
+| FSA-009     |        |        |        |        |        |        |        | X      |
+| FSA-012     |        |        | X      | X      | X      | X      |        |        |
+| FSA-013     |        |        |        |        | X      | X      |        |        |
+| GDPR-001    | X      | X      | X      |        | X      |        | X      |        |
+| GDPR-002    |        |        |        |        |        | X      |        |        |
+| GDPR-004    |        |        |        |        |        |        |        | X      |
+| IDD-001     | X      | X      | X      | X      | X      |        |        |        |
+| IDD-002     |        |        |        | X      | X      |        |        |        |
+| IDD-003     |        |        |        |        | X      |        |        |        |
+| IDD-004     |        |        |        |        |        |        | X      |        |
+| IDD-005     |        | X      |        |        |        |        |        |        |
+| IDD-006     |        | X      | X      |        |        |        |        |        |
+| IDD-007     |        |        |        | X      |        |        |        |        |
+| IDD-008     |        | X      | X      |        | X      |        |        |        |
+| IDD-009     |        | X      |        |        |        |        |        |        |
+
+---
+
+## External System Integration Summary
+
+| System             | Integration Point                 | Stories        |
+| ------------------ | --------------------------------- | -------------- |
+| Transportstyrelsen | Vehicle data lookup               | QNB-01, QNB-02 |
+| Transportstyrelsen | Insurance status notification     | QNB-08         |
+| BankID             | Customer identity verification    | QNB-01         |
+| BankID             | Agent authentication              | QNB-02         |
+| BankID             | Digital policy signing            | QNB-05         |
+| Payment Provider   | Premium collection setup          | QNB-06         |
+| TFF                | Bonus class transfer verification | QNB-07         |


### PR DESCRIPTION
## Summary

- Adds 8 user stories (QNB-01 through QNB-08) for the motor insurance quote-and-bind flow
- Adds use case UC-QNB-001 with main success scenario, alternative flows, business rules, and regulatory compliance mapping
- Includes data model for Quote, Policy, and Demands-and-Needs Assessment entities

## Changes

- **New:** `versioned_docs/version-phase-1/phase-1-motor/user-stories/quote-and-bind.md` — 8 user stories with acceptance criteria, data requirements, external integrations, and regulatory traceability
- **New:** `versioned_docs/version-phase-1/phase-1-motor/use-cases/quote-and-bind.md` — End-to-end use case with 9-step main scenario, 6 alternative flows, 10 business rules, NFRs, and compliance summary
- **Updated:** `versioned_docs/version-phase-1/phase-1-motor/index.md` — Phase 1 Motor overview with scope table and documentation links
- **Updated:** `versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md` — User stories index with QNB summary table
- **Updated:** `versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md` — Use cases index with UC-QNB-001 summary

## Testing

- [x] markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] Docusaurus build succeeds (all links and frontmatter valid)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)