### PR TITLE
docs(#11): Add motor policy administration user stories and use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/index.md
+++ b/docs/phase-1-motor/use-cases/index.md
@@ -4,6 +4,17 @@ sidebar_position: 1
 
 # Use Cases
 
-Use cases for Phase 1 — Motor Insurance.
+Use cases for Phase 1 — Motor Insurance. Each use case describes the detailed interaction flow including actors, preconditions, main flow, exception flows, postconditions, and regulatory references.
 
-_Content will be added in subsequent issues._
+## Policy Administration (MTAs)
+
+Mid-term adjustment and policy lifecycle use cases — see [Policy Administration Use Cases](policy-administration.md).
+
+| ID        | Title                                     | Primary Actor |
+| --------- | ----------------------------------------- | ------------- |
+| UC-PA-001 | Process Mid-Term Vehicle Change           | Customer      |
+| UC-PA-002 | Process Coverage Tier Change              | Customer      |
+| UC-PA-003 | Process Named Driver Change               | Customer      |
+| UC-PA-004 | Manage Policy Status Transitions          | System        |
+| UC-PA-005 | Recalculate Premium After Amendment       | System        |
+| UC-PA-006 | Underwriter Review of High-Risk Amendment | Underwriter   |

--- a/docs/phase-1-motor/use-cases/policy-administration.md
+++ b/docs/phase-1-motor/use-cases/policy-administration.md
@@ -1,0 +1,470 @@
+---
+sidebar_position: 2
+---
+
+# Policy Administration Use Cases
+
+Detailed interaction flows for motor policy mid-term adjustments (MTAs) and policy lifecycle management. Each use case describes the step-by-step process, preconditions, postconditions, and exception flows.
+
+## UC-PA-001: Process Mid-Term Vehicle Change
+
+Handles the end-to-end flow when a customer replaces the insured vehicle on an active policy.
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Transportstyrelsen, Payment Provider, Underwriter (for high-risk vehicles)
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer has the registreringsnummer of the new vehicle
+- The customer is authenticated via BankID
+
+### Main Flow
+
+1. The customer selects "Change vehicle" from their policy management page
+2. The customer enters the new vehicle's registreringsnummer
+3. The system looks up the vehicle in Transportstyrelsen's vehicle registry and retrieves: make, model, year, engine power, weight, vehicle type, VIN
+4. The system displays the vehicle details and asks the customer to confirm the vehicle is correct
+5. The customer confirms the vehicle
+6. The system evaluates the new vehicle against underwriting rules:
+   - If the vehicle is within standard risk parameters → continue to step 7
+   - If the vehicle triggers a high-risk flag → **Exception Flow A**
+7. The system recalculates the premium using the new vehicle's risk factors (vehicle type, value, engine power) while retaining the customer's existing bonus class, address, and coverage tier
+8. The system displays: current premium, new premium, pro-rata adjustment amount, and effective date
+9. The customer reviews and accepts the premium adjustment
+10. The system processes the amendment:
+    a. Updates the policy record with the new vehicle
+    b. Sends a de-registration notification to Transportstyrelsen for the old vehicle
+    c. Sends a registration notification to Transportstyrelsen for the new vehicle
+    d. Creates an amendment record in the policy history
+    e. Triggers premium adjustment via the payment provider (collection or refund)
+11. The system generates an updated policy document
+12. The customer receives confirmation with a link to the updated policy document
+
+### Exception Flows
+
+#### A. High-risk vehicle requires underwriter review
+
+1. The system notifies the customer that the vehicle change requires manual review
+2. The system routes the amendment request to the underwriter queue with the vehicle data and risk assessment
+3. The underwriter reviews the request (see UC-PA-006)
+4. If approved: resume main flow at step 7 with any adjusted terms
+5. If declined: notify the customer with the reason; the original policy remains unchanged
+
+#### B. Vehicle not found in Transportstyrelsen registry
+
+1. The system displays an error: "Vehicle not found in the vehicle registry"
+2. The customer is advised to verify the registreringsnummer
+3. If the vehicle is newly registered, the customer is advised to wait 24 hours for registry propagation and retry
+
+#### C. Transportstyrelsen notification fails
+
+1. The system queues the notification for retry (exponential backoff)
+2. The amendment proceeds — the policy is updated regardless of notification delivery status
+3. Operations staff are alerted after retry exhaustion
+4. Manual intervention sends the notification when the integration is restored
+
+#### D. Customer declines premium adjustment
+
+1. The customer cancels the vehicle change
+2. The original policy remains unchanged
+3. No notifications are sent to Transportstyrelsen
+
+### Postconditions
+
+- The policy record reflects the new vehicle
+- Transportstyrelsen has been notified (or notification is queued)
+- The amendment is recorded in the policy history with full audit trail
+- An updated policy document is available
+- The premium adjustment has been initiated
+
+### Business Rules
+
+- Trafikförsäkring must transfer with the policy — no coverage gap (FSA-007)
+- Bonus class remains with the policyholder, not the vehicle
+- The old vehicle's trafikförsäkring status in the registry is updated
+
+### Regulatory
+
+- **FSA-007** — Continuous trafikförsäkring coverage
+- **FSA-009** — Transportstyrelsen notification
+- **GDPR-002** — Policy data update
+- **GDPR-004** — Transportstyrelsen data exchange
+
+---
+
+## UC-PA-002: Process Coverage Tier Change
+
+Handles upgrades and downgrades between motor insurance coverage tiers (trafikförsäkring, halvförsäkring, helförsäkring).
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Payment Provider
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer is authenticated via BankID
+- The target coverage tier is different from the current tier
+
+### Main Flow
+
+1. The customer selects "Change coverage" from their policy management page
+2. The system displays the available coverage tiers with a comparison:
+
+   | Feature                      | Trafikförsäkring | Halvförsäkring | Helförsäkring |
+   | ---------------------------- | ---------------- | -------------- | ------------- |
+   | Third-party liability        | Included         | Included       | Included      |
+   | Fire and theft               | —                | Included       | Included      |
+   | Glass damage                 | —                | Included       | Included      |
+   | Roadside assistance          | —                | Included       | Included      |
+   | Legal expenses               | —                | Included       | Included      |
+   | Collision damage (vagnskada) | —                | —              | Included      |
+
+3. The customer selects the desired coverage tier
+4. The system checks eligibility:
+   - Downgrade to trafikförsäkring → always permitted
+   - Upgrade to helförsäkring → check vehicle age and value thresholds
+5. The system provides the updated IPID for the new tier (IDD-002)
+6. The system recalculates the premium and displays: current tier and premium, new tier and premium, pro-rata adjustment, effective date
+7. The customer acknowledges the IPID and coverage changes
+8. The customer confirms the tier change
+9. The system processes the amendment:
+   a. Updates the coverage tier on the policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment via the payment provider
+   d. For upgrades: new coverage effective immediately
+   e. For downgrades: new coverage effective from start of next day
+10. The system generates an updated policy document
+11. The customer receives confirmation
+
+### Exception Flows
+
+#### A. Helförsäkring not available for vehicle
+
+1. The system informs the customer that helförsäkring is not available for their vehicle (e.g., vehicle too old or value too low)
+2. The customer is shown alternative options (halvförsäkring if currently on trafikförsäkring only)
+
+#### B. Customer has financed vehicle requiring helförsäkring
+
+1. The system detects that the vehicle is subject to a finance agreement requiring comprehensive coverage
+2. The system warns the customer that their finance agreement may require helförsäkring
+3. The customer may proceed at their own risk or cancel the downgrade
+
+### Postconditions
+
+- The policy record reflects the new coverage tier
+- An updated IPID was provided and acknowledged (for the new tier)
+- The amendment is recorded in the policy history
+- An updated policy document is available
+- Premium adjustment has been initiated
+
+### Regulatory
+
+- **FSA-007** — Trafikförsäkring must remain as minimum coverage
+- **FSA-004** — Clear comparison of coverage tiers
+- **FSA-012** — Pre-contractual disclosure for new coverage
+- **IDD-001** — Demands-and-needs reassessment for significant changes
+- **IDD-002** — Updated IPID provided before confirmation
+
+---
+
+## UC-PA-003: Process Named Driver Change
+
+Handles adding or removing named drivers from a motor insurance policy.
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Underwriter (for high-risk drivers)
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer is authenticated via BankID
+- For adding: the customer has the new driver's personnummer
+
+### Main Flow — Add Named Driver
+
+1. The customer selects "Add driver" from their policy management page
+2. The customer enters the new driver's personnummer
+3. The system validates the personnummer format
+4. The system retrieves the driver's age from the personnummer
+5. The system assesses the risk impact:
+   - Driver age ≥ 25 and no risk flags → continue to step 6
+   - Driver age < 25 or other risk flags → **Exception Flow A**
+6. The system recalculates the premium with the additional driver's risk factors
+7. The system displays: current premium, new premium, adjustment amount, and a description of any surcharges applied
+8. The customer confirms the addition
+9. The system processes the amendment:
+   a. Adds the named driver to the policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment
+10. The system generates an updated policy document
+11. The customer receives confirmation
+
+### Main Flow — Remove Named Driver
+
+1. The customer selects "Remove driver" from their policy management page
+2. The system displays the list of named drivers on the policy (excluding the policyholder)
+3. The customer selects the driver to remove
+4. The system recalculates the premium without the removed driver
+5. The system displays the premium adjustment
+6. The customer confirms the removal
+7. The system processes the amendment:
+   a. Removes the named driver from the active policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment (refund if applicable)
+8. The system generates an updated policy document
+9. The customer receives confirmation
+
+### Exception Flows
+
+#### A. High-risk driver requires underwriter review
+
+1. The system notifies the customer that the driver addition requires review
+2. The system routes the request to the underwriter queue with the driver's risk profile
+3. The underwriter reviews (see UC-PA-006):
+   - Approve with standard terms → resume main flow at step 6
+   - Approve with adjusted terms (e.g., higher deductible) → customer must accept adjusted terms
+   - Decline → customer notified; policy unchanged
+
+#### B. Invalid personnummer
+
+1. The system displays: "Invalid personnummer format"
+2. The customer is asked to re-enter
+
+#### C. Attempting to remove the only driver (policyholder)
+
+1. The system prevents removal: "The policyholder cannot be removed as a named driver"
+
+### Postconditions
+
+- The policy record reflects the updated driver list
+- The amendment is recorded in the policy history
+- An updated policy document is available
+- Premium adjustment has been initiated
+
+### Regulatory
+
+- **GDPR-001** — Named driver personnummer collection must have lawful basis
+- **GDPR-002** — Driver data stored under policy administration
+- **FSA-004** — Surcharges communicated transparently
+- **IDD-001** — Reassess demands and needs if risk profile changes significantly
+
+---
+
+## UC-PA-004: Manage Policy Status Transitions
+
+Handles the lifecycle of policy status changes: active → suspended → lapsed, and reinstatement.
+
+### Actors
+
+- **Primary:** System (automated), Underwriter (for reinstatement review)
+- **Supporting:** Customer, Transportstyrelsen, Payment Provider
+
+### Preconditions
+
+- The policy exists in the system with a known current status
+
+### Main Flow — Suspension Due to Non-Payment
+
+1. The premium payment due date passes without payment
+2. The system sends a payment reminder to the customer with the outstanding amount and a grace period deadline
+3. The grace period expires without payment
+4. The system changes the policy status from "Active" to "Suspended"
+5. The system sends a suspension notification to the customer explaining:
+   - Coverage is no longer active
+   - The reinstatement period and deadline
+   - Consequences for trafikförsäkring (vehicle may incur trafikförsäkringsavgift)
+6. The system notifies Transportstyrelsen that the vehicle's insurance coverage is suspended
+7. The system records the status change in the amendment history
+
+### Main Flow — Reinstatement
+
+1. The customer pays the outstanding premium within the reinstatement period
+2. The payment provider confirms receipt
+3. The system evaluates reinstatement eligibility:
+   - Suspension ≤ configurable threshold → automatic reinstatement (step 4)
+   - Suspension > configurable threshold → **Exception Flow A**
+4. The system changes the policy status from "Suspended" to "Active"
+5. The system notifies Transportstyrelsen that coverage is reinstated
+6. The system sends a reinstatement confirmation to the customer
+7. The system records the reinstatement in the amendment history
+
+### Main Flow — Lapse
+
+1. The reinstatement period expires without payment
+2. The system changes the policy status from "Suspended" to "Lapsed"
+3. The system sends a lapse notification to the customer explaining:
+   - The policy is terminated
+   - The vehicle is now uninsured
+   - TFF may assign default trafikförsäkring with a penalty fee
+   - How to obtain new coverage
+4. The system confirms Transportstyrelsen notification of coverage termination
+5. The system records the lapse in the amendment history
+
+### Exception Flows
+
+#### A. Extended suspension requires underwriter review
+
+1. The system routes the reinstatement request to the underwriter queue
+2. The underwriter reviews the policy's claims history during the suspension period
+3. If approved: resume reinstatement flow at step 4
+4. If declined: the customer is notified that they must apply for a new policy
+
+#### B. Transportstyrelsen notification failure during suspension
+
+1. The system queues the notification for retry
+2. Operations staff are alerted
+3. The status change proceeds on the policy record regardless
+
+### Postconditions
+
+- The policy status reflects the current state
+- Transportstyrelsen has been notified of coverage changes
+- The customer has been notified of the status change and consequences
+- All status transitions are recorded in the amendment history
+
+### Regulatory
+
+- **FSA-007** — A lapsed trafikförsäkring means the vehicle is uninsured
+- **FSA-009** — Transportstyrelsen notified of all coverage status changes
+- **FSA-004** — Customer clearly informed of consequences
+- **FSA-013** — Suspension and lapse procedures comply with Försäkringsavtalslagen
+- **GDPR-002** — Status changes recorded in policy administration
+
+---
+
+## UC-PA-005: Recalculate Premium After Amendment
+
+Handles the premium recalculation triggered by any mid-term policy amendment that changes risk factors.
+
+### Actors
+
+- **Primary:** System (automated)
+- **Supporting:** Payment Provider
+
+### Preconditions
+
+- A policy amendment has been submitted that changes one or more rating factors
+- The current premium and rating factors are known
+
+### Main Flow
+
+1. The system identifies which rating factors have changed:
+   - Vehicle: type, age, value, engine power
+   - Address: postcode risk zone
+   - Coverage tier: trafikförsäkring / halvförsäkring / helförsäkring
+   - Deductible level
+   - Named drivers: count, ages, experience
+   - Mileage band
+2. The system retrieves the current tariff and rating tables
+3. The system calculates the new annual premium using:
+   - Base rate for the vehicle type and coverage tier
+   - Bonus class discount (unchanged by mid-term amendments)
+   - Postcode risk zone factor
+   - Driver surcharges (age, experience)
+   - Mileage factor
+   - Deductible adjustment factor
+4. The system calculates the pro-rata adjustment:
+   - `remaining_days = policy_end_date - amendment_effective_date`
+   - `old_daily_premium = old_annual_premium / 365`
+   - `new_daily_premium = new_annual_premium / 365`
+   - `adjustment = (new_daily_premium - old_daily_premium) × remaining_days`
+5. If the absolute adjustment is below the minimum threshold (configurable) → waive the adjustment
+6. The system returns the calculation result: new annual premium, pro-rata adjustment, effective date, rating factor breakdown
+7. After customer confirmation:
+   - If adjustment > 0 (additional premium): initiate collection via payment provider
+   - If adjustment < 0 (refund): initiate refund or credit to next installment
+8. The system records the premium calculation details in the amendment record
+
+### Exception Flows
+
+#### A. Tariff data unavailable
+
+1. The system logs the error and alerts operations
+2. The amendment is paused; the customer is informed of a temporary delay
+3. When tariff data is available, the system resumes calculation
+
+### Postconditions
+
+- The new premium is calculated and recorded
+- The pro-rata adjustment has been initiated with the payment provider
+- The premium calculation breakdown is stored for audit
+
+### Business Rules
+
+- Bonus class does not change mid-term — it changes only at renewal
+- All premium calculations use the tariff version effective at the amendment date
+- Minimum adjustment threshold prevents micro-transactions
+
+### Regulatory
+
+- **FSA-004** — Premium calculation must be transparent
+- **FSA-006** — Premium data available for regulatory reporting
+- **GDPR-002** — Calculation data retained as part of policy record
+
+---
+
+## UC-PA-006: Underwriter Review of High-Risk Amendment
+
+Handles the manual review process when a policy amendment triggers a high-risk flag.
+
+### Actors
+
+- **Primary:** Underwriter (Riskbedömare)
+- **Supporting:** Customer, System
+
+### Preconditions
+
+- A policy amendment has been flagged as high-risk by the automated risk assessment
+- The amendment is in the underwriter queue
+
+### Main Flow
+
+1. The underwriter opens the amendment request from the queue
+2. The system displays:
+   - Current policy details (coverage, vehicle, drivers, premium)
+   - Proposed amendment details
+   - Risk assessment: flagged triggers, risk score change, historical data
+   - Customer's claims history
+3. The underwriter evaluates the risk and decides:
+   - **Approve** — the amendment proceeds with standard terms
+   - **Approve with adjusted terms** — the underwriter specifies adjustments (e.g., higher deductible, additional exclusion, premium loading)
+   - **Decline** — the amendment is rejected
+4. The underwriter records the decision with a written rationale
+5. The system processes the decision:
+   - Approved: triggers the standard amendment flow (premium recalculation, policy update)
+   - Approved with adjustments: the customer is presented with the adjusted terms and must accept before the amendment proceeds
+   - Declined: the customer is notified with the reason; the original policy remains unchanged
+6. The system records the underwriting decision in the amendment history
+
+### Exception Flows
+
+#### A. Customer rejects adjusted terms
+
+1. The customer declines the underwriter's adjusted terms
+2. The amendment is cancelled; the original policy remains unchanged
+3. The system records the customer's rejection
+
+#### B. SLA breach — review not completed within 2 business days
+
+1. The system escalates the amendment to a senior underwriter
+2. The customer is notified of the delay
+
+### Postconditions
+
+- The underwriter decision is recorded with rationale
+- The amendment is either processed, adjusted, or declined
+- The customer has been notified of the outcome
+
+### Regulatory
+
+- **FSA-004** — Fair treatment; decisions justified and communicated
+- **FSA-005** — Product governance; high-risk amendments monitored
+- **FSA-014** — Underwriting decisions retained for record-keeping period
+- **IDD-001** — Demands-and-needs reassessment if significant risk change

--- a/docs/phase-1-motor/user-stories/index.md
+++ b/docs/phase-1-motor/user-stories/index.md
@@ -4,6 +4,25 @@ sidebar_position: 1
 
 # User Stories
 
-User stories for Phase 1 — Motor Insurance.
+User stories for Phase 1 — Motor Insurance. Each user story follows the format _"As a \<role\>, I want \<goal\> so that \<benefit\>"_ and includes acceptance criteria in Given/When/Then format, business rules, data requirements, and regulatory traceability.
 
-_Content will be added in subsequent issues._
+## Policy Administration (MTAs)
+
+Mid-term adjustments and policy lifecycle management — see [Policy Administration User Stories](policy-administration.md).
+
+| ID        | Title                                       | Actor          |
+| --------- | ------------------------------------------- | -------------- |
+| US-PA-001 | Change Vehicle on Policy                    | Customer       |
+| US-PA-002 | Update Address                              | Customer       |
+| US-PA-003 | Upgrade Coverage Tier                       | Customer       |
+| US-PA-004 | Downgrade Coverage Tier                     | Customer       |
+| US-PA-005 | Adjust Deductible Level                     | Customer       |
+| US-PA-006 | Add Named Driver                            | Customer       |
+| US-PA-007 | Remove Named Driver                         | Customer       |
+| US-PA-008 | Update Annual Mileage Estimate              | Customer       |
+| US-PA-009 | View Amendment History                      | Claims Handler |
+| US-PA-010 | Recalculate Premium After Amendment         | System         |
+| US-PA-011 | Notify Transportstyrelsen of Policy Changes | System         |
+| US-PA-012 | Reissue Policy Document                     | Customer       |
+| US-PA-013 | Manage Policy Status                        | Underwriter    |
+| US-PA-014 | Review High-Risk Amendments                 | Underwriter    |

--- a/docs/phase-1-motor/user-stories/policy-administration.md
+++ b/docs/phase-1-motor/user-stories/policy-administration.md
@@ -1,0 +1,627 @@
+---
+sidebar_position: 2
+---
+
+# Policy Administration User Stories
+
+User stories for mid-term policy adjustments (MTAs) and post-bind policy lifecycle management. These cover all changes a customer or internal actor may make to an active motor insurance policy.
+
+## US-PA-001: Change Vehicle on Policy
+
+**As a** customer,
+**I want to** change the vehicle on my motor insurance policy when I sell my old car and buy a new one,
+**so that** I maintain continuous insurance coverage without a gap.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I submit a vehicle change request with the new vehicle's registreringsnummer
+  **THEN** the system looks up the new vehicle data from Transportstyrelsen and displays the vehicle details for confirmation
+
+- **GIVEN** the new vehicle data is confirmed
+  **WHEN** the system recalculates the premium based on the new vehicle's risk profile
+  **THEN** I see the old premium, the new premium, and the pro-rata adjustment amount with the effective date
+
+- **GIVEN** I accept the vehicle change and premium adjustment
+  **WHEN** the amendment is processed
+  **THEN** the system notifies Transportstyrelsen of the insurance status change for both the old and new vehicles
+
+- **GIVEN** the vehicle change is completed
+  **WHEN** I view my policy
+  **THEN** the policy shows the new vehicle and an updated policy document is available for download
+
+### Business Rules
+
+- The new vehicle must be registered in the fordonsregistret (Transportstyrelsen vehicle registry)
+- Trafikförsäkring coverage must transfer immediately — no coverage gap is permitted (FSA-007)
+- If the new vehicle has a higher risk profile, additional underwriting review may be required
+- Bonus class (bonusklass) transfers with the policyholder, not the vehicle
+- The old vehicle's trafikförsäkring must be cancelled or transferred to another insurer; if not, TFF default coverage applies
+
+### Data Requirements
+
+- New vehicle: registreringsnummer, make, model, year, VIN, vehicle type, engine power, weight
+- Old vehicle: registreringsnummer (for Transportstyrelsen de-registration notification)
+- Premium adjustment: old premium, new premium, effective date, pro-rata calculation
+
+### Regulatory
+
+- **FSA-007** — Mandatory trafikförsäkring must be maintained without gaps
+- **FSA-009** — Transportstyrelsen must be notified of the vehicle change
+- **GDPR-002** — Vehicle and policy data updates must follow data minimization principles
+- **GDPR-004** — Transportstyrelsen notification must transmit only mandated data fields
+- **IDD-001** — If the vehicle change significantly alters risk, reassess demands and needs
+
+---
+
+## US-PA-002: Update Address
+
+**As a** customer,
+**I want to** update my registered address on my policy when I move,
+**so that** my policy reflects my current situation and my premium is correctly calculated.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I submit a new address
+  **THEN** the system validates the address format and postcode
+
+- **GIVEN** the new address is in a different postcode area
+  **WHEN** the premium is recalculated based on the new postcode's risk zone
+  **THEN** I see the premium adjustment (increase or decrease) with the effective date
+
+- **GIVEN** the address change does not affect the premium
+  **WHEN** the change is processed
+  **THEN** the policy is updated immediately without a premium adjustment step
+
+- **GIVEN** identity verification is required for address changes
+  **WHEN** I confirm the change via BankID
+  **THEN** the system records the verified identity and processes the change
+
+### Business Rules
+
+- Address changes require BankID verification (identity-sensitive field)
+- Postcode affects premium through geographic risk zones — certain areas have higher theft or accident rates
+- The new address must be a valid Swedish postcode
+- Address changes take effect immediately; premium adjustments are pro-rata from the effective date
+- An audit trail must record the old address, new address, timestamp, and verification method
+
+### Data Requirements
+
+- New address: street, postcode, city
+- Risk zone mapping: postcode-to-risk-zone lookup table
+- Premium adjustment: old premium, new premium, effective date
+
+### Regulatory
+
+- **GDPR-002** — Address is personal data; updates must be logged with an audit trail
+- **GDPR-006** — Right to rectification — customers may correct inaccurate address data
+- **FSA-004** — Premium recalculation must be transparent and communicated clearly
+
+---
+
+## US-PA-003: Upgrade Coverage Tier
+
+**As a** customer,
+**I want to** upgrade my coverage from halvförsäkring to helförsäkring,
+**so that** I get collision damage protection (vagnskadeförsäkring) for my vehicle.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active policy with halvförsäkring
+  **WHEN** I request an upgrade to helförsäkring
+  **THEN** the system displays the additional coverage included and the new premium
+
+- **GIVEN** I review the coverage comparison
+  **WHEN** the system presents the upgrade
+  **THEN** it shows a clear side-by-side comparison of halvförsäkring vs. helförsäkring benefits, exclusions, and pricing
+
+- **GIVEN** I accept the upgrade
+  **WHEN** the amendment is processed
+  **THEN** the new coverage tier takes effect immediately and an updated policy document is generated
+
+- **GIVEN** the upgrade constitutes a significant change
+  **WHEN** the system processes the upgrade
+  **THEN** an updated IPID for helförsäkring is provided before confirmation
+
+### Business Rules
+
+- Coverage upgrades take effect immediately upon confirmation
+- Premium adjustment is pro-rata for the remaining policy period
+- An upgraded IPID must be provided before the customer confirms (IDD-002)
+- If the vehicle is older than a configurable threshold (e.g., 15 years), helförsäkring may not be offered due to low vehicle value
+- Vagnskadegaranti (collision damage warranty) status should be checked — if active, vagnskadeförsäkring component may be redundant
+
+### Data Requirements
+
+- Current coverage tier and premium
+- New coverage tier, additional coverages, and new premium
+- IPID document version for the new tier
+- Vehicle age and current market value (for eligibility check)
+
+### Regulatory
+
+- **IDD-001** — Reassess demands and needs for significant coverage changes
+- **IDD-002** — Provide updated IPID for the new coverage tier
+- **IDD-007** — If add-ons are offered with the upgrade, present them separately with individual pricing
+- **FSA-004** — Coverage comparison must be clear and transparent
+- **FSA-012** — Pre-contractual disclosure for the new coverage tier
+
+---
+
+## US-PA-004: Downgrade Coverage Tier
+
+**As a** customer,
+**I want to** downgrade my coverage from helförsäkring to halvförsäkring,
+**so that** I reduce my premium while maintaining essential protections.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active policy with helförsäkring
+  **WHEN** I request a downgrade to halvförsäkring
+  **THEN** the system clearly shows which coverages I will lose (vagnskadeförsäkring)
+
+- **GIVEN** I acknowledge the reduced coverage
+  **WHEN** I confirm the downgrade
+  **THEN** the coverage change takes effect from the next day and a premium refund is calculated for the remaining period
+
+- **GIVEN** my vehicle has an outstanding claim
+  **WHEN** I request a downgrade
+  **THEN** the system warns that the downgrade does not affect the pending claim but future incidents will not be covered under the removed coverage
+
+### Business Rules
+
+- Downgrade takes effect from the start of the next day (not immediately, to prevent same-day claim-then-downgrade scenarios)
+- Premium refund is calculated pro-rata for the remaining policy period
+- Downgrade below trafikförsäkring is never permitted (FSA-007)
+- If the customer has a financed vehicle, the finance company may require helförsäkring — the system should warn if applicable
+- The customer must explicitly acknowledge the lost coverages before confirmation
+
+### Data Requirements
+
+- Current and new coverage tiers
+- Coverages being removed with descriptions
+- Premium refund calculation
+- Outstanding claims status
+
+### Regulatory
+
+- **FSA-007** — Trafikförsäkring must always remain as the minimum coverage
+- **FSA-004** — Customer must receive clear information about what coverage is lost
+- **IDD-001** — Reassess demands and needs for significant coverage changes
+- **GDPR-002** — Policy amendment recorded in the policy administration record
+
+---
+
+## US-PA-005: Adjust Deductible Level
+
+**As a** customer,
+**I want to** change my deductible (självrisk) level,
+**so that** I can balance my premium cost against my out-of-pocket risk.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I request a deductible change
+  **THEN** the system displays available deductible levels with the corresponding premium for each
+
+- **GIVEN** I select a new deductible level
+  **WHEN** the premium is recalculated
+  **THEN** I see the premium difference (higher deductible = lower premium, lower deductible = higher premium)
+
+- **GIVEN** I confirm the new deductible
+  **WHEN** the amendment is processed
+  **THEN** the new deductible applies from the effective date and the premium is adjusted pro-rata
+
+### Business Rules
+
+- Available deductible levels are defined per coverage tier (e.g., 1 500 SEK, 3 000 SEK, 5 000 SEK, 7 000 SEK)
+- Different coverage types may have different deductible options (e.g., glass damage has a separate deductible)
+- The deductible change takes effect from the start of the next day
+- Premium adjustment is pro-rata for the remaining policy period
+
+### Data Requirements
+
+- Current deductible level and premium
+- Available deductible options with corresponding premiums
+- Premium adjustment calculation
+
+### Regulatory
+
+- **FSA-004** — Deductible options and their impact on premium must be presented transparently
+- **IDD-001** — Ensure the chosen deductible aligns with the customer's financial situation
+- **GDPR-002** — Amendment recorded in policy administration
+
+---
+
+## US-PA-006: Add Named Driver
+
+**As a** customer,
+**I want to** add a named driver to my motor insurance policy,
+**so that** another person can regularly drive my insured vehicle with full coverage.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I request to add a named driver and provide their personnummer
+  **THEN** the system validates the personnummer and retrieves the driver's age and driving license status
+
+- **GIVEN** the new driver is under 25 years old
+  **WHEN** the premium is recalculated
+  **THEN** the system applies a young driver surcharge and the premium increase is displayed for confirmation
+
+- **GIVEN** the new driver is flagged as high risk (e.g., under 25, recently licensed)
+  **WHEN** the amendment is submitted
+  **THEN** the system routes the request to an underwriter for manual review before processing
+
+- **GIVEN** the named driver is added successfully
+  **WHEN** I view my policy
+  **THEN** the named driver appears on the policy and an updated policy document is generated
+
+### Business Rules
+
+- Named driver's personnummer must be valid and the person must hold a valid Swedish driving license (or equivalent)
+- Drivers under 25 or with less than 2 years of driving experience trigger a young driver surcharge
+- High-risk driver additions (e.g., age under 20, prior claims history) require underwriter approval
+- Adding a named driver does not change the policyholder or the bonus class — bonus follows the policyholder
+- The personnummer of named drivers is sensitive personal data requiring careful handling
+
+### Data Requirements
+
+- Named driver: personnummer, name, date of birth, driving license date, license category
+- Risk assessment: age, driving experience, claims history (if available from previous insurer)
+- Premium adjustment calculation with surcharge breakdown
+
+### Regulatory
+
+- **GDPR-001** — Personal data collection for the named driver requires a lawful basis (contract performance)
+- **GDPR-002** — Named driver data stored as part of policy administration
+- **FSA-004** — Young driver surcharges must be transparently communicated
+- **IDD-001** — If adding a high-risk driver significantly changes the risk profile, reassess demands and needs
+
+---
+
+## US-PA-007: Remove Named Driver
+
+**As a** customer,
+**I want to** remove a named driver from my motor insurance policy,
+**so that** my premium reflects only the drivers who actually use the vehicle.
+
+### Acceptance Criteria
+
+- **GIVEN** I have a named driver on my policy
+  **WHEN** I request to remove them
+  **THEN** the system recalculates the premium without the removed driver's risk factors
+
+- **GIVEN** the removal results in a premium decrease
+  **WHEN** the amendment is processed
+  **THEN** the premium adjustment is applied pro-rata and the named driver is removed from the policy
+
+- **GIVEN** the named driver is removed
+  **WHEN** I view my policy
+  **THEN** the driver no longer appears and an updated policy document is available
+
+### Business Rules
+
+- Removing a named driver takes effect immediately
+- Premium reduction (if any) is applied pro-rata
+- The removed driver's personal data is retained for the policy administration retention period (GDPR-002)
+- At least one driver (the policyholder) must remain on the policy
+
+### Data Requirements
+
+- Named driver to remove: personnummer, name
+- Premium adjustment calculation
+
+### Regulatory
+
+- **GDPR-002** — Removed driver's data retained per retention schedule; not actively processed
+- **FSA-004** — Premium adjustment must be communicated transparently
+
+---
+
+## US-PA-008: Update Annual Mileage Estimate
+
+**As a** customer,
+**I want to** update my estimated annual mileage (körsträcka),
+**so that** my premium reflects my actual driving pattern.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I update my annual mileage estimate
+  **THEN** the system recalculates the premium based on the new mileage band
+
+- **GIVEN** the new mileage is significantly higher than the original estimate
+  **WHEN** the premium increases
+  **THEN** the system displays the new premium and explains that higher mileage increases risk exposure
+
+- **GIVEN** I confirm the mileage change
+  **WHEN** the amendment is processed
+  **THEN** the premium adjustment is applied pro-rata from the effective date
+
+### Business Rules
+
+- Mileage is categorized into bands (e.g., 0–1 000 mil, 1 001–1 500 mil, 1 501–2 000 mil, 2 001+ mil)
+- Higher mileage increases premium; lower mileage decreases premium
+- Customers have a duty to report material changes in driving pattern
+- Misrepresentation of mileage may affect claims settlement (material fact)
+- Mileage changes take effect immediately
+
+### Data Requirements
+
+- Current mileage estimate and band
+- New mileage estimate and band
+- Premium adjustment calculation
+
+### Regulatory
+
+- **FSA-004** — Mileage impact on premium must be communicated clearly
+- **GDPR-002** — Mileage data recorded as part of policy administration
+
+---
+
+## US-PA-009: View Amendment History
+
+**As a** claims handler,
+**I want to** see the complete policy amendment history,
+**so that** I can verify what coverage was active at the time of a claim.
+
+### Acceptance Criteria
+
+- **GIVEN** I am investigating a claim on a motor policy
+  **WHEN** I view the policy amendment history
+  **THEN** I see a chronological list of all amendments with effective dates, amendment types, and details
+
+- **GIVEN** the amendment history is displayed
+  **WHEN** I select a specific amendment
+  **THEN** I see the full details including what changed, the old and new values, the effective date, and who authorized the change
+
+- **GIVEN** a claim date falls between two amendments
+  **WHEN** I check the coverage at the claim date
+  **THEN** the system shows the exact coverage tier, deductible, named drivers, and vehicle that were active on that date
+
+### Business Rules
+
+- Amendment history is an immutable audit trail — entries cannot be modified or deleted
+- Each amendment record includes: amendment type, effective date, old values, new values, timestamp of processing, user/channel that initiated the change
+- Point-in-time coverage reconstruction must be possible for any date in the policy's history
+- Amendment history is accessible to claims handlers, underwriters, and compliance officers
+
+### Data Requirements
+
+- Amendment record: type, effective date, processing timestamp, old values, new values, initiator (customer/agent/system), authorization method
+- Coverage snapshot at any point in time: tier, deductible, vehicle, named drivers, premium
+
+### Regulatory
+
+- **FSA-010** — Claims settlement requires verifying coverage at the time of loss
+- **FSA-014** — Amendment records must be retained for the full record-keeping period
+- **GDPR-002** — Amendment history contains personal data; subject to access rights and retention rules
+
+---
+
+## US-PA-010: Recalculate Premium After Amendment
+
+**As the** system,
+**I want to** recalculate premiums whenever a policy amendment changes risk factors,
+**so that** the customer pays the correct amount for their current coverage and risk profile.
+
+### Acceptance Criteria
+
+- **GIVEN** a policy amendment changes a risk factor (vehicle, address, coverage tier, deductible, named drivers, mileage)
+  **WHEN** the amendment is being processed
+  **THEN** the system calculates the new annual premium using the updated risk factors
+
+- **GIVEN** the premium has changed
+  **WHEN** the pro-rata adjustment is calculated
+  **THEN** the system computes the difference between the old and new premium for the remaining policy period
+
+- **GIVEN** the adjustment results in an additional premium
+  **WHEN** the customer confirms the amendment
+  **THEN** the additional amount is collected via the existing payment method
+
+- **GIVEN** the adjustment results in a premium refund
+  **WHEN** the amendment is processed
+  **THEN** the refund is credited to the customer's payment method or applied to the next premium installment
+
+### Business Rules
+
+- Premium recalculation uses the current rating factors and tariff at the time of amendment
+- Pro-rata calculation: `adjustment = (new_daily_premium - old_daily_premium) × remaining_days`
+- Minimum premium thresholds may apply — very small adjustments (below a configurable threshold) may be waived
+- Premium recalculation does not change the bonus class — bonus changes only at renewal
+- All premium calculations must be auditable with a clear breakdown of rating factors
+
+### Data Requirements
+
+- Rating factors: vehicle type, vehicle age, vehicle value, postcode risk zone, coverage tier, deductible level, named drivers (age, experience), mileage band, bonus class
+- Premium calculation: old annual premium, new annual premium, effective date, remaining days, pro-rata adjustment amount
+- Payment: adjustment amount, payment method, collection/refund date
+
+### Regulatory
+
+- **FSA-004** — Premium calculation must be transparent; the customer must understand why the premium changed
+- **FSA-006** — Premium data must be available for supervisory reporting
+- **GDPR-002** — Premium calculation data is part of the policy administration record
+
+---
+
+## US-PA-011: Notify Transportstyrelsen of Policy Changes
+
+**As the** system,
+**I want to** notify Transportstyrelsen when a vehicle change or policy status change occurs,
+**so that** the national vehicle registry reflects the current insurance status.
+
+### Acceptance Criteria
+
+- **GIVEN** a vehicle change amendment is processed
+  **WHEN** the old vehicle's coverage ends and the new vehicle's coverage begins
+  **THEN** the system sends a de-registration notification for the old vehicle and a registration notification for the new vehicle to Transportstyrelsen
+
+- **GIVEN** a policy is suspended or lapses
+  **WHEN** the status change takes effect
+  **THEN** the system notifies Transportstyrelsen that the vehicle no longer has active coverage
+
+- **GIVEN** a notification fails to deliver
+  **WHEN** the system detects the failure
+  **THEN** it retries according to the configured retry policy and alerts operations staff if retries are exhausted
+
+- **GIVEN** notifications are sent
+  **WHEN** an acknowledgement is received from Transportstyrelsen
+  **THEN** the system logs the acknowledgement with timestamp and reference number
+
+### Business Rules
+
+- Notifications must be sent within the timeframe prescribed by Trafikskadelagen
+- Notification content must follow the Transportstyrelsen API specification — no additional data beyond the mandated schema
+- Failed notifications must be retried with exponential backoff
+- All notification attempts, responses, and failures must be logged for audit
+- The system must handle Transportstyrelsen downtime gracefully with queuing and retry
+
+### Data Requirements
+
+- Notification payload: registreringsnummer, policy number, policyholder personnummer, coverage start/end date, notification type (new, change, cancellation)
+- Response tracking: acknowledgement ID, timestamp, status (success, failure, pending)
+
+### Regulatory
+
+- **FSA-009** — Transportstyrelsen notification is a legal obligation
+- **FSA-007** — Ensures the vehicle registry reflects current trafikförsäkring status
+- **GDPR-004** — Only mandated data fields are transmitted to Transportstyrelsen
+
+---
+
+## US-PA-012: Reissue Policy Document
+
+**As a** customer,
+**I want to** receive an updated policy document after any amendment to my policy,
+**so that** I have a current record of my coverage, terms, and conditions.
+
+### Acceptance Criteria
+
+- **GIVEN** a policy amendment has been processed
+  **WHEN** the amendment takes effect
+  **THEN** the system generates an updated policy document reflecting all current policy details
+
+- **GIVEN** the updated document is generated
+  **WHEN** it is available
+  **THEN** I receive a notification (email or in-app) with a link to download the document
+
+- **GIVEN** I access the document
+  **WHEN** I review it
+  **THEN** it clearly shows the current coverage tier, vehicle, named drivers, deductible, premium, and effective dates
+
+### Business Rules
+
+- A new policy document is generated for every material amendment (vehicle change, coverage change, named driver change)
+- Minor amendments (mileage update, address change with no premium impact) may generate a confirmation letter rather than a full reissue
+- Documents must use clear, plain language (FSA-004)
+- Previous versions of the policy document remain accessible in the document history
+- Documents must be generated in Swedish
+
+### Data Requirements
+
+- Policy summary: policy number, policyholder details, vehicle details, coverage tier, deductible, named drivers, premium, payment schedule
+- Document metadata: version number, generation date, amendment reference
+
+### Regulatory
+
+- **FSA-004** — Policy documents must be clear, transparent, and in plain language
+- **FSA-012** — Contractual information must be provided after binding and after amendments
+- **FSA-014** — Policy documents must be retained for the record-keeping period
+- **GDPR-002** — Documents contain personal data subject to retention rules
+
+---
+
+## US-PA-013: Manage Policy Status
+
+**As an** underwriter,
+**I want to** manage policy status transitions (active, suspended, lapsed),
+**so that** the policy reflects the correct operational state and coverage availability.
+
+### Acceptance Criteria
+
+- **GIVEN** a policyholder has failed to pay the premium within the grace period
+  **WHEN** the payment deadline passes
+  **THEN** the policy status changes to "suspended" and the customer is notified
+
+- **GIVEN** a policy is suspended
+  **WHEN** the policyholder pays the outstanding premium within the reinstatement period
+  **THEN** the policy is reinstated to "active" with continuous coverage (no gap)
+
+- **GIVEN** a suspended policy reaches the end of the reinstatement period without payment
+  **WHEN** the reinstatement period expires
+  **THEN** the policy status changes to "lapsed" and Transportstyrelsen is notified
+
+- **GIVEN** a policy transitions to any new status
+  **WHEN** the transition is processed
+  **THEN** the system records the status change with timestamp, reason, and authorization in the amendment history
+
+### Business Rules
+
+- Policy statuses: **Active** (coverage in force), **Suspended** (coverage temporarily inactive due to non-payment), **Lapsed** (coverage terminated due to prolonged non-payment)
+- Suspension grace period and reinstatement period are configurable per product
+- A suspended trafikförsäkring policy triggers Transportstyrelsen notification — the vehicle owner risks trafikförsäkringsavgift (penalty fee)
+- Reinstatement may require underwriter review if the suspension exceeded a configurable threshold
+- Status changes are irreversible through the standard flow — reversals require underwriter override with documented justification
+
+### Data Requirements
+
+- Policy status: current status, effective date of status change, reason
+- Payment status: outstanding balance, last payment date, grace period end date, reinstatement deadline
+- Notification records: customer notification sent, Transportstyrelsen notification sent
+
+### Regulatory
+
+- **FSA-007** — Lapsed trafikförsäkring means the vehicle is uninsured; Transportstyrelsen must be notified
+- **FSA-009** — Status changes that affect coverage must be reported to Transportstyrelsen
+- **FSA-004** — Customers must be clearly informed about suspension consequences
+- **FSA-013** — Cancellation and suspension rules must comply with Försäkringsavtalslagen
+- **GDPR-002** — Status change history is part of the policy administration record
+
+---
+
+## US-PA-014: Review High-Risk Amendments
+
+**As an** underwriter,
+**I want to** review amendments that significantly change the risk profile of a policy,
+**so that** I can approve, adjust terms, or decline the change.
+
+### Acceptance Criteria
+
+- **GIVEN** an amendment triggers a high-risk flag (e.g., adding a driver under 20, changing to a high-performance vehicle)
+  **WHEN** the amendment is submitted
+  **THEN** the system routes the amendment to the underwriter queue for manual review
+
+- **GIVEN** the amendment is in the underwriter queue
+  **WHEN** I review the amendment details
+  **THEN** I see the current policy, the proposed change, the risk assessment, and the premium impact
+
+- **GIVEN** I approve the amendment
+  **WHEN** I authorize it
+  **THEN** the amendment is processed and the customer is notified of the updated terms and premium
+
+- **GIVEN** I decline the amendment or adjust the terms
+  **WHEN** I record my decision with a rationale
+  **THEN** the customer is notified of the decision and the reasons for any modifications
+
+### Business Rules
+
+- High-risk triggers are configurable: driver age thresholds, vehicle type categories, vehicle value thresholds, claims history thresholds
+- Underwriter decisions must be recorded with rationale for audit purposes
+- SLA for underwriter review: decision within 2 business days of submission
+- If the underwriter adjusts terms (e.g., higher deductible, exclusion), the customer must accept the adjusted terms before the amendment proceeds
+
+### Data Requirements
+
+- Amendment details: type, proposed changes, risk factors affected
+- Risk assessment: risk score change, flagged triggers, historical claims data
+- Underwriter decision: approve/decline/adjust, rationale, adjusted terms (if any), decision date
+
+### Regulatory
+
+- **FSA-004** — Fair treatment — decisions must be justified and communicated to the customer
+- **FSA-005** — Product governance — high-risk amendments must be monitored
+- **IDD-001** — Significant changes may require a fresh demands-and-needs assessment
+- **FSA-014** — Underwriting decisions and rationales must be retained

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
@@ -21,3 +21,16 @@ issuance and Transportstyrelsen notification. It covers:
 - Policy issuance and insurance certificate delivery
 - Transportstyrelsen notification
 - Agent-assisted and broker-assisted alternative flows
+
+## Policy Administration (MTAs)
+
+Mid-term adjustment and policy lifecycle use cases — see [Policy Administration Use Cases](policy-administration.md).
+
+| ID        | Title                                     | Primary Actor |
+| --------- | ----------------------------------------- | ------------- |
+| UC-PA-001 | Process Mid-Term Vehicle Change           | Customer      |
+| UC-PA-002 | Process Coverage Tier Change              | Customer      |
+| UC-PA-003 | Process Named Driver Change               | Customer      |
+| UC-PA-004 | Manage Policy Status Transitions          | System        |
+| UC-PA-005 | Recalculate Premium After Amendment       | System        |
+| UC-PA-006 | Underwriter Review of High-Risk Amendment | Underwriter   |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/policy-administration.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/policy-administration.md
@@ -1,0 +1,470 @@
+---
+sidebar_position: 2
+---
+
+# Policy Administration Use Cases
+
+Detailed interaction flows for motor policy mid-term adjustments (MTAs) and policy lifecycle management. Each use case describes the step-by-step process, preconditions, postconditions, and exception flows.
+
+## UC-PA-001: Process Mid-Term Vehicle Change
+
+Handles the end-to-end flow when a customer replaces the insured vehicle on an active policy.
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Transportstyrelsen, Payment Provider, Underwriter (for high-risk vehicles)
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer has the registreringsnummer of the new vehicle
+- The customer is authenticated via BankID
+
+### Main Flow
+
+1. The customer selects "Change vehicle" from their policy management page
+2. The customer enters the new vehicle's registreringsnummer
+3. The system looks up the vehicle in Transportstyrelsen's vehicle registry and retrieves: make, model, year, engine power, weight, vehicle type, VIN
+4. The system displays the vehicle details and asks the customer to confirm the vehicle is correct
+5. The customer confirms the vehicle
+6. The system evaluates the new vehicle against underwriting rules:
+   - If the vehicle is within standard risk parameters → continue to step 7
+   - If the vehicle triggers a high-risk flag → **Exception Flow A**
+7. The system recalculates the premium using the new vehicle's risk factors (vehicle type, value, engine power) while retaining the customer's existing bonus class, address, and coverage tier
+8. The system displays: current premium, new premium, pro-rata adjustment amount, and effective date
+9. The customer reviews and accepts the premium adjustment
+10. The system processes the amendment:
+    a. Updates the policy record with the new vehicle
+    b. Sends a de-registration notification to Transportstyrelsen for the old vehicle
+    c. Sends a registration notification to Transportstyrelsen for the new vehicle
+    d. Creates an amendment record in the policy history
+    e. Triggers premium adjustment via the payment provider (collection or refund)
+11. The system generates an updated policy document
+12. The customer receives confirmation with a link to the updated policy document
+
+### Exception Flows
+
+#### A. High-risk vehicle requires underwriter review
+
+1. The system notifies the customer that the vehicle change requires manual review
+2. The system routes the amendment request to the underwriter queue with the vehicle data and risk assessment
+3. The underwriter reviews the request (see UC-PA-006)
+4. If approved: resume main flow at step 7 with any adjusted terms
+5. If declined: notify the customer with the reason; the original policy remains unchanged
+
+#### B. Vehicle not found in Transportstyrelsen registry
+
+1. The system displays an error: "Vehicle not found in the vehicle registry"
+2. The customer is advised to verify the registreringsnummer
+3. If the vehicle is newly registered, the customer is advised to wait 24 hours for registry propagation and retry
+
+#### C. Transportstyrelsen notification fails
+
+1. The system queues the notification for retry (exponential backoff)
+2. The amendment proceeds — the policy is updated regardless of notification delivery status
+3. Operations staff are alerted after retry exhaustion
+4. Manual intervention sends the notification when the integration is restored
+
+#### D. Customer declines premium adjustment
+
+1. The customer cancels the vehicle change
+2. The original policy remains unchanged
+3. No notifications are sent to Transportstyrelsen
+
+### Postconditions
+
+- The policy record reflects the new vehicle
+- Transportstyrelsen has been notified (or notification is queued)
+- The amendment is recorded in the policy history with full audit trail
+- An updated policy document is available
+- The premium adjustment has been initiated
+
+### Business Rules
+
+- Trafikförsäkring must transfer with the policy — no coverage gap (FSA-007)
+- Bonus class remains with the policyholder, not the vehicle
+- The old vehicle's trafikförsäkring status in the registry is updated
+
+### Regulatory
+
+- **FSA-007** — Continuous trafikförsäkring coverage
+- **FSA-009** — Transportstyrelsen notification
+- **GDPR-002** — Policy data update
+- **GDPR-004** — Transportstyrelsen data exchange
+
+---
+
+## UC-PA-002: Process Coverage Tier Change
+
+Handles upgrades and downgrades between motor insurance coverage tiers (trafikförsäkring, halvförsäkring, helförsäkring).
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Payment Provider
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer is authenticated via BankID
+- The target coverage tier is different from the current tier
+
+### Main Flow
+
+1. The customer selects "Change coverage" from their policy management page
+2. The system displays the available coverage tiers with a comparison:
+
+   | Feature                      | Trafikförsäkring | Halvförsäkring | Helförsäkring |
+   | ---------------------------- | ---------------- | -------------- | ------------- |
+   | Third-party liability        | Included         | Included       | Included      |
+   | Fire and theft               | —                | Included       | Included      |
+   | Glass damage                 | —                | Included       | Included      |
+   | Roadside assistance          | —                | Included       | Included      |
+   | Legal expenses               | —                | Included       | Included      |
+   | Collision damage (vagnskada) | —                | —              | Included      |
+
+3. The customer selects the desired coverage tier
+4. The system checks eligibility:
+   - Downgrade to trafikförsäkring → always permitted
+   - Upgrade to helförsäkring → check vehicle age and value thresholds
+5. The system provides the updated IPID for the new tier (IDD-002)
+6. The system recalculates the premium and displays: current tier and premium, new tier and premium, pro-rata adjustment, effective date
+7. The customer acknowledges the IPID and coverage changes
+8. The customer confirms the tier change
+9. The system processes the amendment:
+   a. Updates the coverage tier on the policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment via the payment provider
+   d. For upgrades: new coverage effective immediately
+   e. For downgrades: new coverage effective from start of next day
+10. The system generates an updated policy document
+11. The customer receives confirmation
+
+### Exception Flows
+
+#### A. Helförsäkring not available for vehicle
+
+1. The system informs the customer that helförsäkring is not available for their vehicle (e.g., vehicle too old or value too low)
+2. The customer is shown alternative options (halvförsäkring if currently on trafikförsäkring only)
+
+#### B. Customer has financed vehicle requiring helförsäkring
+
+1. The system detects that the vehicle is subject to a finance agreement requiring comprehensive coverage
+2. The system warns the customer that their finance agreement may require helförsäkring
+3. The customer may proceed at their own risk or cancel the downgrade
+
+### Postconditions
+
+- The policy record reflects the new coverage tier
+- An updated IPID was provided and acknowledged (for the new tier)
+- The amendment is recorded in the policy history
+- An updated policy document is available
+- Premium adjustment has been initiated
+
+### Regulatory
+
+- **FSA-007** — Trafikförsäkring must remain as minimum coverage
+- **FSA-004** — Clear comparison of coverage tiers
+- **FSA-012** — Pre-contractual disclosure for new coverage
+- **IDD-001** — Demands-and-needs reassessment for significant changes
+- **IDD-002** — Updated IPID provided before confirmation
+
+---
+
+## UC-PA-003: Process Named Driver Change
+
+Handles adding or removing named drivers from a motor insurance policy.
+
+### Actors
+
+- **Primary:** Customer (Privatkund)
+- **Supporting:** Underwriter (for high-risk drivers)
+
+### Preconditions
+
+- The customer has an active motor insurance policy
+- The customer is authenticated via BankID
+- For adding: the customer has the new driver's personnummer
+
+### Main Flow — Add Named Driver
+
+1. The customer selects "Add driver" from their policy management page
+2. The customer enters the new driver's personnummer
+3. The system validates the personnummer format
+4. The system retrieves the driver's age from the personnummer
+5. The system assesses the risk impact:
+   - Driver age ≥ 25 and no risk flags → continue to step 6
+   - Driver age < 25 or other risk flags → **Exception Flow A**
+6. The system recalculates the premium with the additional driver's risk factors
+7. The system displays: current premium, new premium, adjustment amount, and a description of any surcharges applied
+8. The customer confirms the addition
+9. The system processes the amendment:
+   a. Adds the named driver to the policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment
+10. The system generates an updated policy document
+11. The customer receives confirmation
+
+### Main Flow — Remove Named Driver
+
+1. The customer selects "Remove driver" from their policy management page
+2. The system displays the list of named drivers on the policy (excluding the policyholder)
+3. The customer selects the driver to remove
+4. The system recalculates the premium without the removed driver
+5. The system displays the premium adjustment
+6. The customer confirms the removal
+7. The system processes the amendment:
+   a. Removes the named driver from the active policy record
+   b. Creates an amendment record in the policy history
+   c. Triggers premium adjustment (refund if applicable)
+8. The system generates an updated policy document
+9. The customer receives confirmation
+
+### Exception Flows
+
+#### A. High-risk driver requires underwriter review
+
+1. The system notifies the customer that the driver addition requires review
+2. The system routes the request to the underwriter queue with the driver's risk profile
+3. The underwriter reviews (see UC-PA-006):
+   - Approve with standard terms → resume main flow at step 6
+   - Approve with adjusted terms (e.g., higher deductible) → customer must accept adjusted terms
+   - Decline → customer notified; policy unchanged
+
+#### B. Invalid personnummer
+
+1. The system displays: "Invalid personnummer format"
+2. The customer is asked to re-enter
+
+#### C. Attempting to remove the only driver (policyholder)
+
+1. The system prevents removal: "The policyholder cannot be removed as a named driver"
+
+### Postconditions
+
+- The policy record reflects the updated driver list
+- The amendment is recorded in the policy history
+- An updated policy document is available
+- Premium adjustment has been initiated
+
+### Regulatory
+
+- **GDPR-001** — Named driver personnummer collection must have lawful basis
+- **GDPR-002** — Driver data stored under policy administration
+- **FSA-004** — Surcharges communicated transparently
+- **IDD-001** — Reassess demands and needs if risk profile changes significantly
+
+---
+
+## UC-PA-004: Manage Policy Status Transitions
+
+Handles the lifecycle of policy status changes: active → suspended → lapsed, and reinstatement.
+
+### Actors
+
+- **Primary:** System (automated), Underwriter (for reinstatement review)
+- **Supporting:** Customer, Transportstyrelsen, Payment Provider
+
+### Preconditions
+
+- The policy exists in the system with a known current status
+
+### Main Flow — Suspension Due to Non-Payment
+
+1. The premium payment due date passes without payment
+2. The system sends a payment reminder to the customer with the outstanding amount and a grace period deadline
+3. The grace period expires without payment
+4. The system changes the policy status from "Active" to "Suspended"
+5. The system sends a suspension notification to the customer explaining:
+   - Coverage is no longer active
+   - The reinstatement period and deadline
+   - Consequences for trafikförsäkring (vehicle may incur trafikförsäkringsavgift)
+6. The system notifies Transportstyrelsen that the vehicle's insurance coverage is suspended
+7. The system records the status change in the amendment history
+
+### Main Flow — Reinstatement
+
+1. The customer pays the outstanding premium within the reinstatement period
+2. The payment provider confirms receipt
+3. The system evaluates reinstatement eligibility:
+   - Suspension ≤ configurable threshold → automatic reinstatement (step 4)
+   - Suspension > configurable threshold → **Exception Flow A**
+4. The system changes the policy status from "Suspended" to "Active"
+5. The system notifies Transportstyrelsen that coverage is reinstated
+6. The system sends a reinstatement confirmation to the customer
+7. The system records the reinstatement in the amendment history
+
+### Main Flow — Lapse
+
+1. The reinstatement period expires without payment
+2. The system changes the policy status from "Suspended" to "Lapsed"
+3. The system sends a lapse notification to the customer explaining:
+   - The policy is terminated
+   - The vehicle is now uninsured
+   - TFF may assign default trafikförsäkring with a penalty fee
+   - How to obtain new coverage
+4. The system confirms Transportstyrelsen notification of coverage termination
+5. The system records the lapse in the amendment history
+
+### Exception Flows
+
+#### A. Extended suspension requires underwriter review
+
+1. The system routes the reinstatement request to the underwriter queue
+2. The underwriter reviews the policy's claims history during the suspension period
+3. If approved: resume reinstatement flow at step 4
+4. If declined: the customer is notified that they must apply for a new policy
+
+#### B. Transportstyrelsen notification failure during suspension
+
+1. The system queues the notification for retry
+2. Operations staff are alerted
+3. The status change proceeds on the policy record regardless
+
+### Postconditions
+
+- The policy status reflects the current state
+- Transportstyrelsen has been notified of coverage changes
+- The customer has been notified of the status change and consequences
+- All status transitions are recorded in the amendment history
+
+### Regulatory
+
+- **FSA-007** — A lapsed trafikförsäkring means the vehicle is uninsured
+- **FSA-009** — Transportstyrelsen notified of all coverage status changes
+- **FSA-004** — Customer clearly informed of consequences
+- **FSA-013** — Suspension and lapse procedures comply with Försäkringsavtalslagen
+- **GDPR-002** — Status changes recorded in policy administration
+
+---
+
+## UC-PA-005: Recalculate Premium After Amendment
+
+Handles the premium recalculation triggered by any mid-term policy amendment that changes risk factors.
+
+### Actors
+
+- **Primary:** System (automated)
+- **Supporting:** Payment Provider
+
+### Preconditions
+
+- A policy amendment has been submitted that changes one or more rating factors
+- The current premium and rating factors are known
+
+### Main Flow
+
+1. The system identifies which rating factors have changed:
+   - Vehicle: type, age, value, engine power
+   - Address: postcode risk zone
+   - Coverage tier: trafikförsäkring / halvförsäkring / helförsäkring
+   - Deductible level
+   - Named drivers: count, ages, experience
+   - Mileage band
+2. The system retrieves the current tariff and rating tables
+3. The system calculates the new annual premium using:
+   - Base rate for the vehicle type and coverage tier
+   - Bonus class discount (unchanged by mid-term amendments)
+   - Postcode risk zone factor
+   - Driver surcharges (age, experience)
+   - Mileage factor
+   - Deductible adjustment factor
+4. The system calculates the pro-rata adjustment:
+   - `remaining_days = policy_end_date - amendment_effective_date`
+   - `old_daily_premium = old_annual_premium / 365`
+   - `new_daily_premium = new_annual_premium / 365`
+   - `adjustment = (new_daily_premium - old_daily_premium) × remaining_days`
+5. If the absolute adjustment is below the minimum threshold (configurable) → waive the adjustment
+6. The system returns the calculation result: new annual premium, pro-rata adjustment, effective date, rating factor breakdown
+7. After customer confirmation:
+   - If adjustment > 0 (additional premium): initiate collection via payment provider
+   - If adjustment < 0 (refund): initiate refund or credit to next installment
+8. The system records the premium calculation details in the amendment record
+
+### Exception Flows
+
+#### A. Tariff data unavailable
+
+1. The system logs the error and alerts operations
+2. The amendment is paused; the customer is informed of a temporary delay
+3. When tariff data is available, the system resumes calculation
+
+### Postconditions
+
+- The new premium is calculated and recorded
+- The pro-rata adjustment has been initiated with the payment provider
+- The premium calculation breakdown is stored for audit
+
+### Business Rules
+
+- Bonus class does not change mid-term — it changes only at renewal
+- All premium calculations use the tariff version effective at the amendment date
+- Minimum adjustment threshold prevents micro-transactions
+
+### Regulatory
+
+- **FSA-004** — Premium calculation must be transparent
+- **FSA-006** — Premium data available for regulatory reporting
+- **GDPR-002** — Calculation data retained as part of policy record
+
+---
+
+## UC-PA-006: Underwriter Review of High-Risk Amendment
+
+Handles the manual review process when a policy amendment triggers a high-risk flag.
+
+### Actors
+
+- **Primary:** Underwriter (Riskbedömare)
+- **Supporting:** Customer, System
+
+### Preconditions
+
+- A policy amendment has been flagged as high-risk by the automated risk assessment
+- The amendment is in the underwriter queue
+
+### Main Flow
+
+1. The underwriter opens the amendment request from the queue
+2. The system displays:
+   - Current policy details (coverage, vehicle, drivers, premium)
+   - Proposed amendment details
+   - Risk assessment: flagged triggers, risk score change, historical data
+   - Customer's claims history
+3. The underwriter evaluates the risk and decides:
+   - **Approve** — the amendment proceeds with standard terms
+   - **Approve with adjusted terms** — the underwriter specifies adjustments (e.g., higher deductible, additional exclusion, premium loading)
+   - **Decline** — the amendment is rejected
+4. The underwriter records the decision with a written rationale
+5. The system processes the decision:
+   - Approved: triggers the standard amendment flow (premium recalculation, policy update)
+   - Approved with adjustments: the customer is presented with the adjusted terms and must accept before the amendment proceeds
+   - Declined: the customer is notified with the reason; the original policy remains unchanged
+6. The system records the underwriting decision in the amendment history
+
+### Exception Flows
+
+#### A. Customer rejects adjusted terms
+
+1. The customer declines the underwriter's adjusted terms
+2. The amendment is cancelled; the original policy remains unchanged
+3. The system records the customer's rejection
+
+#### B. SLA breach — review not completed within 2 business days
+
+1. The system escalates the amendment to a senior underwriter
+2. The customer is notified of the delay
+
+### Postconditions
+
+- The underwriter decision is recorded with rationale
+- The amendment is either processed, adjusted, or declined
+- The customer has been notified of the outcome
+
+### Regulatory
+
+- **FSA-004** — Fair treatment; decisions justified and communicated
+- **FSA-005** — Product governance; high-risk amendments monitored
+- **FSA-014** — Underwriting decisions retained for record-keeping period
+- **IDD-001** — Demands-and-needs reassessment if significant risk change

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
@@ -24,3 +24,24 @@ flow from initial customer inquiry through policy issuance:
 | QNB-06 | Private Customer | Receive insurance certificate immediately |
 | QNB-07 | Underwriter      | Apply bonus class rules automatically     |
 | QNB-08 | System           | Notify Transportstyrelsen of new policy   |
+
+## Policy Administration (MTAs)
+
+Mid-term adjustments and policy lifecycle management — see [Policy Administration User Stories](policy-administration.md).
+
+| ID        | Title                                       | Actor          |
+| --------- | ------------------------------------------- | -------------- |
+| US-PA-001 | Change Vehicle on Policy                    | Customer       |
+| US-PA-002 | Update Address                              | Customer       |
+| US-PA-003 | Upgrade Coverage Tier                       | Customer       |
+| US-PA-004 | Downgrade Coverage Tier                     | Customer       |
+| US-PA-005 | Adjust Deductible Level                     | Customer       |
+| US-PA-006 | Add Named Driver                            | Customer       |
+| US-PA-007 | Remove Named Driver                         | Customer       |
+| US-PA-008 | Update Annual Mileage Estimate              | Customer       |
+| US-PA-009 | View Amendment History                      | Claims Handler |
+| US-PA-010 | Recalculate Premium After Amendment         | System         |
+| US-PA-011 | Notify Transportstyrelsen of Policy Changes | System         |
+| US-PA-012 | Reissue Policy Document                     | Customer       |
+| US-PA-013 | Manage Policy Status                        | Underwriter    |
+| US-PA-014 | Review High-Risk Amendments                 | Underwriter    |

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/policy-administration.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/policy-administration.md
@@ -1,0 +1,627 @@
+---
+sidebar_position: 2
+---
+
+# Policy Administration User Stories
+
+User stories for mid-term policy adjustments (MTAs) and post-bind policy lifecycle management. These cover all changes a customer or internal actor may make to an active motor insurance policy.
+
+## US-PA-001: Change Vehicle on Policy
+
+**As a** customer,
+**I want to** change the vehicle on my motor insurance policy when I sell my old car and buy a new one,
+**so that** I maintain continuous insurance coverage without a gap.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I submit a vehicle change request with the new vehicle's registreringsnummer
+  **THEN** the system looks up the new vehicle data from Transportstyrelsen and displays the vehicle details for confirmation
+
+- **GIVEN** the new vehicle data is confirmed
+  **WHEN** the system recalculates the premium based on the new vehicle's risk profile
+  **THEN** I see the old premium, the new premium, and the pro-rata adjustment amount with the effective date
+
+- **GIVEN** I accept the vehicle change and premium adjustment
+  **WHEN** the amendment is processed
+  **THEN** the system notifies Transportstyrelsen of the insurance status change for both the old and new vehicles
+
+- **GIVEN** the vehicle change is completed
+  **WHEN** I view my policy
+  **THEN** the policy shows the new vehicle and an updated policy document is available for download
+
+### Business Rules
+
+- The new vehicle must be registered in the fordonsregistret (Transportstyrelsen vehicle registry)
+- Trafikförsäkring coverage must transfer immediately — no coverage gap is permitted (FSA-007)
+- If the new vehicle has a higher risk profile, additional underwriting review may be required
+- Bonus class (bonusklass) transfers with the policyholder, not the vehicle
+- The old vehicle's trafikförsäkring must be cancelled or transferred to another insurer; if not, TFF default coverage applies
+
+### Data Requirements
+
+- New vehicle: registreringsnummer, make, model, year, VIN, vehicle type, engine power, weight
+- Old vehicle: registreringsnummer (for Transportstyrelsen de-registration notification)
+- Premium adjustment: old premium, new premium, effective date, pro-rata calculation
+
+### Regulatory
+
+- **FSA-007** — Mandatory trafikförsäkring must be maintained without gaps
+- **FSA-009** — Transportstyrelsen must be notified of the vehicle change
+- **GDPR-002** — Vehicle and policy data updates must follow data minimization principles
+- **GDPR-004** — Transportstyrelsen notification must transmit only mandated data fields
+- **IDD-001** — If the vehicle change significantly alters risk, reassess demands and needs
+
+---
+
+## US-PA-002: Update Address
+
+**As a** customer,
+**I want to** update my registered address on my policy when I move,
+**so that** my policy reflects my current situation and my premium is correctly calculated.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I submit a new address
+  **THEN** the system validates the address format and postcode
+
+- **GIVEN** the new address is in a different postcode area
+  **WHEN** the premium is recalculated based on the new postcode's risk zone
+  **THEN** I see the premium adjustment (increase or decrease) with the effective date
+
+- **GIVEN** the address change does not affect the premium
+  **WHEN** the change is processed
+  **THEN** the policy is updated immediately without a premium adjustment step
+
+- **GIVEN** identity verification is required for address changes
+  **WHEN** I confirm the change via BankID
+  **THEN** the system records the verified identity and processes the change
+
+### Business Rules
+
+- Address changes require BankID verification (identity-sensitive field)
+- Postcode affects premium through geographic risk zones — certain areas have higher theft or accident rates
+- The new address must be a valid Swedish postcode
+- Address changes take effect immediately; premium adjustments are pro-rata from the effective date
+- An audit trail must record the old address, new address, timestamp, and verification method
+
+### Data Requirements
+
+- New address: street, postcode, city
+- Risk zone mapping: postcode-to-risk-zone lookup table
+- Premium adjustment: old premium, new premium, effective date
+
+### Regulatory
+
+- **GDPR-002** — Address is personal data; updates must be logged with an audit trail
+- **GDPR-006** — Right to rectification — customers may correct inaccurate address data
+- **FSA-004** — Premium recalculation must be transparent and communicated clearly
+
+---
+
+## US-PA-003: Upgrade Coverage Tier
+
+**As a** customer,
+**I want to** upgrade my coverage from halvförsäkring to helförsäkring,
+**so that** I get collision damage protection (vagnskadeförsäkring) for my vehicle.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active policy with halvförsäkring
+  **WHEN** I request an upgrade to helförsäkring
+  **THEN** the system displays the additional coverage included and the new premium
+
+- **GIVEN** I review the coverage comparison
+  **WHEN** the system presents the upgrade
+  **THEN** it shows a clear side-by-side comparison of halvförsäkring vs. helförsäkring benefits, exclusions, and pricing
+
+- **GIVEN** I accept the upgrade
+  **WHEN** the amendment is processed
+  **THEN** the new coverage tier takes effect immediately and an updated policy document is generated
+
+- **GIVEN** the upgrade constitutes a significant change
+  **WHEN** the system processes the upgrade
+  **THEN** an updated IPID for helförsäkring is provided before confirmation
+
+### Business Rules
+
+- Coverage upgrades take effect immediately upon confirmation
+- Premium adjustment is pro-rata for the remaining policy period
+- An upgraded IPID must be provided before the customer confirms (IDD-002)
+- If the vehicle is older than a configurable threshold (e.g., 15 years), helförsäkring may not be offered due to low vehicle value
+- Vagnskadegaranti (collision damage warranty) status should be checked — if active, vagnskadeförsäkring component may be redundant
+
+### Data Requirements
+
+- Current coverage tier and premium
+- New coverage tier, additional coverages, and new premium
+- IPID document version for the new tier
+- Vehicle age and current market value (for eligibility check)
+
+### Regulatory
+
+- **IDD-001** — Reassess demands and needs for significant coverage changes
+- **IDD-002** — Provide updated IPID for the new coverage tier
+- **IDD-007** — If add-ons are offered with the upgrade, present them separately with individual pricing
+- **FSA-004** — Coverage comparison must be clear and transparent
+- **FSA-012** — Pre-contractual disclosure for the new coverage tier
+
+---
+
+## US-PA-004: Downgrade Coverage Tier
+
+**As a** customer,
+**I want to** downgrade my coverage from helförsäkring to halvförsäkring,
+**so that** I reduce my premium while maintaining essential protections.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active policy with helförsäkring
+  **WHEN** I request a downgrade to halvförsäkring
+  **THEN** the system clearly shows which coverages I will lose (vagnskadeförsäkring)
+
+- **GIVEN** I acknowledge the reduced coverage
+  **WHEN** I confirm the downgrade
+  **THEN** the coverage change takes effect from the next day and a premium refund is calculated for the remaining period
+
+- **GIVEN** my vehicle has an outstanding claim
+  **WHEN** I request a downgrade
+  **THEN** the system warns that the downgrade does not affect the pending claim but future incidents will not be covered under the removed coverage
+
+### Business Rules
+
+- Downgrade takes effect from the start of the next day (not immediately, to prevent same-day claim-then-downgrade scenarios)
+- Premium refund is calculated pro-rata for the remaining policy period
+- Downgrade below trafikförsäkring is never permitted (FSA-007)
+- If the customer has a financed vehicle, the finance company may require helförsäkring — the system should warn if applicable
+- The customer must explicitly acknowledge the lost coverages before confirmation
+
+### Data Requirements
+
+- Current and new coverage tiers
+- Coverages being removed with descriptions
+- Premium refund calculation
+- Outstanding claims status
+
+### Regulatory
+
+- **FSA-007** — Trafikförsäkring must always remain as the minimum coverage
+- **FSA-004** — Customer must receive clear information about what coverage is lost
+- **IDD-001** — Reassess demands and needs for significant coverage changes
+- **GDPR-002** — Policy amendment recorded in the policy administration record
+
+---
+
+## US-PA-005: Adjust Deductible Level
+
+**As a** customer,
+**I want to** change my deductible (självrisk) level,
+**so that** I can balance my premium cost against my out-of-pocket risk.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I request a deductible change
+  **THEN** the system displays available deductible levels with the corresponding premium for each
+
+- **GIVEN** I select a new deductible level
+  **WHEN** the premium is recalculated
+  **THEN** I see the premium difference (higher deductible = lower premium, lower deductible = higher premium)
+
+- **GIVEN** I confirm the new deductible
+  **WHEN** the amendment is processed
+  **THEN** the new deductible applies from the effective date and the premium is adjusted pro-rata
+
+### Business Rules
+
+- Available deductible levels are defined per coverage tier (e.g., 1 500 SEK, 3 000 SEK, 5 000 SEK, 7 000 SEK)
+- Different coverage types may have different deductible options (e.g., glass damage has a separate deductible)
+- The deductible change takes effect from the start of the next day
+- Premium adjustment is pro-rata for the remaining policy period
+
+### Data Requirements
+
+- Current deductible level and premium
+- Available deductible options with corresponding premiums
+- Premium adjustment calculation
+
+### Regulatory
+
+- **FSA-004** — Deductible options and their impact on premium must be presented transparently
+- **IDD-001** — Ensure the chosen deductible aligns with the customer's financial situation
+- **GDPR-002** — Amendment recorded in policy administration
+
+---
+
+## US-PA-006: Add Named Driver
+
+**As a** customer,
+**I want to** add a named driver to my motor insurance policy,
+**so that** another person can regularly drive my insured vehicle with full coverage.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I request to add a named driver and provide their personnummer
+  **THEN** the system validates the personnummer and retrieves the driver's age and driving license status
+
+- **GIVEN** the new driver is under 25 years old
+  **WHEN** the premium is recalculated
+  **THEN** the system applies a young driver surcharge and the premium increase is displayed for confirmation
+
+- **GIVEN** the new driver is flagged as high risk (e.g., under 25, recently licensed)
+  **WHEN** the amendment is submitted
+  **THEN** the system routes the request to an underwriter for manual review before processing
+
+- **GIVEN** the named driver is added successfully
+  **WHEN** I view my policy
+  **THEN** the named driver appears on the policy and an updated policy document is generated
+
+### Business Rules
+
+- Named driver's personnummer must be valid and the person must hold a valid Swedish driving license (or equivalent)
+- Drivers under 25 or with less than 2 years of driving experience trigger a young driver surcharge
+- High-risk driver additions (e.g., age under 20, prior claims history) require underwriter approval
+- Adding a named driver does not change the policyholder or the bonus class — bonus follows the policyholder
+- The personnummer of named drivers is sensitive personal data requiring careful handling
+
+### Data Requirements
+
+- Named driver: personnummer, name, date of birth, driving license date, license category
+- Risk assessment: age, driving experience, claims history (if available from previous insurer)
+- Premium adjustment calculation with surcharge breakdown
+
+### Regulatory
+
+- **GDPR-001** — Personal data collection for the named driver requires a lawful basis (contract performance)
+- **GDPR-002** — Named driver data stored as part of policy administration
+- **FSA-004** — Young driver surcharges must be transparently communicated
+- **IDD-001** — If adding a high-risk driver significantly changes the risk profile, reassess demands and needs
+
+---
+
+## US-PA-007: Remove Named Driver
+
+**As a** customer,
+**I want to** remove a named driver from my motor insurance policy,
+**so that** my premium reflects only the drivers who actually use the vehicle.
+
+### Acceptance Criteria
+
+- **GIVEN** I have a named driver on my policy
+  **WHEN** I request to remove them
+  **THEN** the system recalculates the premium without the removed driver's risk factors
+
+- **GIVEN** the removal results in a premium decrease
+  **WHEN** the amendment is processed
+  **THEN** the premium adjustment is applied pro-rata and the named driver is removed from the policy
+
+- **GIVEN** the named driver is removed
+  **WHEN** I view my policy
+  **THEN** the driver no longer appears and an updated policy document is available
+
+### Business Rules
+
+- Removing a named driver takes effect immediately
+- Premium reduction (if any) is applied pro-rata
+- The removed driver's personal data is retained for the policy administration retention period (GDPR-002)
+- At least one driver (the policyholder) must remain on the policy
+
+### Data Requirements
+
+- Named driver to remove: personnummer, name
+- Premium adjustment calculation
+
+### Regulatory
+
+- **GDPR-002** — Removed driver's data retained per retention schedule; not actively processed
+- **FSA-004** — Premium adjustment must be communicated transparently
+
+---
+
+## US-PA-008: Update Annual Mileage Estimate
+
+**As a** customer,
+**I want to** update my estimated annual mileage (körsträcka),
+**so that** my premium reflects my actual driving pattern.
+
+### Acceptance Criteria
+
+- **GIVEN** I have an active motor insurance policy
+  **WHEN** I update my annual mileage estimate
+  **THEN** the system recalculates the premium based on the new mileage band
+
+- **GIVEN** the new mileage is significantly higher than the original estimate
+  **WHEN** the premium increases
+  **THEN** the system displays the new premium and explains that higher mileage increases risk exposure
+
+- **GIVEN** I confirm the mileage change
+  **WHEN** the amendment is processed
+  **THEN** the premium adjustment is applied pro-rata from the effective date
+
+### Business Rules
+
+- Mileage is categorized into bands (e.g., 0–1 000 mil, 1 001–1 500 mil, 1 501–2 000 mil, 2 001+ mil)
+- Higher mileage increases premium; lower mileage decreases premium
+- Customers have a duty to report material changes in driving pattern
+- Misrepresentation of mileage may affect claims settlement (material fact)
+- Mileage changes take effect immediately
+
+### Data Requirements
+
+- Current mileage estimate and band
+- New mileage estimate and band
+- Premium adjustment calculation
+
+### Regulatory
+
+- **FSA-004** — Mileage impact on premium must be communicated clearly
+- **GDPR-002** — Mileage data recorded as part of policy administration
+
+---
+
+## US-PA-009: View Amendment History
+
+**As a** claims handler,
+**I want to** see the complete policy amendment history,
+**so that** I can verify what coverage was active at the time of a claim.
+
+### Acceptance Criteria
+
+- **GIVEN** I am investigating a claim on a motor policy
+  **WHEN** I view the policy amendment history
+  **THEN** I see a chronological list of all amendments with effective dates, amendment types, and details
+
+- **GIVEN** the amendment history is displayed
+  **WHEN** I select a specific amendment
+  **THEN** I see the full details including what changed, the old and new values, the effective date, and who authorized the change
+
+- **GIVEN** a claim date falls between two amendments
+  **WHEN** I check the coverage at the claim date
+  **THEN** the system shows the exact coverage tier, deductible, named drivers, and vehicle that were active on that date
+
+### Business Rules
+
+- Amendment history is an immutable audit trail — entries cannot be modified or deleted
+- Each amendment record includes: amendment type, effective date, old values, new values, timestamp of processing, user/channel that initiated the change
+- Point-in-time coverage reconstruction must be possible for any date in the policy's history
+- Amendment history is accessible to claims handlers, underwriters, and compliance officers
+
+### Data Requirements
+
+- Amendment record: type, effective date, processing timestamp, old values, new values, initiator (customer/agent/system), authorization method
+- Coverage snapshot at any point in time: tier, deductible, vehicle, named drivers, premium
+
+### Regulatory
+
+- **FSA-010** — Claims settlement requires verifying coverage at the time of loss
+- **FSA-014** — Amendment records must be retained for the full record-keeping period
+- **GDPR-002** — Amendment history contains personal data; subject to access rights and retention rules
+
+---
+
+## US-PA-010: Recalculate Premium After Amendment
+
+**As the** system,
+**I want to** recalculate premiums whenever a policy amendment changes risk factors,
+**so that** the customer pays the correct amount for their current coverage and risk profile.
+
+### Acceptance Criteria
+
+- **GIVEN** a policy amendment changes a risk factor (vehicle, address, coverage tier, deductible, named drivers, mileage)
+  **WHEN** the amendment is being processed
+  **THEN** the system calculates the new annual premium using the updated risk factors
+
+- **GIVEN** the premium has changed
+  **WHEN** the pro-rata adjustment is calculated
+  **THEN** the system computes the difference between the old and new premium for the remaining policy period
+
+- **GIVEN** the adjustment results in an additional premium
+  **WHEN** the customer confirms the amendment
+  **THEN** the additional amount is collected via the existing payment method
+
+- **GIVEN** the adjustment results in a premium refund
+  **WHEN** the amendment is processed
+  **THEN** the refund is credited to the customer's payment method or applied to the next premium installment
+
+### Business Rules
+
+- Premium recalculation uses the current rating factors and tariff at the time of amendment
+- Pro-rata calculation: `adjustment = (new_daily_premium - old_daily_premium) × remaining_days`
+- Minimum premium thresholds may apply — very small adjustments (below a configurable threshold) may be waived
+- Premium recalculation does not change the bonus class — bonus changes only at renewal
+- All premium calculations must be auditable with a clear breakdown of rating factors
+
+### Data Requirements
+
+- Rating factors: vehicle type, vehicle age, vehicle value, postcode risk zone, coverage tier, deductible level, named drivers (age, experience), mileage band, bonus class
+- Premium calculation: old annual premium, new annual premium, effective date, remaining days, pro-rata adjustment amount
+- Payment: adjustment amount, payment method, collection/refund date
+
+### Regulatory
+
+- **FSA-004** — Premium calculation must be transparent; the customer must understand why the premium changed
+- **FSA-006** — Premium data must be available for supervisory reporting
+- **GDPR-002** — Premium calculation data is part of the policy administration record
+
+---
+
+## US-PA-011: Notify Transportstyrelsen of Policy Changes
+
+**As the** system,
+**I want to** notify Transportstyrelsen when a vehicle change or policy status change occurs,
+**so that** the national vehicle registry reflects the current insurance status.
+
+### Acceptance Criteria
+
+- **GIVEN** a vehicle change amendment is processed
+  **WHEN** the old vehicle's coverage ends and the new vehicle's coverage begins
+  **THEN** the system sends a de-registration notification for the old vehicle and a registration notification for the new vehicle to Transportstyrelsen
+
+- **GIVEN** a policy is suspended or lapses
+  **WHEN** the status change takes effect
+  **THEN** the system notifies Transportstyrelsen that the vehicle no longer has active coverage
+
+- **GIVEN** a notification fails to deliver
+  **WHEN** the system detects the failure
+  **THEN** it retries according to the configured retry policy and alerts operations staff if retries are exhausted
+
+- **GIVEN** notifications are sent
+  **WHEN** an acknowledgement is received from Transportstyrelsen
+  **THEN** the system logs the acknowledgement with timestamp and reference number
+
+### Business Rules
+
+- Notifications must be sent within the timeframe prescribed by Trafikskadelagen
+- Notification content must follow the Transportstyrelsen API specification — no additional data beyond the mandated schema
+- Failed notifications must be retried with exponential backoff
+- All notification attempts, responses, and failures must be logged for audit
+- The system must handle Transportstyrelsen downtime gracefully with queuing and retry
+
+### Data Requirements
+
+- Notification payload: registreringsnummer, policy number, policyholder personnummer, coverage start/end date, notification type (new, change, cancellation)
+- Response tracking: acknowledgement ID, timestamp, status (success, failure, pending)
+
+### Regulatory
+
+- **FSA-009** — Transportstyrelsen notification is a legal obligation
+- **FSA-007** — Ensures the vehicle registry reflects current trafikförsäkring status
+- **GDPR-004** — Only mandated data fields are transmitted to Transportstyrelsen
+
+---
+
+## US-PA-012: Reissue Policy Document
+
+**As a** customer,
+**I want to** receive an updated policy document after any amendment to my policy,
+**so that** I have a current record of my coverage, terms, and conditions.
+
+### Acceptance Criteria
+
+- **GIVEN** a policy amendment has been processed
+  **WHEN** the amendment takes effect
+  **THEN** the system generates an updated policy document reflecting all current policy details
+
+- **GIVEN** the updated document is generated
+  **WHEN** it is available
+  **THEN** I receive a notification (email or in-app) with a link to download the document
+
+- **GIVEN** I access the document
+  **WHEN** I review it
+  **THEN** it clearly shows the current coverage tier, vehicle, named drivers, deductible, premium, and effective dates
+
+### Business Rules
+
+- A new policy document is generated for every material amendment (vehicle change, coverage change, named driver change)
+- Minor amendments (mileage update, address change with no premium impact) may generate a confirmation letter rather than a full reissue
+- Documents must use clear, plain language (FSA-004)
+- Previous versions of the policy document remain accessible in the document history
+- Documents must be generated in Swedish
+
+### Data Requirements
+
+- Policy summary: policy number, policyholder details, vehicle details, coverage tier, deductible, named drivers, premium, payment schedule
+- Document metadata: version number, generation date, amendment reference
+
+### Regulatory
+
+- **FSA-004** — Policy documents must be clear, transparent, and in plain language
+- **FSA-012** — Contractual information must be provided after binding and after amendments
+- **FSA-014** — Policy documents must be retained for the record-keeping period
+- **GDPR-002** — Documents contain personal data subject to retention rules
+
+---
+
+## US-PA-013: Manage Policy Status
+
+**As an** underwriter,
+**I want to** manage policy status transitions (active, suspended, lapsed),
+**so that** the policy reflects the correct operational state and coverage availability.
+
+### Acceptance Criteria
+
+- **GIVEN** a policyholder has failed to pay the premium within the grace period
+  **WHEN** the payment deadline passes
+  **THEN** the policy status changes to "suspended" and the customer is notified
+
+- **GIVEN** a policy is suspended
+  **WHEN** the policyholder pays the outstanding premium within the reinstatement period
+  **THEN** the policy is reinstated to "active" with continuous coverage (no gap)
+
+- **GIVEN** a suspended policy reaches the end of the reinstatement period without payment
+  **WHEN** the reinstatement period expires
+  **THEN** the policy status changes to "lapsed" and Transportstyrelsen is notified
+
+- **GIVEN** a policy transitions to any new status
+  **WHEN** the transition is processed
+  **THEN** the system records the status change with timestamp, reason, and authorization in the amendment history
+
+### Business Rules
+
+- Policy statuses: **Active** (coverage in force), **Suspended** (coverage temporarily inactive due to non-payment), **Lapsed** (coverage terminated due to prolonged non-payment)
+- Suspension grace period and reinstatement period are configurable per product
+- A suspended trafikförsäkring policy triggers Transportstyrelsen notification — the vehicle owner risks trafikförsäkringsavgift (penalty fee)
+- Reinstatement may require underwriter review if the suspension exceeded a configurable threshold
+- Status changes are irreversible through the standard flow — reversals require underwriter override with documented justification
+
+### Data Requirements
+
+- Policy status: current status, effective date of status change, reason
+- Payment status: outstanding balance, last payment date, grace period end date, reinstatement deadline
+- Notification records: customer notification sent, Transportstyrelsen notification sent
+
+### Regulatory
+
+- **FSA-007** — Lapsed trafikförsäkring means the vehicle is uninsured; Transportstyrelsen must be notified
+- **FSA-009** — Status changes that affect coverage must be reported to Transportstyrelsen
+- **FSA-004** — Customers must be clearly informed about suspension consequences
+- **FSA-013** — Cancellation and suspension rules must comply with Försäkringsavtalslagen
+- **GDPR-002** — Status change history is part of the policy administration record
+
+---
+
+## US-PA-014: Review High-Risk Amendments
+
+**As an** underwriter,
+**I want to** review amendments that significantly change the risk profile of a policy,
+**so that** I can approve, adjust terms, or decline the change.
+
+### Acceptance Criteria
+
+- **GIVEN** an amendment triggers a high-risk flag (e.g., adding a driver under 20, changing to a high-performance vehicle)
+  **WHEN** the amendment is submitted
+  **THEN** the system routes the amendment to the underwriter queue for manual review
+
+- **GIVEN** the amendment is in the underwriter queue
+  **WHEN** I review the amendment details
+  **THEN** I see the current policy, the proposed change, the risk assessment, and the premium impact
+
+- **GIVEN** I approve the amendment
+  **WHEN** I authorize it
+  **THEN** the amendment is processed and the customer is notified of the updated terms and premium
+
+- **GIVEN** I decline the amendment or adjust the terms
+  **WHEN** I record my decision with a rationale
+  **THEN** the customer is notified of the decision and the reasons for any modifications
+
+### Business Rules
+
+- High-risk triggers are configurable: driver age thresholds, vehicle type categories, vehicle value thresholds, claims history thresholds
+- Underwriter decisions must be recorded with rationale for audit purposes
+- SLA for underwriter review: decision within 2 business days of submission
+- If the underwriter adjusts terms (e.g., higher deductible, exclusion), the customer must accept the adjusted terms before the amendment proceeds
+
+### Data Requirements
+
+- Amendment details: type, proposed changes, risk factors affected
+- Risk assessment: risk score change, flagged triggers, historical claims data
+- Underwriter decision: approve/decline/adjust, rationale, adjusted terms (if any), decision date
+
+### Regulatory
+
+- **FSA-004** — Fair treatment — decisions must be justified and communicated to the customer
+- **FSA-005** — Product governance — high-risk amendments must be monitored
+- **IDD-001** — Significant changes may require a fresh demands-and-needs assessment
+- **FSA-014** — Underwriting decisions and rationales must be retained


### PR DESCRIPTION
## Summary
- Adds 14 user stories (US-PA-001 through US-PA-014) covering all motor policy administration scenarios: vehicle changes, address updates, coverage tier changes, deductible adjustments, named driver management, mileage updates, amendment history, premium recalculation, Transportstyrelsen notifications, policy document reissue, policy status management, and underwriter review of high-risk amendments
- Adds 6 detailed use cases (UC-PA-001 through UC-PA-006) with main flows, exception flows, preconditions, postconditions, and business rules
- Full regulatory traceability to FSA (FSA-004, FSA-007, FSA-009, FSA-010, FSA-012, FSA-013, FSA-014), GDPR (GDPR-001, GDPR-002, GDPR-004, GDPR-006), and IDD (IDD-001, IDD-002, IDD-007) requirements

## Changes
- `docs/phase-1-motor/user-stories/policy-administration.md` — new file with 14 user stories
- `docs/phase-1-motor/use-cases/policy-administration.md` — new file with 6 use cases
- `docs/phase-1-motor/user-stories/index.md` — updated with summary table
- `docs/phase-1-motor/use-cases/index.md` — updated with summary table
- Mirrored all changes to `versioned_docs/version-phase-1/` snapshot

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier passes
- [x] Docusaurus build succeeds (links and frontmatter validated)

Closes #11

🤖 Generated with Claude Code