### PR TITLE
docs(#12): Document motor claims handling user stories and use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/index.md
+++ b/docs/phase-1-motor/use-cases/index.md
@@ -18,3 +18,15 @@ Mid-term adjustment and policy lifecycle use cases — see [Policy Administratio
 | UC-PA-004 | Manage Policy Status Transitions          | System        |
 | UC-PA-005 | Recalculate Premium After Amendment       | System        |
 | UC-PA-006 | Underwriter Review of High-Risk Amendment | Underwriter   |
+
+## Claims Handling
+
+Use cases describing the detailed workflows for motor insurance claims
+processing.
+
+| ID                                         | Title                              | Scope                                         |
+| ------------------------------------------ | ---------------------------------- | --------------------------------------------- |
+| [UC-CLM-001](uc-claims-lifecycle.md)       | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
+| [UC-CLM-002](uc-fnol-processing.md)        | FNOL Processing                    | First notification of loss — online and phone |
+| [UC-CLM-003](uc-settlement-calculation.md) | Settlement Calculation and Payment | Settlement rules and payment execution        |
+| [UC-CLM-004](uc-fraud-screening.md)        | Fraud Screening and Investigation  | Automated and manual fraud detection          |

--- a/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
@@ -1,0 +1,195 @@
+---
+sidebar_position: 10
+---
+
+# UC-CLM-001: Claims Lifecycle
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a motor insurance claim, from first notification of loss (FNOL) through investigation, decision, settlement, and closure. It serves as the orchestrating use case that ties together the individual claims processing steps.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund), [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad), [Police (Polis)](../../actors/external-actors.md#police-polis), [Medical Provider (Vårdgivare)](../../actors/external-actors.md#medical-provider-vårdgivare), [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff), [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider)
+
+## Preconditions
+
+1. The customer holds an active motor insurance policy with TryggFörsäkring
+2. An insured event has occurred (accident, theft, damage, etc.)
+
+## Postconditions
+
+**Success:**
+
+- Claim is settled and closed with full documentation
+- Customer has received the settlement amount (or repair has been completed)
+- Bonus class has been updated (if applicable)
+- Subrogation has been initiated (if applicable)
+- All records are retained per regulatory requirements
+
+**Failure:**
+
+- Claim is denied with documented reason and customer notification
+- Customer has been informed of complaints procedure and dispute resolution options
+
+## Main Flow
+
+```mermaid
+flowchart TD
+    A[1. FNOL - Customer reports claim] --> B[2. Claim Registration]
+    B --> C[3. Coverage Verification]
+    C --> D{Coverage confirmed?}
+    D -->|No| E[Deny claim - notify customer]
+    D -->|Yes| F[4. Fraud Screening]
+    F --> G{Fraud flag?}
+    G -->|High risk| H[Fraud Investigation]
+    H --> I{Fraud confirmed?}
+    I -->|Yes| E
+    I -->|No| J[5. Liability Determination]
+    G -->|Low/Medium| J
+    J --> K[6. Damage Assessment]
+    K --> L[7. Claims Decision]
+    L --> M{Decision?}
+    M -->|Deny| E
+    M -->|Approve| N[8. Settlement Calculation]
+    N --> O[9. Payment / Repair Authorization]
+    O --> P[10. Bonus Class Update]
+    P --> Q{Subrogation eligible?}
+    Q -->|Yes| R[11. Subrogation]
+    Q -->|No| S[12. Claim Closure]
+    R --> S
+    E --> T[Record denial and close]
+```
+
+### Step-by-Step
+
+| Step | Action                                                        | Actor           | System Response                                             | Reference                                                                                                        |
+| ---- | ------------------------------------------------------------- | --------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1    | Customer reports the incident via web, app, or phone          | Customer        | Creates FNOL record, assigns claim number                   | [US-CLM-001](../user-stories/claims-fnol.md)                                                                     |
+| 2    | Claims handler reviews and registers the claim                | Claims Handler  | Links claim to policy, sets status to "Registered"          | [US-CLM-002](../user-stories/claims-registration.md)                                                             |
+| 3    | System verifies coverage was active and claim type is covered | Claims Handler  | Displays coverage confirmation or flags issues              | [US-CLM-003](../user-stories/claims-coverage-verification.md)                                                    |
+| 4    | System runs automated fraud screening                         | System          | Assigns fraud risk score; flags suspicious claims           | [US-CLM-006](../user-stories/claims-fraud-screening.md)                                                          |
+| 5    | Claims handler determines liability based on evidence         | Claims Handler  | Records liability split and supporting evidence             | [US-CLM-004](../user-stories/claims-liability.md)                                                                |
+| 6    | Claims adjuster assesses vehicle damage                       | Claims Adjuster | Records repair estimate or total loss valuation             | [US-CLM-005](../user-stories/claims-damage-assessment.md)                                                        |
+| 7    | Claims handler makes approve/deny decision                    | Claims Handler  | Records decision and rationale                              | [US-CLM-007](../user-stories/claims-decision.md)                                                                 |
+| 8    | System calculates settlement amount                           | Claims Handler  | Calculates repair cost or total loss value minus deductible | [US-CLM-008](../user-stories/claims-settlement.md)                                                               |
+| 9    | Payment is issued or repair is authorized                     | Claims Handler  | Processes payment or sends repair authorization             | [US-CLM-008](../user-stories/claims-settlement.md), [US-CLM-014](../user-stories/claims-repair-authorization.md) |
+| 10   | System updates bonus class                                    | System          | Recalculates bonus class based on claim type                | [US-CLM-010](../user-stories/claims-bonus-impact.md)                                                             |
+| 11   | Subrogation initiated if third party at fault                 | Claims Handler  | Records recovery target and tracks recovery                 | [US-CLM-009](../user-stories/claims-subrogation.md)                                                              |
+| 12   | Claims handler performs final review and closes claim         | Claims Handler  | Sets status to "Closed", updates statistics                 | [US-CLM-015](../user-stories/claims-closure.md)                                                                  |
+
+## Alternative Flows
+
+### A1: Phone-Reported Claim
+
+At step 1, if the customer reports the claim by phone:
+
+1. The claims handler captures incident details during the call
+2. The handler creates the claim record on behalf of the customer
+3. The process continues from step 2
+
+### A2: Third-Party Claimant
+
+At step 1, if the claimant is a third party (not the policyholder):
+
+1. The third party reports damage or injury caused by a TryggFörsäkring policyholder
+2. The system creates a third-party claim linked to the policyholder's trafikförsäkring
+3. Coverage verification confirms the policy was active (trafikförsäkring covers third parties)
+4. The process continues from step 5 (liability determination)
+
+### A3: TFF Claim
+
+At step 3, if coverage verification reveals the at-fault vehicle is uninsured:
+
+1. The claim is flagged as a TFF claim
+2. The process follows the TFF claims handling flow (see [US-CLM-011](../user-stories/claims-tff.md))
+
+### A4: Personal Injury Claim
+
+At step 1, if the claim involves personal injury:
+
+1. An additional personal injury sub-claim is created
+2. Medical documentation is requested from healthcare providers
+3. Injury compensation is calculated per Trafikskadelagen schedules
+4. The claim may remain open for an extended period (see [US-CLM-012](../user-stories/claims-personal-injury.md))
+
+### A5: Glass-Only Claim (Fast Track)
+
+At step 1, if the claim is for glass damage only:
+
+1. The customer is directed to an authorized glass repair shop
+2. Coverage verification is performed (halvförsäkring or helförsäkring required)
+3. The repair shop performs the replacement and bills TryggFörsäkring directly
+4. The customer pays only the glass deductible
+5. No bonus class impact — claim is closed after payment
+
+## Exception Flows
+
+### E1: Coverage Denied
+
+At step 3, if coverage verification fails:
+
+1. The claims handler records the denial reason
+2. The system generates a denial notification to the customer
+3. The notification includes the complaints procedure and external dispute resolution (ARN)
+4. The claim is closed with status "Denied"
+
+### E2: Claim Disputed by Customer
+
+After step 7, if the customer disputes the decision:
+
+1. The customer files a complaint through the complaints procedure (FSA-011)
+2. The complaint is registered and linked to the claim
+3. The complaint is investigated per the complaints handling process
+4. If the complaint is upheld, the claim decision may be revised
+
+## Business Rules
+
+| Rule       | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| BR-CLM-001 | A claim must be linked to exactly one active policy                      |
+| BR-CLM-002 | Coverage verification must be completed before any settlement decision   |
+| BR-CLM-003 | Claims exceeding the handler's authority limit must be escalated         |
+| BR-CLM-004 | Denial notifications must include complaints procedure information       |
+| BR-CLM-005 | Bonus class changes take effect at the next renewal date                 |
+| BR-CLM-006 | Trafikförsäkring personal injury claims have a 10-year limitation period |
+| BR-CLM-007 | The customer must be made whole before subrogation is pursued            |
+| BR-CLM-008 | Fraud investigation must not unreasonably delay legitimate claims        |
+
+## Key Performance Indicators
+
+| KPI                      | Description                                   | Target                               |
+| ------------------------ | --------------------------------------------- | ------------------------------------ |
+| FNOL to registration     | Time from customer report to claim registered | < 1 business day                     |
+| Registration to decision | Time from registration to approve/deny        | < 10 business days (standard claims) |
+| Decision to payment      | Time from approval to payment issued          | < 5 business days                    |
+| Total cycle time         | FNOL to claim closure                         | < 30 business days (standard claims) |
+| Customer satisfaction    | Post-claim survey score                       | ≥ 4.0 / 5.0                          |
+| Fraud detection rate     | Percentage of fraudulent claims detected      | Monitored (no fixed target)          |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the entire lifecycle must be efficient and transparent
+- **FSA-011** — Complaints handling: denial and dispute paths must be available
+- **FSA-014** — Record keeping: complete claim lifecycle records must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data must be handled according to GDPR throughout the lifecycle
+- **IDD-005** — Claims handling disclosure: claim reporting procedures must be communicated to customers at policy purchase (via IPID)
+
+## Related User Stories
+
+- [US-CLM-001](../user-stories/claims-fnol.md) — Report a Claim Online (FNOL)
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims
+- [US-CLM-003](../user-stories/claims-coverage-verification.md) — Verify Coverage and Check Exclusions
+- [US-CLM-004](../user-stories/claims-liability.md) — Determine Liability
+- [US-CLM-005](../user-stories/claims-damage-assessment.md) — Assess Vehicle Damage
+- [US-CLM-006](../user-stories/claims-fraud-screening.md) — Screen Claims for Fraud
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-008](../user-stories/claims-settlement.md) — Calculate and Process Settlement
+- [US-CLM-009](../user-stories/claims-subrogation.md) — Recover Costs Through Subrogation
+- [US-CLM-010](../user-stories/claims-bonus-impact.md) — Update Bonus Class After Claim
+- [US-CLM-011](../user-stories/claims-tff.md) — Process TFF Claims
+- [US-CLM-012](../user-stories/claims-personal-injury.md) — Handle Personal Injury Claims
+- [US-CLM-013](../user-stories/claims-tracking.md) — Track Claim Status
+- [US-CLM-014](../user-stories/claims-repair-authorization.md) — Authorize Repairs at Network Shops
+- [US-CLM-015](../user-stories/claims-closure.md) — Close and Review Claims

--- a/docs/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 11
+---
+
+# UC-CLM-002: FNOL Processing
+
+## Overview
+
+This use case details the First Notification of Loss (FNOL) process — from the customer initiating a claim report through to the claim being registered and assigned to a claims handler. FNOL is the entry point for all claims and must be fast, intuitive, and capture sufficient information for the claims team to begin investigation.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare), [BankID](../../actors/external-actors.md#bankid)
+
+## Preconditions
+
+1. The customer is registered and has at least one active motor insurance policy
+2. An insured event has occurred
+3. The customer has access to the web portal or mobile app (or calls the claims phone line)
+
+## Postconditions
+
+**Success:**
+
+- A claim record exists with a unique claim number (skadenummer)
+- The claim is linked to the correct policy
+- Incident details, photos, and supporting documents are stored
+- A claims handler has been assigned
+- The customer has received confirmation with the claim number
+
+**Failure:**
+
+- The customer is unable to complete the FNOL (e.g., no active policy found, system error)
+- The customer is informed of the issue and directed to contact customer service
+
+## Main Flow (Online Self-Service)
+
+| Step | Actor    | Action                                                          | System Response                                                                                   |
+| ---- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 1    | Customer | Opens the claims reporting page and authenticates via BankID    | System verifies identity and retrieves active policies                                            |
+| 2    | Customer | Selects the policy and vehicle for the claim                    | System displays policy details and eligible claim types based on coverage tier                    |
+| 3    | Customer | Selects the claim type (e.g., collision, theft, glass)          | System adapts the FNOL form to the selected claim type                                            |
+| 4    | Customer | Enters incident details: date, time, location, description      | System validates the incident date against the policy's coverage period                           |
+| 5    | Customer | Enters information about other parties involved (if applicable) | System records other party details: name, vehicle registration, insurer                           |
+| 6    | Customer | Uploads photos of the damage and any supporting documents       | System stores photos linked to the claim record                                                   |
+| 7    | Customer | Reviews the complete FNOL summary                               | System displays a summary for the customer to confirm                                             |
+| 8    | Customer | Submits the claim report                                        | System creates the claim record, generates a claim number, and sends confirmation to the customer |
+| 9    | System   | Assigns the claim to a claims handler based on rules            | Claims handler is notified of the new claim assignment                                            |
+
+## Alternative Flow: Phone-Reported FNOL
+
+| Step | Actor          | Action                                                                 | System Response                                              |
+| ---- | -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | Customer       | Calls the claims phone line                                            | Claims handler answers and verifies identity                 |
+| 2    | Claims Handler | Searches for the customer's policy using personnummer or policy number | System displays matching policies                            |
+| 3    | Claims Handler | Selects the correct policy and creates a new claim                     | System opens the FNOL registration form                      |
+| 4    | Claims Handler | Enters incident details as reported by the customer                    | System validates and records the information                 |
+| 5    | Claims Handler | Records any additional details (police report number, witnesses)       | System stores all details in the claim record                |
+| 6    | Claims Handler | Submits the claim registration                                         | System creates the claim record and generates a claim number |
+| 7    | Claims Handler | Provides the claim number to the customer                              | Customer can use the number for online tracking              |
+
+## Alternative Flow: Third-Party FNOL
+
+| Step | Actor          | Action                                                                  | System Response                                                    |
+| ---- | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1    | Third Party    | Contacts TryggFörsäkring to report damage caused by an insured vehicle  | Claims handler verifies the policy exists for the reported vehicle |
+| 2    | Claims Handler | Creates a third-party claim against the policyholder's trafikförsäkring | System creates a third-party claim record                          |
+| 3    | Claims Handler | Records the third party's details and the incident information          | System stores the claim with the third party as claimant           |
+| 4    | Claims Handler | Notifies the policyholder of the third-party claim                      | System sends notification to the policyholder                      |
+
+## Validation Rules
+
+| Rule        | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| VR-FNOL-001 | Incident date must not be in the future                            |
+| VR-FNOL-002 | Incident date must fall within the policy's active coverage period |
+| VR-FNOL-003 | Claim type must be covered by the policy's coverage tier           |
+| VR-FNOL-004 | At least one photo is recommended but not required at FNOL stage   |
+| VR-FNOL-005 | Police report number is required for theft and hit-and-run claims  |
+| VR-FNOL-006 | Other party information is required for multi-vehicle collisions   |
+
+## Data Model
+
+### Claim Record (Created at FNOL)
+
+| Field                      | Type      | Required       | Description                            |
+| -------------------------- | --------- | -------------- | -------------------------------------- |
+| Claim number (skadenummer) | String    | Auto-generated | Unique identifier for the claim        |
+| Policy number              | String    | Yes            | Link to the insured policy             |
+| Claim type                 | Enum      | Yes            | Type of claim (collision, theft, etc.) |
+| Status                     | Enum      | Auto-set       | Initial status: "Registered"           |
+| Incident date              | Date      | Yes            | When the event occurred                |
+| Incident time              | Time      | No             | Time of the event (if known)           |
+| Incident location          | String    | Yes            | Where the event occurred               |
+| Incident description       | Text      | Yes            | Free-text description                  |
+| Police report number       | String    | Conditional    | Required for theft, hit-and-run        |
+| Reporter                   | Reference | Yes            | Customer or third party who reported   |
+| Photos                     | File[]    | No             | Uploaded damage photos                 |
+| Other parties              | Object[]  | Conditional    | Other vehicles/persons involved        |
+| Created date               | Timestamp | Auto-set       | When the FNOL was submitted            |
+| Assigned handler           | Reference | Auto-set       | Claims handler assigned to the claim   |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: FNOL must be processed promptly; the customer must receive acknowledgement without undue delay
+- **FSA-014** — Record keeping: the complete FNOL record must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization; collect only what is necessary
+- **GDPR-001** — Identity verification via BankID for online FNOL
+- **IDD-005** — The IPID must have informed the customer about the claims reporting process before policy purchase
+
+## Related User Stories
+
+- [US-CLM-001](../user-stories/claims-fnol.md) — Report a Claim Online (FNOL)
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims
+- [US-CLM-013](../user-stories/claims-tracking.md) — Track Claim Status

--- a/docs/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/docs/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 13
+---
+
+# UC-CLM-004: Fraud Screening and Investigation
+
+## Overview
+
+This use case describes the fraud screening and investigation process for motor insurance claims. It covers automated fraud indicator detection at claim registration, manual investigation workflows, and the outcomes of fraud investigations including criminal referral.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Preconditions
+
+1. A claim has been registered in the system
+2. Automated fraud screening rules are configured
+3. Integration with the industry fraud database (GSR) is active (if available)
+
+## Postconditions
+
+**Cleared:**
+
+- Claim is cleared of fraud suspicion and proceeds through normal claims processing
+- The fraud screening result is recorded in the claim file
+
+**Fraud confirmed:**
+
+- Claim is denied with documented fraud determination
+- Criminal referral to police is initiated (if warranted)
+- Fraud indicators are recorded for future pattern detection
+- Customer is notified of the denial (without disclosing investigation details)
+
+## Main Flow: Automated Screening
+
+| Step | Actor  | Action                     | System Response                                                          |
+| ---- | ------ | -------------------------- | ------------------------------------------------------------------------ |
+| 1    | System | Claim is registered        | System automatically runs fraud screening rules against the claim        |
+| 2    | System | Evaluates fraud indicators | System calculates a fraud risk score: low, medium, or high               |
+| 3a   | System | Score is low               | Claim proceeds to normal processing; screening result is logged          |
+| 3b   | System | Score is medium            | Claim is flagged for handler review; specific indicators are highlighted |
+| 3c   | System | Score is high              | Claim is flagged for investigation; settlement processing is paused      |
+
+## Alternative Flow: Manual Investigation
+
+| Step | Actor          | Action                                                                           | System Response                                                  |
+| ---- | -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1    | Claims Handler | Reviews flagged fraud indicators on a medium/high-risk claim                     | System displays the specific indicators that triggered the flag  |
+| 2    | Claims Handler | Decides to investigate further                                                   | System records the investigation start and pauses settlement     |
+| 3    | Claims Handler | Gathers additional evidence (interviews, document verification, site inspection) | System stores investigation notes and evidence in the claim file |
+| 4    | Claims Handler | Checks the industry fraud database (GSR) for matching patterns                   | System queries GSR and displays any matches                      |
+| 5    | Claims Handler | Reviews damage assessment for consistency with reported incident                 | Claims adjuster may be asked to re-inspect                       |
+| 6    | Claims Handler | Records investigation findings                                                   | System stores the complete investigation record                  |
+| 7a   | Claims Handler | Clears the claim (no fraud found)                                                | System removes the fraud flag and resumes normal processing      |
+| 7b   | Claims Handler | Confirms fraud                                                                   | System denies the claim and records the fraud determination      |
+
+## Alternative Flow: Criminal Referral
+
+| Step | Actor          | Action                                               | System Response                                              |
+| ---- | -------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | Claims Handler | Fraud investigation confirms insurance fraud         | System records the confirmed fraud determination             |
+| 2    | Claims Handler | Decides to refer the case to police                  | System generates a criminal referral summary                 |
+| 3    | Claims Handler | Submits the referral to the Swedish Police Authority | System records the referral date and police reference number |
+| 4    | Claims Handler | Monitors the police investigation outcome            | System tracks the referral status                            |
+
+## Fraud Indicators and Scoring
+
+| Indicator                              | Weight | Description                                                                    |
+| -------------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| Recent policy inception                | Medium | Policy was purchased within 30 days of the claim                               |
+| Coverage upgrade before claim          | High   | Coverage tier was increased within 60 days of the claim                        |
+| Multiple recent claims                 | Medium | 2+ claims filed by the same policyholder within 12 months                      |
+| Inconsistent details                   | High   | FNOL details conflict with police report or physical evidence                  |
+| Disproportionate claim amount          | Medium | Claim amount significantly exceeds expected cost for the incident type         |
+| GSR match                              | High   | Policyholder, vehicle, or linked parties appear in the industry fraud database |
+| Total loss on recently insured vehicle | High   | Vehicle declared total loss shortly after being insured                        |
+| Late reporting                         | Low    | More than 30 days between incident date and FNOL                               |
+| Unusual incident location              | Low    | Incident occurred in an unusual or hard-to-verify location                     |
+
+### Scoring Logic
+
+- **Low risk:** No high-weight indicators; at most one medium-weight indicator
+- **Medium risk:** One or more medium-weight indicators; no high-weight indicators
+- **High risk:** One or more high-weight indicators; or three or more medium-weight indicators
+
+## Business Rules
+
+| Rule       | Description                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| BR-FRD-001 | Fraud screening runs automatically on every new claim                                        |
+| BR-FRD-002 | High-risk claims must be reviewed by a claims handler before settlement                      |
+| BR-FRD-003 | Investigation details must never be disclosed to the claimant during an active investigation |
+| BR-FRD-004 | Fraud investigation must not unreasonably delay settlement of legitimate claims              |
+| BR-FRD-005 | Criminal referral requires senior claims handler or manager approval                         |
+| BR-FRD-006 | Cleared fraud flags must retain the investigation log for audit purposes                     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: fraud investigation must not unreasonably delay settlement of legitimate claims; the insurer must balance fraud prevention with fair treatment
+- **FSA-014** — Record keeping: fraud investigation records must be retained for 10 years from investigation closure
+- **GDPR-006** — Fraud detection and prevention: automated screening must use pseudonymized data where possible; access to full claim details is restricted to flagged cases; the claimant has the right to object to automated profiling
+- **GDPR-003** — Claims processing: fraud investigation data is sensitive and must be protected with strict access controls; purpose limitation applies
+- **GDPR-001** — Data sharing with GSR and police must have a lawful basis; data minimization applies to all external data sharing
+
+## Related User Stories
+
+- [US-CLM-006](../user-stories/claims-fraud-screening.md) — Screen Claims for Fraud
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims

--- a/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 12
+---
+
+# UC-CLM-003: Settlement Calculation and Payment
+
+## Overview
+
+This use case describes the settlement calculation and payment process for approved motor insurance claims. It covers the rules for calculating settlement amounts across different claim types (repair, total loss, glass, theft, personal injury) and the payment execution flow.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad)
+
+## Preconditions
+
+1. The claim has been approved (status: "Approved" / Godkänd)
+2. Damage assessment is complete (for vehicle damage claims)
+3. Liability determination is complete (for multi-party claims)
+
+## Postconditions
+
+**Success:**
+
+- Settlement amount has been calculated and documented
+- Payment has been issued and confirmed
+- Claim status is updated to "Settled" (Reglerad)
+- Payment records are stored for audit and regulatory compliance
+
+**Failure:**
+
+- Payment fails (e.g., invalid bank details, payment provider error)
+- Claims handler is notified and payment is retried or alternative payment method is used
+
+## Main Flow: Vehicle Repair Settlement
+
+| Step | Actor          | Action                                              | System Response                                                                      |
+| ---- | -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 1    | Claims Handler | Opens the approved claim for settlement             | System displays the damage assessment with approved repair estimate                  |
+| 2    | System         | Calculates settlement: repair cost minus deductible | System displays the calculated settlement amount with breakdown                      |
+| 3    | Claims Handler | Verifies the calculation and selects payment method | System presents options: direct payment to customer or direct billing to repair shop |
+| 4a   | Claims Handler | Selects direct billing to repair shop               | System sends repair authorization to the shop; customer pays deductible to shop      |
+| 4b   | Claims Handler | Selects payment to customer                         | System initiates bank transfer to customer's registered account                      |
+| 5    | System         | Processes the payment via payment provider          | System records payment status and updates claim status                               |
+| 6    | System         | Confirms payment completion                         | Claim status changes to "Settled" (Reglerad)                                         |
+
+## Alternative Flow: Total Loss Settlement
+
+| Step | Actor           | Action                                                                        | System Response                                                       |
+| ---- | --------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1    | Claims Adjuster | Declares the vehicle a total loss (repair cost > threshold % of market value) | System flags the claim for total loss processing                      |
+| 2    | System          | Calculates vehicle market value using industry valuation data                 | System displays the market value with valuation methodology           |
+| 3    | Claims Handler  | Reviews the total loss valuation                                              | Handler may adjust within guidelines or request independent valuation |
+| 4    | System          | Calculates settlement: market value − deductible − salvage value              | System displays the total loss settlement breakdown                   |
+| 5    | Claims Handler  | Confirms the settlement and initiates payment                                 | System processes payment to the customer                              |
+| 6    | System          | Records the settlement and updates claim status                               | Claim status changes to "Settled"                                     |
+
+## Alternative Flow: Liability-Split Settlement
+
+| Step | Actor          | Action                                                  | System Response                                                                               |
+| ---- | -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 1    | Claims Handler | Opens a claim with shared liability (e.g., 70/30 split) | System displays the liability determination and damage assessment                             |
+| 2    | System         | Calculates the policyholder's share of the damage       | Settlement = (total damage × policyholder's non-fault percentage) − deductible                |
+| 3    | Claims Handler | Reviews and confirms the adjusted settlement            | System processes payment for the adjusted amount                                              |
+| 4    | Claims Handler | Initiates subrogation for the at-fault party's share    | System creates a subrogation record (see [US-CLM-009](../user-stories/claims-subrogation.md)) |
+
+## Alternative Flow: Trafikförsäkring Personal Injury Settlement
+
+| Step | Actor          | Action                                                   | System Response                                                                        |
+| ---- | -------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1    | Claims Handler | Opens a personal injury claim with medical documentation | System displays injury details and compensation components                             |
+| 2    | Claims Handler | Enters compensation amounts per component                | System calculates total: medical costs + income loss + pain and suffering + disability |
+| 3    | Claims Handler | Reviews the total compensation                           | No deductible applies to trafikförsäkring personal injury claims                       |
+| 4    | System         | Processes interim or final payment to the injured party  | System records the payment and tracks remaining compensation if applicable             |
+
+## Settlement Calculation Rules
+
+### Repair Settlement
+
+```text
+Settlement = Approved Repair Cost − Applicable Deductible (självrisk)
+```
+
+- Repair cost is based on the approved damage assessment estimate
+- Deductible is determined by the policy terms and claim type
+- If the policyholder is partially at fault in a multi-party incident, the settlement is adjusted by the non-fault percentage
+
+### Total Loss Settlement
+
+```text
+Settlement = Vehicle Market Value − Deductible − Salvage Value
+```
+
+- Market value is the vehicle's fair market value at the time of loss
+- Salvage value is deducted if the customer retains the damaged vehicle
+- Total loss threshold: repair cost exceeds a configurable percentage (typically 75%) of market value
+
+### Glass Settlement
+
+```text
+Settlement = Glass Repair/Replacement Cost − Glass Deductible
+```
+
+- Glass claims typically have a lower deductible than other claim types
+- Repair (if possible) is preferred over full replacement
+
+### Theft Settlement
+
+```text
+If vehicle not recovered:
+  Settlement = Vehicle Market Value at Time of Theft − Deductible
+
+If vehicle recovered with damage:
+  Settlement = Repair Cost − Deductible
+```
+
+- A waiting period may apply before settling a theft claim (to allow for recovery)
+
+## Payment Methods
+
+| Method                        | Use Case                               | Details                                       |
+| ----------------------------- | -------------------------------------- | --------------------------------------------- |
+| Bank transfer to customer     | Standard settlement payment            | Uses customer's registered bank account       |
+| Direct billing to repair shop | Network shop repair                    | Shop invoices TryggFörsäkring directly        |
+| Bank transfer to third party  | Third-party liability settlement       | Payment to the injured party or their insurer |
+| Interim payment               | Personal injury with ongoing treatment | Partial payments while claim remains open     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: settlement must be calculated fairly and paid promptly; the customer must receive a clear explanation of the calculation
+- **FSA-004** — Consumer protection: settlement breakdowns must be transparent and in plain language
+- **FSA-014** — Record keeping: all settlement calculations, payment records, and supporting documentation must be retained for 10 years
+- **GDPR-003** — Claims processing: payment data (bank accounts) must be handled securely with purpose limitation
+- **GDPR-001** — Customer bank details must be collected and stored securely; used only for claim payments
+
+## Related User Stories
+
+- [US-CLM-005](../user-stories/claims-damage-assessment.md) — Assess Vehicle Damage
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-008](../user-stories/claims-settlement.md) — Calculate and Process Settlement
+- [US-CLM-014](../user-stories/claims-repair-authorization.md) — Authorize Repairs at Network Shops

--- a/docs/phase-1-motor/user-stories/claims-bonus-impact.md
+++ b/docs/phase-1-motor/user-stories/claims-bonus-impact.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 19
+---
+
+# US-CLM-010: Update Bonus Class After Claim
+
+## User Story
+
+**As the** system,
+**I want to** recalculate the customer's bonus class after a claim is settled,
+**so that** future premiums correctly reflect the customer's updated claims history.
+
+## Actors
+
+- **Primary:** System (automated process)
+- **Supporting:** [Underwriter (Riskbedömare)](../../actors/internal-actors.md#underwriter-riskbedömare), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Bonus class is the primary premium adjustment mechanism in Swedish motor insurance.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled (status "Settled" / Reglerad)
+  **WHEN** the system processes the settlement
+  **THEN** the system recalculates the policyholder's bonus class according to the bonus class rules, applying the appropriate penalty for the claim type
+
+- **GIVEN** a claim type that does not affect bonus (e.g., glass-only, animal collision)
+  **WHEN** the system evaluates bonus impact
+  **THEN** the bonus class remains unchanged and the system records that the claim was bonus-neutral
+
+- **GIVEN** a claim type that does affect bonus (e.g., collision at fault)
+  **WHEN** the system recalculates the bonus class
+  **THEN** the bonus class is reduced by the configured number of steps (typically 3 steps down for a collision claim) and the new bonus class is recorded on the policy
+
+- **GIVEN** a bonus class change has been applied
+  **WHEN** the customer views their policy
+  **THEN** the updated bonus class is displayed along with a notification explaining the change and its effect on the next renewal premium
+
+- **GIVEN** a claim is denied or withdrawn
+  **WHEN** the system evaluates bonus impact
+  **THEN** the bonus class is not affected
+
+## Bonus Class Rules (Typical)
+
+| Event                                  | Bonus Impact            |
+| -------------------------------------- | ----------------------- |
+| Claim-free year                        | +1 step (up to maximum) |
+| At-fault collision (vagnskada)         | −3 steps                |
+| Third-party liability claim (at fault) | −3 steps                |
+| Glass-only claim (glasskada)           | No impact               |
+| Animal collision (viltskada)           | No impact               |
+| Theft (stöld)                          | No impact               |
+| Fire (brand)                           | No impact               |
+| Natural damage                         | No impact               |
+| Roadside assistance (vägassistans)     | No impact               |
+
+## Bonus Class Scale (Example)
+
+| Class       | Premium Discount  | Years Claim-Free to Reach            |
+| ----------- | ----------------- | ------------------------------------ |
+| 1 (lowest)  | 0% (base premium) | N/A (entry or after multiple claims) |
+| 2           | ~10%              | 1 claim-free year from class 1       |
+| 3           | ~20%              | 1 claim-free year from class 2       |
+| 4           | ~30%              | 1 claim-free year from class 3       |
+| 5           | ~40%              | 1 claim-free year from class 4       |
+| 6           | ~50%              | 1 claim-free year from class 5       |
+| 7 (highest) | ~60%              | 1 claim-free year from class 6       |
+
+## Regulatory
+
+- **FSA-004** — Consumer protection: bonus class rules must be transparent and communicated to the customer at policy inception and at renewal
+- **FSA-010** — Fair claims settlement: bonus impact must be clearly communicated to the customer after a claim
+- **FSA-014** — Record keeping: bonus class history and all changes must be retained for the duration of the policy plus 10 years
+- **GDPR-002** — Policy administration: bonus class data is part of the policy record and follows the same retention rules
+
+## Dependencies
+
+- Depends on US-CLM-008 (Settlement) — bonus is recalculated after settlement
+- Bonus class rules defined by underwriting (depends on underwriting guidelines)
+- TFF bonus class transfer process for customers switching insurers
+
+## Notes
+
+- When a customer switches insurers, TFF coordinates the transfer of bonus class history between companies
+- Some insurers offer "bonus protection" (bonusskydd) as an add-on that prevents the first claim from affecting the bonus class — if offered by TryggFörsäkring, this must be checked before applying a bonus penalty
+- Bonus class changes take effect at the next renewal (huvudförfallodag), not immediately

--- a/docs/phase-1-motor/user-stories/claims-closure.md
+++ b/docs/phase-1-motor/user-stories/claims-closure.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 24
+---
+
+# US-CLM-015: Close and Review Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** perform a final review and close a claim after all settlements and recoveries are complete,
+**so that** the claim record is finalized and statistics are updated.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Actuary (Aktuarie)](../../actors/internal-actors.md#actuary)
+
+## Priority
+
+**Must Have** — Claim closure finalizes the financial record and feeds actuarial analysis.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled and all payments processed
+  **WHEN** the claims handler initiates claim closure
+  **THEN** the system verifies that: all payments have been confirmed, all subrogation cases are resolved or written off, all required documents are attached, and the bonus class impact has been applied
+
+- **GIVEN** all closure checks pass
+  **WHEN** the claims handler closes the claim
+  **THEN** the system changes the claim status to "Closed" (Stängd), records the closure date, and calculates the total claim cost (payments minus recoveries)
+
+- **GIVEN** a claim is closed
+  **WHEN** the system processes the closure
+  **THEN** the claim data feeds into actuarial reporting: claim type, total cost, time to settlement, and other key metrics are updated in the reporting dataset
+
+- **GIVEN** a closed claim needs to be reopened
+  **WHEN** the claims handler reopens the claim (e.g., new information, disputed settlement, additional injury)
+  **THEN** the system changes the status to "Reopened" (Återöppnad), records the reason for reopening, and allows further processing
+
+- **GIVEN** a personal injury claim under trafikförsäkring
+  **WHEN** the claims handler assesses whether to close the claim
+  **THEN** the system warns if the claim is being closed within the 10-year limitation period and there may be outstanding injury developments
+
+## Claim Closure Checklist
+
+| Check                  | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| All payments confirmed | Settlement payments received by payees                |
+| Subrogation resolved   | Recovery cases closed or written off                  |
+| Documents complete     | All required documents attached to the claim          |
+| Bonus impact applied   | Policyholder's bonus class updated (if applicable)    |
+| Customer notified      | Customer informed of final settlement and closure     |
+| No pending disputes    | No active complaints or disputes related to the claim |
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: claim closure must ensure the customer has received the full settlement owed
+- **FSA-014** — Record keeping: closed claim records must be retained for 10 years after closure; the record must be complete and auditable
+- **FSA-006** — Supervisory reporting: closed claims data feeds into regulatory reports (claims frequency, severity, reserves)
+- **GDPR-003** — Claims processing: closed claim data remains subject to GDPR retention rules; data must be deleted after the retention period expires
+
+## Dependencies
+
+- Depends on US-CLM-008 (Settlement) — all payments must be complete
+- Depends on US-CLM-009 (Subrogation) — recovery cases must be resolved
+- Depends on US-CLM-010 (Bonus Impact) — bonus class must be updated
+
+## Notes
+
+- Claims closed in error can be reopened with appropriate authorization
+- Personal injury claims under trafikförsäkring may be reopened within the 10-year limitation period if the injured party's condition changes
+- Claim closure triggers reserve release in the accounting system

--- a/docs/phase-1-motor/user-stories/claims-coverage-verification.md
+++ b/docs/phase-1-motor/user-stories/claims-coverage-verification.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 12
+---
+
+# US-CLM-003: Verify Coverage and Check Exclusions
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** verify that the policy was active at the time of the incident and that no exclusions apply,
+**so that** I can confirm or deny coverage before proceeding with the claim.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — Coverage verification is a prerequisite for all claims decisions.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been registered
+  **WHEN** the claims handler initiates coverage verification
+  **THEN** the system checks that the policy was active on the incident date and displays the result (covered / not covered / partially covered)
+
+- **GIVEN** a claim type is selected
+  **WHEN** the system verifies coverage
+  **THEN** it checks the policy's coverage tier against the claim type and confirms whether the specific coverage applies (e.g., collision damage requires helförsäkring)
+
+- **GIVEN** the policy has exclusions
+  **WHEN** the system performs coverage verification
+  **THEN** it evaluates applicable exclusions (e.g., racing, commercial use, unlicensed driver) and flags any that may apply to the reported circumstances
+
+- **GIVEN** a coverage verification is complete
+  **WHEN** the system displays the result
+  **THEN** the result includes: policy status at incident date, applicable coverage, deductible amount (självrisk), any flagged exclusions, and the coverage tier details
+
+- **GIVEN** coverage is denied due to exclusion or lapsed policy
+  **WHEN** the claims handler records the denial
+  **THEN** the system requires a documented denial reason and generates a denial notification to the customer explaining the reason in clear language
+
+## Common Exclusion Categories
+
+| Exclusion                  | Description                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| Policy not active          | Policy had not yet started or had been cancelled before the incident              |
+| Coverage tier insufficient | Claim type not covered by the policy's tier (e.g., collision on halvförsäkring)   |
+| Excluded use               | Vehicle was being used for an excluded purpose (racing, taxi without endorsement) |
+| Unlicensed driver          | Driver at the time of the incident did not hold a valid license                   |
+| Alcohol or drugs           | Driver was under the influence at the time of the incident                        |
+| Intentional damage         | Damage was caused intentionally by the policyholder or insured                    |
+| Waiting period             | Incident occurred during a waiting period after policy inception                  |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: coverage verification must be performed promptly; denial reasons must be clearly communicated
+- **FSA-004** — Consumer protection: denial notifications must use plain language and inform the customer of their right to dispute the decision
+- **FSA-011** — Complaints handling: denial notifications must include information about the complaints procedure
+- **GDPR-003** — Claims processing: coverage verification decisions and their rationale must be documented and retained
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) — claim must be registered before coverage can be verified
+- Requires policy data including coverage tier, active dates, and exclusion rules
+
+## Notes
+
+- Trafikförsäkring claims have special rules: even if the policyholder's own policy has exclusions, third parties injured by the vehicle are always covered under trafikförsäkring (Trafikskadelagen)
+- Coverage verification for TFF claims follows a different process (see [US-CLM-011](claims-tff.md))

--- a/docs/phase-1-motor/user-stories/claims-damage-assessment.md
+++ b/docs/phase-1-motor/user-stories/claims-damage-assessment.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 14
+---
+
+# US-CLM-005: Assess Vehicle Damage
+
+## User Story
+
+**As a** claims adjuster (värderare),
+**I want to** record damage assessment results with photos and repair estimates,
+**so that** the settlement is well-documented and based on accurate valuations.
+
+## Actors
+
+- **Primary:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad)
+
+## Priority
+
+**Must Have** — Damage assessment determines whether the vehicle is repaired or declared a total loss, and drives settlement amounts.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim requires damage assessment
+  **WHEN** the claims handler assigns the assessment
+  **THEN** the system assigns the assessment to a claims adjuster and notifies the adjuster with the claim details and customer contact information
+
+- **GIVEN** a claims adjuster inspects the vehicle
+  **WHEN** the adjuster records the assessment
+  **THEN** the system captures: damage description, affected components, repair estimate (parts and labor), photos of damage, and the adjuster's assessment of whether the damage is consistent with the reported incident
+
+- **GIVEN** a repair shop provides a repair estimate
+  **WHEN** the adjuster reviews the estimate
+  **THEN** the system allows the adjuster to upload the repair shop estimate, compare it against market rates, and approve or adjust the estimate
+
+- **GIVEN** repair costs exceed a configurable percentage of the vehicle's market value
+  **WHEN** the adjuster records the assessment
+  **THEN** the system flags the vehicle for total loss evaluation and calculates the vehicle's current market value
+
+- **GIVEN** a vehicle is assessed as a total loss (totalförlust)
+  **WHEN** the adjuster records the total loss decision
+  **THEN** the system calculates the settlement amount as the vehicle's market value minus the deductible (självrisk) and minus any salvage value
+
+- **GIVEN** the assessment is complete
+  **WHEN** the adjuster submits the assessment report
+  **THEN** the system attaches the report to the claim record and notifies the claims handler that the assessment is ready for review
+
+## Damage Assessment Data
+
+| Field                 | Required    | Description                                             |
+| --------------------- | ----------- | ------------------------------------------------------- |
+| Damage description    | Yes         | Detailed description of damage observed                 |
+| Affected components   | Yes         | List of damaged vehicle parts                           |
+| Repair estimate       | Yes         | Cost breakdown: parts, labor, paint                     |
+| Photos                | Yes         | Minimum required photos of damage                       |
+| Repair vs. total loss | Yes         | Adjuster's recommendation                               |
+| Market value          | Conditional | Required if total loss is being considered              |
+| Salvage value         | Conditional | Required if vehicle is a total loss                     |
+| Consistency check     | Yes         | Whether damage is consistent with the reported incident |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: damage assessment must be performed promptly and objectively; the assessment must support fair settlement
+- **FSA-014** — Record keeping: assessment reports, photos, and estimates must be retained for 10 years
+- **GDPR-003** — Claims processing: photos must capture damage only; incidental capture of bystanders or non-relevant personal data should be avoided
+- **GDPR-001** — Customer and third-party data processed during assessment must follow data minimization principles
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) and US-CLM-003 (Coverage Verification)
+- Repair shop integration for estimates and repair authorization
+
+## Notes
+
+- For glass-only claims (glasskada), a simplified assessment process may apply where the customer goes directly to an authorized glass repair shop without a separate adjuster inspection
+- Remote assessment via customer-submitted photos and video may be used for minor damage to reduce cycle time

--- a/docs/phase-1-motor/user-stories/claims-decision.md
+++ b/docs/phase-1-motor/user-stories/claims-decision.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 16
+---
+
+# US-CLM-007: Approve or Deny a Claim
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** make an informed decision to approve, deny, or refer a claim for further investigation,
+**so that** claims are resolved fairly and in accordance with policy terms and regulations.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — The claims decision is the central step in the claims lifecycle.
+
+## Acceptance Criteria
+
+- **GIVEN** coverage has been verified, liability determined, and damage assessed
+  **WHEN** the claims handler reviews all claim evidence
+  **THEN** the system presents a decision summary showing: coverage status, liability split, damage assessment, fraud screening result, deductible amount, and calculated settlement amount
+
+- **GIVEN** a claims handler approves a claim
+  **WHEN** the handler records the approval
+  **THEN** the system changes the claim status to "Approved" (Godkänd), records the approved settlement amount, and advances the claim to settlement processing
+
+- **GIVEN** a claims handler denies a claim
+  **WHEN** the handler records the denial
+  **THEN** the system requires a denial reason from a predefined list (plus free text explanation), changes the claim status to "Denied" (Avslagen), and generates a denial letter to the customer
+
+- **GIVEN** a claim is denied
+  **WHEN** the denial notification is sent to the customer
+  **THEN** the notification includes: the specific reason for denial, the relevant policy terms or exclusions, information about the complaints procedure (FSA-011), and reference to external dispute resolution (ARN)
+
+- **GIVEN** a claim exceeds the handler's settlement authority
+  **WHEN** the handler attempts to approve the claim
+  **THEN** the system routes the claim to a senior handler or manager for approval based on configurable authority limits
+
+- **GIVEN** a claims handler refers a claim for further investigation
+  **WHEN** the handler records the referral
+  **THEN** the system changes the claim status to "Under investigation" (Under utredning) and notifies the appropriate team
+
+## Claims Decision Authority
+
+| Decision Level | Maximum Settlement Amount                        | Approver                                         |
+| -------------- | ------------------------------------------------ | ------------------------------------------------ |
+| Level 1        | Up to configurable threshold (e.g., SEK 50,000)  | Claims handler                                   |
+| Level 2        | Up to configurable threshold (e.g., SEK 250,000) | Senior claims handler                            |
+| Level 3        | Above Level 2 threshold                          | Claims manager                                   |
+| Total loss     | Any amount                                       | Requires adjuster report + Level 2 or 3 approval |
+
+## Denial Reason Categories
+
+| Category                | Example                                                         |
+| ----------------------- | --------------------------------------------------------------- |
+| Policy not active       | Policy had lapsed before the incident date                      |
+| Coverage not applicable | Claim type not covered by the policy tier                       |
+| Exclusion applies       | Excluded use, unlicensed driver, intoxication                   |
+| Fraudulent claim        | Fraud investigation confirmed                                   |
+| Insufficient evidence   | Unable to verify the claim with available evidence              |
+| Late reporting          | Claim reported beyond reasonable timeframe without valid reason |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: decisions must be made promptly; denial reasons must be clear and justified
+- **FSA-004** — Consumer protection: denial notifications must use plain language
+- **FSA-011** — Complaints handling: denial notifications must inform the customer of the complaints procedure and external dispute resolution options (ARN, Personförsäkringsnämnden)
+- **FSA-014** — Record keeping: all claims decisions, rationale, and supporting evidence must be retained for 10 years
+- **GDPR-003** — Claims processing: decision records containing personal data must follow retention and access control requirements
+
+## Dependencies
+
+- Depends on US-CLM-003 (Coverage Verification)
+- Depends on US-CLM-004 (Liability Determination)
+- Depends on US-CLM-005 (Damage Assessment)
+- Depends on US-CLM-006 (Fraud Screening)
+
+## Notes
+
+- Customers must be informed of the decision within a reasonable timeframe as defined by internal SLAs
+- All decision records must be auditable for regulatory inspection

--- a/docs/phase-1-motor/user-stories/claims-fnol.md
+++ b/docs/phase-1-motor/user-stories/claims-fnol.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 10
+---
+
+# US-CLM-001: Report a Claim Online (FNOL)
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** report a motor insurance claim online with photos and incident details,
+**so that** the claims process starts immediately without waiting for office hours.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — FNOL is the entry point for all claims processing.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active motor insurance policy
+  **WHEN** the customer opens the claims reporting form (skadeanmälan) on web or mobile
+  **THEN** the system displays claim types matching the customer's coverage tier (trafikförsäkring, halvförsäkring, or helförsäkring)
+
+- **GIVEN** a customer is filling out the FNOL form
+  **WHEN** the customer enters incident details (date, time, location, description)
+  **THEN** the system validates that the incident date falls within the policy's active coverage period
+
+- **GIVEN** a customer is reporting a claim
+  **WHEN** the customer uploads photos of the damage
+  **THEN** the system accepts common image formats (JPEG, PNG, HEIF) up to a configurable maximum file size and stores them linked to the claim record
+
+- **GIVEN** a customer has completed the FNOL form
+  **WHEN** the customer submits the claim report
+  **THEN** the system creates a claim record with a unique claim number (skadenummer), links it to the policy, and sends the customer a confirmation with the claim number
+
+- **GIVEN** a claim has been submitted
+  **WHEN** the system processes the new claim
+  **THEN** the system assigns the claim to a claims handler based on claim type and workload rules
+
+- **GIVEN** a customer must verify their identity for the claim
+  **WHEN** the customer signs in
+  **THEN** the system authenticates the customer via [BankID](../../actors/external-actors.md#bankid)
+
+## Claim Types Supported
+
+The FNOL form must support the following motor claim types:
+
+| Claim Type            | Swedish Term | Coverage Required               |
+| --------------------- | ------------ | ------------------------------- |
+| Collision             | Vagnskada    | Helförsäkring                   |
+| Theft                 | Stöld        | Halvförsäkring or Helförsäkring |
+| Fire                  | Brand        | Halvförsäkring or Helförsäkring |
+| Glass damage          | Glasskada    | Halvförsäkring or Helförsäkring |
+| Natural damage        | Naturskada   | Halvförsäkring or Helförsäkring |
+| Animal collision      | Viltskada    | Halvförsäkring or Helförsäkring |
+| Third-party liability | Trafikskada  | Trafikförsäkring                |
+| Personal injury       | Personskada  | Trafikförsäkring                |
+| Roadside assistance   | Vägassistans | Halvförsäkring or Helförsäkring |
+
+## Data Captured at FNOL
+
+| Field                  | Required    | Description                            |
+| ---------------------- | ----------- | -------------------------------------- |
+| Incident date and time | Yes         | When the event occurred                |
+| Incident location      | Yes         | Address or coordinates                 |
+| Incident description   | Yes         | Free-text description of what happened |
+| Claim type             | Yes         | Selected from coverage-eligible types  |
+| Police report number   | Conditional | Required for theft, third-party claims |
+| Other parties involved | Conditional | Name, registration number, insurer     |
+| Witness information    | No          | Name and contact details               |
+| Photos                 | No          | Damage photos, scene photos            |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the claims process must begin promptly upon FNOL
+- **FSA-014** — Record keeping: the FNOL and all associated data must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization principles; collect only what is necessary for the claim
+- **GDPR-001** — Customer identity verification via BankID before claim submission
+- **IDD-005** — Claims handling disclosure: the IPID must have informed the customer about how to make a claim (pre-purchase)
+
+## Dependencies
+
+- Active policy must exist (depends on Quote and Bind — Issue #10)
+- Actor definitions (depends on Actors — Issue #5)
+- BankID integration for identity verification
+
+## Notes
+
+- Customers may also report claims by phone; the claims handler uses the same underlying claim registration process (see [US-CLM-002](claims-registration.md))
+- Third-party claimants (not policyholders) may also submit FNOL for trafikförsäkring claims; these follow a different identity verification flow

--- a/docs/phase-1-motor/user-stories/claims-fraud-screening.md
+++ b/docs/phase-1-motor/user-stories/claims-fraud-screening.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 15
+---
+
+# US-CLM-006: Screen Claims for Fraud
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want** the system to flag potential fraud indicators on incoming claims,
+**so that** I can investigate suspicious claims before settlement.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare)
+
+## Priority
+
+**Should Have** — Fraud screening protects the insurance portfolio and is an industry expectation, though manual investigation can serve as an interim process.
+
+## Acceptance Criteria
+
+- **GIVEN** a new claim is registered
+  **WHEN** the system processes the claim
+  **THEN** it runs automated fraud screening rules and assigns a fraud risk score or flag (low / medium / high)
+
+- **GIVEN** a claim is flagged as medium or high fraud risk
+  **WHEN** the claims handler views the claim
+  **THEN** the system displays the specific fraud indicators that triggered the flag, allowing the handler to review and either escalate for investigation or clear the flag with documented rationale
+
+- **GIVEN** a claims handler escalates a claim for fraud investigation
+  **WHEN** the handler marks the claim for investigation
+  **THEN** the system records the escalation reason, pauses settlement processing, and notifies the designated fraud investigation team
+
+- **GIVEN** a fraud investigation is complete
+  **WHEN** the investigator records the outcome (confirmed fraud / cleared)
+  **THEN** the system updates the claim status accordingly and, if fraud is confirmed, records the decision for potential criminal referral to police
+
+## Fraud Indicators
+
+The following indicators should be evaluated during automated screening:
+
+| Indicator                        | Description                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| Recent policy inception          | Claim filed shortly after policy was purchased                                       |
+| Coverage upgrade before claim    | Coverage tier was increased shortly before the incident                              |
+| Multiple recent claims           | Policyholder has filed multiple claims in a short period                             |
+| Inconsistent incident details    | Details in the FNOL conflict with known facts (e.g., location, time)                 |
+| Claim amount disproportionate    | Claimed damage amount is disproportionate to the incident description                |
+| Known fraud network              | Policyholder, vehicle, or linked parties appear in the industry fraud database (GSR) |
+| Total loss on high-value vehicle | Vehicle declared total loss with suspicious circumstances                            |
+| Late reporting                   | Significant delay between incident date and FNOL                                     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: fraud investigation must not unreasonably delay settlement of legitimate claims
+- **GDPR-006** — Fraud detection and prevention: fraud screening must follow data minimization; access full claims details only for flagged cases; automated screening should use pseudonymized data where possible
+- **GDPR-003** — Claims processing: fraud investigation data is sensitive and must be protected with strict access controls
+- **FSA-014** — Record keeping: fraud investigation records must be retained for 10 years from investigation closure
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) — claim must be registered before screening
+- Integration with GSR (Gemensamt skadeanmälningsregister) — industry fraud database
+
+## Notes
+
+- Automated fraud screening supplements but does not replace the claims handler's professional judgment
+- If a claim is referred to police for criminal investigation, the insurer must have a lawful basis under GDPR to share personal data with law enforcement
+- Fraud detection results must never be disclosed to the claimant during an active investigation

--- a/docs/phase-1-motor/user-stories/claims-liability.md
+++ b/docs/phase-1-motor/user-stories/claims-liability.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 13
+---
+
+# US-CLM-004: Determine Liability
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** determine liability for a motor incident based on evidence and applicable rules,
+**so that** settlement responsibility is correctly assigned between parties.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Priority
+
+**Must Have** — Liability determination drives settlement calculations and subrogation.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves a collision between two or more vehicles
+  **WHEN** the claims handler assesses liability
+  **THEN** the system allows the handler to record liability as a percentage split (e.g., 100/0, 50/50, 70/30) for each party involved
+
+- **GIVEN** a claim involves a single-vehicle incident (e.g., driving off the road)
+  **WHEN** the claims handler assesses liability
+  **THEN** the system records the policyholder as fully liable and calculates settlement based on policy coverage and deductible
+
+- **GIVEN** a claim involves a third-party claimant under trafikförsäkring
+  **WHEN** the claims handler assesses liability
+  **THEN** the system records the policyholder's liability to the third party and flags the claim for potential subrogation if the third party was partially at fault
+
+- **GIVEN** a police report is available
+  **WHEN** the claims handler uploads or links the report
+  **THEN** the system attaches the report to the claim record and allows the handler to reference it in the liability determination
+
+- **GIVEN** liability has been determined
+  **WHEN** the handler records the decision
+  **THEN** the system stores the liability decision with the rationale, evidence references, and the handler's identity, and advances the claim to the next stage
+
+- **GIVEN** a multi-party incident involves another insurer
+  **WHEN** liability is shared
+  **THEN** the system records the other insurer's details (company name, claim reference) for inter-company settlement coordination
+
+## Liability Scenarios
+
+| Scenario                     | Typical Liability Split    | Notes                                               |
+| ---------------------------- | -------------------------- | --------------------------------------------------- |
+| Rear-end collision           | 100% rear driver           | Presumption under Swedish traffic law               |
+| Intersection collision       | Varies (50/50 or assessed) | Based on right-of-way rules                         |
+| Single-vehicle accident      | 100% policyholder          | Collision coverage applies if helförsäkring         |
+| Parked vehicle hit           | 100% striking vehicle      | Third-party liability claim                         |
+| Animal collision (viltskada) | No fault                   | Covered as a natural hazard                         |
+| Unknown third party          | Special handling           | May involve TFF if the other driver is unidentified |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: liability decisions must be evidence-based and documented; the claimant must be informed of the outcome
+- **FSA-014** — Record keeping: liability determinations and supporting evidence must be retained for 10 years
+- **GDPR-003** — Claims processing: police reports and third-party personal data must follow data minimization and purpose limitation
+- **GDPR-001** — Third-party personal data (names, registration numbers) collected during liability assessment must have a lawful basis
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-003 (Coverage Verification) — coverage must be confirmed before liability impacts settlement
+
+## Notes
+
+- Under Trafikskadelagen, personal injury liability for trafikförsäkring is strict — the insurer pays regardless of fault, though recovery from the at-fault party may follow (see [US-CLM-009](claims-subrogation.md))
+- Animal collisions (viltskada) are treated as no-fault events and do not affect the policyholder's bonus class

--- a/docs/phase-1-motor/user-stories/claims-personal-injury.md
+++ b/docs/phase-1-motor/user-stories/claims-personal-injury.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 21
+---
+
+# US-CLM-012: Handle Personal Injury Claims Under Trafikförsäkring
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** process personal injury claims under trafikförsäkring with appropriate medical documentation and compensation schedules,
+**so that** injured parties receive fair compensation as required by Trafikskadelagen.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Medical Provider (Vårdgivare)](../../actors/external-actors.md#medical-provider-vårdgivare), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Personal injury claims under trafikförsäkring are legally mandated with a 10-year claim window.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves personal injury from a traffic incident
+  **WHEN** the claims handler registers the injury claim
+  **THEN** the system creates a personal injury claim record linked to the main claim, with separate tracking for medical documentation and injury-specific compensation
+
+- **GIVEN** a personal injury claim requires medical documentation
+  **WHEN** the claims handler requests medical records
+  **THEN** the system sends a consent-based request to the medical provider and tracks the document request status
+
+- **GIVEN** medical documentation has been received
+  **WHEN** the claims handler reviews the injury claim
+  **THEN** the system stores the medical documentation under special category data protection (GDPR Article 9) with restricted access limited to authorized claims handlers
+
+- **GIVEN** a personal injury settlement is being calculated
+  **WHEN** the claims handler processes the injury claim
+  **THEN** the system supports calculation of compensation components: medical costs (sjukvårdskostnader), income loss (inkomstförlust), pain and suffering (sveda och värk), and permanent disability (invaliditet)
+
+- **GIVEN** a personal injury claimant is not the policyholder
+  **WHEN** a third-party injured person files a claim
+  **THEN** the system allows the third party to file directly against the policyholder's trafikförsäkring, as mandated by Trafikskadelagen
+
+- **GIVEN** a personal injury claim has a long recovery period
+  **WHEN** the claims handler manages the claim over time
+  **THEN** the system supports interim payments and keeps the claim open for the duration of treatment, up to the 10-year limitation period
+
+## Compensation Components
+
+| Component            | Swedish Term            | Description                                    |
+| -------------------- | ----------------------- | ---------------------------------------------- |
+| Medical costs        | Sjukvårdskostnader      | Actual medical treatment costs                 |
+| Income loss          | Inkomstförlust          | Lost earnings during recovery                  |
+| Pain and suffering   | Sveda och värk          | Compensation for pain during the acute phase   |
+| Permanent disability | Invaliditet             | Compensation for lasting impairment            |
+| Loss of amenity      | Lyte och men            | Compensation for reduced quality of life       |
+| Future income loss   | Framtida inkomstförlust | Long-term earnings reduction due to disability |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: personal injury claims must be handled fairly with particular care given the vulnerability of injured claimants
+- **FSA-007** — Mandatory trafikförsäkring: personal injury coverage is the core purpose of trafikförsäkring under Trafikskadelagen
+- **FSA-014** — Record keeping: personal injury claim records must be retained for 10 years from claim closure (Trafikskadelagen allows claims up to 10 years after the injury)
+- **GDPR-003** — Claims processing: medical data is special category personal data (Article 9) requiring explicit consent or legal obligation basis
+- **GDPR-001** — Data minimization: collect only medical data directly relevant to the injury claim; do not request the claimant's full medical history
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-004 (Liability Determination) — though trafikförsäkring injury liability is strict
+- Medical provider integration for medical records exchange
+
+## Notes
+
+- Under Trafikskadelagen, personal injury liability is strict — the insurer must compensate the injured party regardless of fault
+- Personal injury claims often remain open for extended periods (months to years) due to ongoing treatment
+- The 10-year limitation period means claims can be filed long after the original policy period has ended
+- Medical data must be stored with the highest level of access control and is subject to DPIA requirements

--- a/docs/phase-1-motor/user-stories/claims-registration.md
+++ b/docs/phase-1-motor/user-stories/claims-registration.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 11
+---
+
+# US-CLM-002: Register and Manage Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** see all policy details and coverage at claim registration,
+**so that** I can verify coverage quickly and register the claim accurately.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Claim registration is the foundation for all subsequent claims processing.
+
+## Acceptance Criteria
+
+- **GIVEN** a claims handler opens a new or incoming FNOL
+  **WHEN** the handler views the claim
+  **THEN** the system displays the linked policy details including: coverage tier, active coverages, deductible amounts (självrisk), policy start and end dates, bonus class, and named drivers
+
+- **GIVEN** a claims handler is registering a claim
+  **WHEN** the handler confirms the claim type
+  **THEN** the system automatically verifies that the policy's coverage tier includes the reported claim type and displays a clear coverage confirmation or denial indicator
+
+- **GIVEN** a claim involves a phone-reported incident (not self-service FNOL)
+  **WHEN** the claims handler enters the incident details manually
+  **THEN** the system creates a claim record using the same data structure and validation rules as the online FNOL form
+
+- **GIVEN** a claim has been registered
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system displays the claim status, all attached documents, the incident timeline, and the assigned handler
+
+- **GIVEN** multiple claims exist for the same policy
+  **WHEN** the claims handler views the policy
+  **THEN** the system displays the complete claim history for that policy, sortable by date and status
+
+- **GIVEN** a claim requires additional information
+  **WHEN** the claims handler requests documents from the customer
+  **THEN** the system sends a notification to the customer specifying which documents are needed and tracks the outstanding request
+
+## Claim Status Lifecycle
+
+Claims follow this status progression:
+
+| Status                 | Swedish Term          | Description                         |
+| ---------------------- | --------------------- | ----------------------------------- |
+| Registered             | Registrerad           | Claim received and recorded         |
+| Under investigation    | Under utredning       | Handler is investigating            |
+| Awaiting information   | Väntar på information | Documents or details needed         |
+| Assessment in progress | Under värdering       | Damage being assessed               |
+| Decision pending       | Beslut väntande       | Ready for approve/deny decision     |
+| Approved               | Godkänd               | Claim approved for settlement       |
+| Denied                 | Avslagen              | Claim denied with documented reason |
+| Settled                | Reglerad              | Payment made, claim completed       |
+| Closed                 | Stängd                | Claim finalized and closed          |
+| Reopened               | Återöppnad            | Previously closed claim reopened    |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: claims must be registered promptly and handled without undue delay
+- **FSA-014** — Record keeping: all claim records, status changes, and communications must be retained for 10 years after claim closure
+- **GDPR-003** — Claims processing: access to claim data must be limited to authorized claims staff; personal data must follow purpose limitation
+- **GDPR-001** — Data minimization: only collect information necessary for the claim investigation
+
+## Dependencies
+
+- Depends on US-CLM-001 (FNOL) for online-submitted claims
+- Requires access to policy data (depends on Quote and Bind — Issue #10)
+
+## Notes
+
+- Claims handlers must be able to register claims for both policyholders and third-party claimants
+- The claim record must support linking to external references: police report numbers, medical record references, repair shop estimates

--- a/docs/phase-1-motor/user-stories/claims-repair-authorization.md
+++ b/docs/phase-1-motor/user-stories/claims-repair-authorization.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 23
+---
+
+# US-CLM-014: Authorize Repairs at Network Shops
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** authorize repairs at network shops with direct billing,
+**so that** the customer gets fast service and only pays the deductible.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Should Have** — Direct repair authorization streamlines the customer experience and controls repair costs.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been approved and repair is needed
+  **WHEN** the claims handler selects a repair approach
+  **THEN** the system displays a list of authorized network repair shops, with the option to filter by location, availability, and specialization
+
+- **GIVEN** the claims handler selects a network repair shop
+  **WHEN** the handler authorizes the repair
+  **THEN** the system sends a repair authorization to the shop including: claim number, vehicle details, approved repair scope, maximum authorized amount, and the customer's contact information
+
+- **GIVEN** a repair authorization has been sent
+  **WHEN** the repair shop accepts the assignment
+  **THEN** the system updates the claim status and notifies the customer with the shop's name, address, and contact details
+
+- **GIVEN** the repair is complete
+  **WHEN** the repair shop submits the final invoice
+  **THEN** the system validates the invoice against the authorized amount, processes payment to the shop (minus the customer's deductible), and records the transaction
+
+- **GIVEN** the repair cost exceeds the authorized amount
+  **WHEN** the repair shop requests additional authorization
+  **THEN** the system routes the request to the claims handler for approval before the shop proceeds with additional work
+
+- **GIVEN** the customer chooses a non-network repair shop
+  **WHEN** the customer submits the repair invoice for reimbursement
+  **THEN** the system processes reimbursement to the customer (repair cost minus deductible) after validation of the invoice
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: customers must have the option to choose their own repair shop, even if direct billing is only available at network shops
+- **FSA-004** — Consumer protection: the customer must be informed of the difference between network and non-network repair options
+- **GDPR-003** — Claims processing: personal data shared with repair shops must be limited to what is necessary for the repair (data minimization)
+- **GDPR-001** — Data processing agreements must be in place with all network repair shops
+
+## Dependencies
+
+- Depends on US-CLM-007 (Claims Decision) — claim must be approved
+- Depends on US-CLM-005 (Damage Assessment) — repair scope must be defined
+- Repair shop integration for authorization and invoicing
+
+## Notes
+
+- Network repair shops have pre-agreed labor rates and parts pricing, which helps control costs
+- Glass-only claims typically go directly to authorized glass repair shops (e.g., Carglass, Ryds Bilglas) with a simplified authorization process
+- Rental car arrangement during repair may be covered under the policy — this should be coordinated with the repair authorization

--- a/docs/phase-1-motor/user-stories/claims-settlement.md
+++ b/docs/phase-1-motor/user-stories/claims-settlement.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 17
+---
+
+# US-CLM-008: Calculate and Process Settlement
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** calculate the correct settlement amount including deductibles, depreciation, and applicable rules,
+**so that** the customer receives a fair and accurate payment.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider)
+
+## Priority
+
+**Must Have** — Settlement calculation and payment are the core outcome of the claims process.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been approved
+  **WHEN** the system calculates the settlement
+  **THEN** the calculation includes: repair cost (or market value for total loss), minus the applicable deductible (självrisk), minus depreciation if applicable, adjusted for the liability split
+
+- **GIVEN** a customer wants to know their deductible before proceeding
+  **WHEN** the customer views claim details
+  **THEN** the system displays the applicable deductible amount (självrisk) based on the claim type and policy terms
+
+- **GIVEN** a claim is for vehicle repair
+  **WHEN** the settlement is calculated
+  **THEN** the system uses the approved repair estimate from the damage assessment (US-CLM-005) and subtracts the deductible
+
+- **GIVEN** a claim is for a total loss (totalförlust)
+  **WHEN** the settlement is calculated
+  **THEN** the system calculates: vehicle market value at time of loss, minus deductible, minus salvage value (if the customer retains the vehicle)
+
+- **GIVEN** a settlement has been calculated
+  **WHEN** the claims handler approves the payment
+  **THEN** the system initiates payment to the designated payee (customer bank account, repair shop, or third party) via the payment provider
+
+- **GIVEN** a settlement payment is for direct repair shop billing
+  **WHEN** the claims handler authorizes the repair
+  **THEN** the system sends a repair authorization to the repair shop with the approved repair scope and amount, and the customer pays only the deductible to the shop
+
+- **GIVEN** a settlement is paid
+  **WHEN** the payment is confirmed by the payment provider
+  **THEN** the system updates the claim status to "Settled" (Reglerad) and records the payment details (amount, date, payee, payment reference)
+
+## Settlement Calculation Rules
+
+| Claim Type            | Calculation                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Repair (vagnskada)    | Approved repair cost − deductible                                                                                  |
+| Total loss            | Market value − deductible − salvage value                                                                          |
+| Glass (glasskada)     | Repair/replacement cost − glass deductible (often lower)                                                           |
+| Theft (stöld)         | Market value at time of theft − deductible (if not recovered); repair cost − deductible (if recovered with damage) |
+| Third-party liability | Actual damage to third party (no deductible for trafikförsäkring injury claims)                                    |
+| Personal injury       | Per Trafikskadelagen compensation schedule (medical costs, income loss, pain and suffering)                        |
+
+## Deductible (Självrisk) Structure
+
+| Coverage                           | Typical Deductible Range | Notes                                           |
+| ---------------------------------- | ------------------------ | ----------------------------------------------- |
+| Collision (vagnskada)              | SEK 3,000–10,000         | Selected at policy purchase                     |
+| Theft (stöld)                      | SEK 1,500–3,000          | May vary by policy                              |
+| Fire (brand)                       | SEK 1,500–3,000          | May vary by policy                              |
+| Glass (glasskada)                  | SEK 500–2,000            | Often a lower deductible                        |
+| Trafikförsäkring (personal injury) | No deductible            | Mandatory coverage, no excess for injury claims |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: settlement amounts must be fair and calculated transparently; payment must be made without undue delay
+- **FSA-004** — Consumer protection: the settlement calculation must be explained to the customer in plain language
+- **FSA-014** — Record keeping: settlement calculations, payment records, and all supporting documentation must be retained for 10 years
+- **GDPR-003** — Claims processing: payment data (bank account details) must be handled securely and retained per GDPR requirements
+
+## Dependencies
+
+- Depends on US-CLM-007 (Claims Decision) — claim must be approved before settlement
+- Depends on US-CLM-005 (Damage Assessment) — for repair cost or total loss valuation
+- Payment provider integration for disbursement
+
+## Notes
+
+- For multi-party claims where liability is shared, the settlement amount is adjusted according to the liability split (e.g., if the policyholder is 30% at fault, they bear 30% of their own damage)
+- VAT handling on repair costs must follow applicable rules
+- Customers may dispute settlement amounts through the complaints procedure (FSA-011)

--- a/docs/phase-1-motor/user-stories/claims-subrogation.md
+++ b/docs/phase-1-motor/user-stories/claims-subrogation.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 18
+---
+
+# US-CLM-009: Recover Costs Through Subrogation
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** initiate recovery of settlement costs from at-fault third parties or their insurers,
+**so that** TryggFörsäkring recovers costs it is entitled to under Swedish law.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)
+
+## Priority
+
+**Should Have** — Subrogation recovery directly impacts the company's loss ratio and financial performance.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled where a third party was at fault
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system flags the claim as eligible for subrogation (regressrätt) and displays the recoverable amount based on the liability split
+
+- **GIVEN** a subrogation-eligible claim is identified
+  **WHEN** the claims handler initiates subrogation
+  **THEN** the system records the target party (at-fault driver, their insurer), the amount to be recovered, and the legal basis for recovery
+
+- **GIVEN** subrogation involves another Swedish insurer
+  **WHEN** the claims handler sends a recovery request
+  **THEN** the system supports inter-company claims settlement via TFF-defined processes and formats
+
+- **GIVEN** a subrogation payment is received
+  **WHEN** the payment is recorded
+  **THEN** the system updates the claim record with the recovered amount, adjusts the net claim cost, and closes the subrogation case
+
+- **GIVEN** a subrogation attempt is unsuccessful
+  **WHEN** the claims handler records the outcome
+  **THEN** the system records the reason (uninsured party, disputed liability, uncollectible) and closes the subrogation case with the unrecovered amount documented
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: subrogation activities must not delay settlement to the policyholder; the policyholder must be made whole first
+- **FSA-014** — Record keeping: all subrogation records, communications, and outcomes must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data shared with third-party insurers for subrogation must have a lawful basis (contract performance, legal obligation)
+- **GDPR-001** — Data shared in subrogation must follow data minimization — only share what is necessary for the recovery claim
+
+## Dependencies
+
+- Depends on US-CLM-004 (Liability Determination) — liability must be established before subrogation
+- Depends on US-CLM-008 (Settlement) — settlement must be paid before pursuing recovery
+- TFF integration for inter-company settlement
+
+## Notes
+
+- Under Swedish law, the insurer may subrogate to the policyholder's rights against a third party after paying the claim
+- Subrogation does not apply to trafikförsäkring personal injury claims between insurers in the same way — these follow Trafikskadelagen rules
+- The customer's deductible should also be recovered in the subrogation process where possible

--- a/docs/phase-1-motor/user-stories/claims-tff.md
+++ b/docs/phase-1-motor/user-stories/claims-tff.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 20
+---
+
+# US-CLM-011: Process TFF Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** process claims involving uninsured, unknown, or foreign vehicles via TFF,
+**so that** victims are compensated even when the at-fault vehicle lacks valid Swedish insurance.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff), [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Priority
+
+**Should Have** — TFF claims are a regulatory requirement for trafikförsäkring participation, though volume is lower than standard claims.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves a vehicle that is not insured with any Swedish insurer
+  **WHEN** the claims handler identifies the vehicle as uninsured
+  **THEN** the system allows the claim to be flagged as a TFF claim and routes it through the TFF claims process
+
+- **GIVEN** a claim involves an unidentified vehicle (hit-and-run, smitning)
+  **WHEN** the claims handler records the claim
+  **THEN** the system allows the claim to be registered without an opposing party's vehicle details and flags it for TFF processing, requiring a police report reference
+
+- **GIVEN** a claim involves a foreign-registered vehicle
+  **WHEN** the claims handler identifies the vehicle as foreign
+  **THEN** the system supports recording the foreign vehicle details and insurer (if known), and routes the claim through TFF's international claims coordination (green card system)
+
+- **GIVEN** a TFF claim has been processed
+  **WHEN** the claims handler submits the claim to TFF
+  **THEN** the system transmits the claim data to TFF in the required format and tracks the TFF response (acceptance, request for additional information, or rejection)
+
+- **GIVEN** TFF has settled a claim
+  **WHEN** TFF communicates the settlement decision
+  **THEN** the system records the TFF settlement details and closes the claim accordingly
+
+## TFF Claim Scenarios
+
+| Scenario                              | Description                                                  | Special Requirements                                     |
+| ------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| Uninsured vehicle (oförsäkrat fordon) | At-fault vehicle has no valid trafikförsäkring               | Police report recommended; TFF covers the victim         |
+| Unidentified vehicle (okänt fordon)   | Hit-and-run where the vehicle cannot be identified           | Police report required; TFF covers personal injury only  |
+| Foreign vehicle                       | Vehicle registered abroad, involved in an incident in Sweden | Green card or other international insurance coordination |
+| TFF cost recovery                     | TFF recovers costs from the uninsured vehicle owner          | Not handled by TryggFörsäkring — TFF pursues directly    |
+
+## Regulatory
+
+- **FSA-007** — Mandatory trafikförsäkring: the TFF system exists to ensure victims are always compensated, even when the at-fault vehicle is uninsured
+- **FSA-008** — TFF membership: TryggFörsäkring must participate in TFF's claims coordination as a condition of selling trafikförsäkring
+- **FSA-010** — Fair claims settlement: TFF claims must be handled with the same fairness and timeliness standards as standard claims
+- **FSA-014** — Record keeping: TFF claim records, communications, and outcomes must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data shared with TFF must follow data minimization; share only required fields
+- **GDPR-004** — TFF reporting: data exchange with TFF is based on legal obligation under Trafikskadelagen
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-004 (Liability Determination)
+- TFF system integration for claim submission and response handling
+
+## Notes
+
+- TFF claims can take longer to resolve due to the inter-organization coordination
+- For hit-and-run claims where the vehicle is unidentified, TFF only covers personal injury (not vehicle damage)
+- Foreign vehicle claims may involve correspondence with the vehicle's home-country insurer through the green card system

--- a/docs/phase-1-motor/user-stories/claims-tracking.md
+++ b/docs/phase-1-motor/user-stories/claims-tracking.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 22
+---
+
+# US-CLM-013: Track Claim Status
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** track my claim status online,
+**so that** I know what is happening with my claim without calling customer service.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Should Have** — Claim tracking improves customer experience and reduces call center volume.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active claim
+  **WHEN** the customer logs in and navigates to claims
+  **THEN** the system displays all the customer's claims with their current status, claim number, and claim type
+
+- **GIVEN** a customer views a specific claim
+  **WHEN** the customer opens the claim details
+  **THEN** the system displays: claim status, a timeline of status changes with dates, the assigned handler's name, any outstanding information requests, the applicable deductible (självrisk), and estimated settlement amount (when available)
+
+- **GIVEN** a claim status changes
+  **WHEN** the system updates the claim
+  **THEN** the customer receives a notification (email or push notification based on preferences) with the new status and any action required from the customer
+
+- **GIVEN** a claim has an outstanding information request
+  **WHEN** the customer views the claim
+  **THEN** the system clearly displays what additional information or documents are needed and allows the customer to upload them directly
+
+- **GIVEN** a claim has been settled
+  **WHEN** the customer views the claim
+  **THEN** the system displays the final settlement amount, payment date, and payment method
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: customers must be kept informed of claim progress
+- **FSA-004** — Consumer protection: claim status information must be clear and in plain language
+- **GDPR-003** — Claims processing: the customer's view must only display their own claim data; access requires authentication via BankID
+
+## Dependencies
+
+- Depends on US-CLM-001 (FNOL) and US-CLM-002 (Claim Registration)
+- BankID integration for customer authentication
+
+## Notes
+
+- Third-party claimants (not policyholders) should also have limited claim tracking capability for their filed claims
+- The claims handler's internal notes and fraud investigation details must never be visible to the customer

--- a/docs/phase-1-motor/user-stories/index.md
+++ b/docs/phase-1-motor/user-stories/index.md
@@ -26,3 +26,26 @@ Mid-term adjustments and policy lifecycle management — see [Policy Administrat
 | US-PA-012 | Reissue Policy Document                     | Customer       |
 | US-PA-013 | Manage Policy Status                        | Underwriter    |
 | US-PA-014 | Review High-Risk Amendments                 | Underwriter    |
+
+## Claims Handling
+
+User stories covering the full motor insurance claims lifecycle, from first
+notification of loss through settlement and closure.
+
+| ID                                            | Title                                                | Priority    |
+| --------------------------------------------- | ---------------------------------------------------- | ----------- |
+| [US-CLM-001](claims-fnol.md)                  | Report a Claim Online (FNOL)                         | Must Have   |
+| [US-CLM-002](claims-registration.md)          | Register and Manage Claims                           | Must Have   |
+| [US-CLM-003](claims-coverage-verification.md) | Verify Coverage and Check Exclusions                 | Must Have   |
+| [US-CLM-004](claims-liability.md)             | Determine Liability                                  | Must Have   |
+| [US-CLM-005](claims-damage-assessment.md)     | Assess Vehicle Damage                                | Must Have   |
+| [US-CLM-006](claims-fraud-screening.md)       | Screen Claims for Fraud                              | Should Have |
+| [US-CLM-007](claims-decision.md)              | Approve or Deny a Claim                              | Must Have   |
+| [US-CLM-008](claims-settlement.md)            | Calculate and Process Settlement                     | Must Have   |
+| [US-CLM-009](claims-subrogation.md)           | Recover Costs Through Subrogation                    | Should Have |
+| [US-CLM-010](claims-bonus-impact.md)          | Update Bonus Class After Claim                       | Must Have   |
+| [US-CLM-011](claims-tff.md)                   | Process TFF Claims                                   | Should Have |
+| [US-CLM-012](claims-personal-injury.md)       | Handle Personal Injury Claims Under Trafikförsäkring | Must Have   |
+| [US-CLM-013](claims-tracking.md)              | Track Claim Status                                   | Should Have |
+| [US-CLM-014](claims-repair-authorization.md)  | Authorize Repairs at Network Shops                   | Should Have |
+| [US-CLM-015](claims-closure.md)               | Close and Review Claims                              | Must Have   |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
@@ -34,3 +34,15 @@ Mid-term adjustment and policy lifecycle use cases — see [Policy Administratio
 | UC-PA-004 | Manage Policy Status Transitions          | System        |
 | UC-PA-005 | Recalculate Premium After Amendment       | System        |
 | UC-PA-006 | Underwriter Review of High-Risk Amendment | Underwriter   |
+
+## Claims Handling
+
+Use cases describing the detailed workflows for motor insurance claims
+processing.
+
+| ID                                         | Title                              | Scope                                         |
+| ------------------------------------------ | ---------------------------------- | --------------------------------------------- |
+| [UC-CLM-001](uc-claims-lifecycle.md)       | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
+| [UC-CLM-002](uc-fnol-processing.md)        | FNOL Processing                    | First notification of loss — online and phone |
+| [UC-CLM-003](uc-settlement-calculation.md) | Settlement Calculation and Payment | Settlement rules and payment execution        |
+| [UC-CLM-004](uc-fraud-screening.md)        | Fraud Screening and Investigation  | Automated and manual fraud detection          |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-claims-lifecycle.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-claims-lifecycle.md
@@ -1,0 +1,195 @@
+---
+sidebar_position: 10
+---
+
+# UC-CLM-001: Claims Lifecycle
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a motor insurance claim, from first notification of loss (FNOL) through investigation, decision, settlement, and closure. It serves as the orchestrating use case that ties together the individual claims processing steps.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund), [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad), [Police (Polis)](../../actors/external-actors.md#police-polis), [Medical Provider (Vårdgivare)](../../actors/external-actors.md#medical-provider-vårdgivare), [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff), [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider)
+
+## Preconditions
+
+1. The customer holds an active motor insurance policy with TryggFörsäkring
+2. An insured event has occurred (accident, theft, damage, etc.)
+
+## Postconditions
+
+**Success:**
+
+- Claim is settled and closed with full documentation
+- Customer has received the settlement amount (or repair has been completed)
+- Bonus class has been updated (if applicable)
+- Subrogation has been initiated (if applicable)
+- All records are retained per regulatory requirements
+
+**Failure:**
+
+- Claim is denied with documented reason and customer notification
+- Customer has been informed of complaints procedure and dispute resolution options
+
+## Main Flow
+
+```mermaid
+flowchart TD
+    A[1. FNOL - Customer reports claim] --> B[2. Claim Registration]
+    B --> C[3. Coverage Verification]
+    C --> D{Coverage confirmed?}
+    D -->|No| E[Deny claim - notify customer]
+    D -->|Yes| F[4. Fraud Screening]
+    F --> G{Fraud flag?}
+    G -->|High risk| H[Fraud Investigation]
+    H --> I{Fraud confirmed?}
+    I -->|Yes| E
+    I -->|No| J[5. Liability Determination]
+    G -->|Low/Medium| J
+    J --> K[6. Damage Assessment]
+    K --> L[7. Claims Decision]
+    L --> M{Decision?}
+    M -->|Deny| E
+    M -->|Approve| N[8. Settlement Calculation]
+    N --> O[9. Payment / Repair Authorization]
+    O --> P[10. Bonus Class Update]
+    P --> Q{Subrogation eligible?}
+    Q -->|Yes| R[11. Subrogation]
+    Q -->|No| S[12. Claim Closure]
+    R --> S
+    E --> T[Record denial and close]
+```
+
+### Step-by-Step
+
+| Step | Action                                                        | Actor           | System Response                                             | Reference                                                                                                        |
+| ---- | ------------------------------------------------------------- | --------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1    | Customer reports the incident via web, app, or phone          | Customer        | Creates FNOL record, assigns claim number                   | [US-CLM-001](../user-stories/claims-fnol.md)                                                                     |
+| 2    | Claims handler reviews and registers the claim                | Claims Handler  | Links claim to policy, sets status to "Registered"          | [US-CLM-002](../user-stories/claims-registration.md)                                                             |
+| 3    | System verifies coverage was active and claim type is covered | Claims Handler  | Displays coverage confirmation or flags issues              | [US-CLM-003](../user-stories/claims-coverage-verification.md)                                                    |
+| 4    | System runs automated fraud screening                         | System          | Assigns fraud risk score; flags suspicious claims           | [US-CLM-006](../user-stories/claims-fraud-screening.md)                                                          |
+| 5    | Claims handler determines liability based on evidence         | Claims Handler  | Records liability split and supporting evidence             | [US-CLM-004](../user-stories/claims-liability.md)                                                                |
+| 6    | Claims adjuster assesses vehicle damage                       | Claims Adjuster | Records repair estimate or total loss valuation             | [US-CLM-005](../user-stories/claims-damage-assessment.md)                                                        |
+| 7    | Claims handler makes approve/deny decision                    | Claims Handler  | Records decision and rationale                              | [US-CLM-007](../user-stories/claims-decision.md)                                                                 |
+| 8    | System calculates settlement amount                           | Claims Handler  | Calculates repair cost or total loss value minus deductible | [US-CLM-008](../user-stories/claims-settlement.md)                                                               |
+| 9    | Payment is issued or repair is authorized                     | Claims Handler  | Processes payment or sends repair authorization             | [US-CLM-008](../user-stories/claims-settlement.md), [US-CLM-014](../user-stories/claims-repair-authorization.md) |
+| 10   | System updates bonus class                                    | System          | Recalculates bonus class based on claim type                | [US-CLM-010](../user-stories/claims-bonus-impact.md)                                                             |
+| 11   | Subrogation initiated if third party at fault                 | Claims Handler  | Records recovery target and tracks recovery                 | [US-CLM-009](../user-stories/claims-subrogation.md)                                                              |
+| 12   | Claims handler performs final review and closes claim         | Claims Handler  | Sets status to "Closed", updates statistics                 | [US-CLM-015](../user-stories/claims-closure.md)                                                                  |
+
+## Alternative Flows
+
+### A1: Phone-Reported Claim
+
+At step 1, if the customer reports the claim by phone:
+
+1. The claims handler captures incident details during the call
+2. The handler creates the claim record on behalf of the customer
+3. The process continues from step 2
+
+### A2: Third-Party Claimant
+
+At step 1, if the claimant is a third party (not the policyholder):
+
+1. The third party reports damage or injury caused by a TryggFörsäkring policyholder
+2. The system creates a third-party claim linked to the policyholder's trafikförsäkring
+3. Coverage verification confirms the policy was active (trafikförsäkring covers third parties)
+4. The process continues from step 5 (liability determination)
+
+### A3: TFF Claim
+
+At step 3, if coverage verification reveals the at-fault vehicle is uninsured:
+
+1. The claim is flagged as a TFF claim
+2. The process follows the TFF claims handling flow (see [US-CLM-011](../user-stories/claims-tff.md))
+
+### A4: Personal Injury Claim
+
+At step 1, if the claim involves personal injury:
+
+1. An additional personal injury sub-claim is created
+2. Medical documentation is requested from healthcare providers
+3. Injury compensation is calculated per Trafikskadelagen schedules
+4. The claim may remain open for an extended period (see [US-CLM-012](../user-stories/claims-personal-injury.md))
+
+### A5: Glass-Only Claim (Fast Track)
+
+At step 1, if the claim is for glass damage only:
+
+1. The customer is directed to an authorized glass repair shop
+2. Coverage verification is performed (halvförsäkring or helförsäkring required)
+3. The repair shop performs the replacement and bills TryggFörsäkring directly
+4. The customer pays only the glass deductible
+5. No bonus class impact — claim is closed after payment
+
+## Exception Flows
+
+### E1: Coverage Denied
+
+At step 3, if coverage verification fails:
+
+1. The claims handler records the denial reason
+2. The system generates a denial notification to the customer
+3. The notification includes the complaints procedure and external dispute resolution (ARN)
+4. The claim is closed with status "Denied"
+
+### E2: Claim Disputed by Customer
+
+After step 7, if the customer disputes the decision:
+
+1. The customer files a complaint through the complaints procedure (FSA-011)
+2. The complaint is registered and linked to the claim
+3. The complaint is investigated per the complaints handling process
+4. If the complaint is upheld, the claim decision may be revised
+
+## Business Rules
+
+| Rule       | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| BR-CLM-001 | A claim must be linked to exactly one active policy                      |
+| BR-CLM-002 | Coverage verification must be completed before any settlement decision   |
+| BR-CLM-003 | Claims exceeding the handler's authority limit must be escalated         |
+| BR-CLM-004 | Denial notifications must include complaints procedure information       |
+| BR-CLM-005 | Bonus class changes take effect at the next renewal date                 |
+| BR-CLM-006 | Trafikförsäkring personal injury claims have a 10-year limitation period |
+| BR-CLM-007 | The customer must be made whole before subrogation is pursued            |
+| BR-CLM-008 | Fraud investigation must not unreasonably delay legitimate claims        |
+
+## Key Performance Indicators
+
+| KPI                      | Description                                   | Target                               |
+| ------------------------ | --------------------------------------------- | ------------------------------------ |
+| FNOL to registration     | Time from customer report to claim registered | < 1 business day                     |
+| Registration to decision | Time from registration to approve/deny        | < 10 business days (standard claims) |
+| Decision to payment      | Time from approval to payment issued          | < 5 business days                    |
+| Total cycle time         | FNOL to claim closure                         | < 30 business days (standard claims) |
+| Customer satisfaction    | Post-claim survey score                       | ≥ 4.0 / 5.0                          |
+| Fraud detection rate     | Percentage of fraudulent claims detected      | Monitored (no fixed target)          |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the entire lifecycle must be efficient and transparent
+- **FSA-011** — Complaints handling: denial and dispute paths must be available
+- **FSA-014** — Record keeping: complete claim lifecycle records must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data must be handled according to GDPR throughout the lifecycle
+- **IDD-005** — Claims handling disclosure: claim reporting procedures must be communicated to customers at policy purchase (via IPID)
+
+## Related User Stories
+
+- [US-CLM-001](../user-stories/claims-fnol.md) — Report a Claim Online (FNOL)
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims
+- [US-CLM-003](../user-stories/claims-coverage-verification.md) — Verify Coverage and Check Exclusions
+- [US-CLM-004](../user-stories/claims-liability.md) — Determine Liability
+- [US-CLM-005](../user-stories/claims-damage-assessment.md) — Assess Vehicle Damage
+- [US-CLM-006](../user-stories/claims-fraud-screening.md) — Screen Claims for Fraud
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-008](../user-stories/claims-settlement.md) — Calculate and Process Settlement
+- [US-CLM-009](../user-stories/claims-subrogation.md) — Recover Costs Through Subrogation
+- [US-CLM-010](../user-stories/claims-bonus-impact.md) — Update Bonus Class After Claim
+- [US-CLM-011](../user-stories/claims-tff.md) — Process TFF Claims
+- [US-CLM-012](../user-stories/claims-personal-injury.md) — Handle Personal Injury Claims
+- [US-CLM-013](../user-stories/claims-tracking.md) — Track Claim Status
+- [US-CLM-014](../user-stories/claims-repair-authorization.md) — Authorize Repairs at Network Shops
+- [US-CLM-015](../user-stories/claims-closure.md) — Close and Review Claims

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 11
+---
+
+# UC-CLM-002: FNOL Processing
+
+## Overview
+
+This use case details the First Notification of Loss (FNOL) process — from the customer initiating a claim report through to the claim being registered and assigned to a claims handler. FNOL is the entry point for all claims and must be fast, intuitive, and capture sufficient information for the claims team to begin investigation.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare), [BankID](../../actors/external-actors.md#bankid)
+
+## Preconditions
+
+1. The customer is registered and has at least one active motor insurance policy
+2. An insured event has occurred
+3. The customer has access to the web portal or mobile app (or calls the claims phone line)
+
+## Postconditions
+
+**Success:**
+
+- A claim record exists with a unique claim number (skadenummer)
+- The claim is linked to the correct policy
+- Incident details, photos, and supporting documents are stored
+- A claims handler has been assigned
+- The customer has received confirmation with the claim number
+
+**Failure:**
+
+- The customer is unable to complete the FNOL (e.g., no active policy found, system error)
+- The customer is informed of the issue and directed to contact customer service
+
+## Main Flow (Online Self-Service)
+
+| Step | Actor    | Action                                                          | System Response                                                                                   |
+| ---- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 1    | Customer | Opens the claims reporting page and authenticates via BankID    | System verifies identity and retrieves active policies                                            |
+| 2    | Customer | Selects the policy and vehicle for the claim                    | System displays policy details and eligible claim types based on coverage tier                    |
+| 3    | Customer | Selects the claim type (e.g., collision, theft, glass)          | System adapts the FNOL form to the selected claim type                                            |
+| 4    | Customer | Enters incident details: date, time, location, description      | System validates the incident date against the policy's coverage period                           |
+| 5    | Customer | Enters information about other parties involved (if applicable) | System records other party details: name, vehicle registration, insurer                           |
+| 6    | Customer | Uploads photos of the damage and any supporting documents       | System stores photos linked to the claim record                                                   |
+| 7    | Customer | Reviews the complete FNOL summary                               | System displays a summary for the customer to confirm                                             |
+| 8    | Customer | Submits the claim report                                        | System creates the claim record, generates a claim number, and sends confirmation to the customer |
+| 9    | System   | Assigns the claim to a claims handler based on rules            | Claims handler is notified of the new claim assignment                                            |
+
+## Alternative Flow: Phone-Reported FNOL
+
+| Step | Actor          | Action                                                                 | System Response                                              |
+| ---- | -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | Customer       | Calls the claims phone line                                            | Claims handler answers and verifies identity                 |
+| 2    | Claims Handler | Searches for the customer's policy using personnummer or policy number | System displays matching policies                            |
+| 3    | Claims Handler | Selects the correct policy and creates a new claim                     | System opens the FNOL registration form                      |
+| 4    | Claims Handler | Enters incident details as reported by the customer                    | System validates and records the information                 |
+| 5    | Claims Handler | Records any additional details (police report number, witnesses)       | System stores all details in the claim record                |
+| 6    | Claims Handler | Submits the claim registration                                         | System creates the claim record and generates a claim number |
+| 7    | Claims Handler | Provides the claim number to the customer                              | Customer can use the number for online tracking              |
+
+## Alternative Flow: Third-Party FNOL
+
+| Step | Actor          | Action                                                                  | System Response                                                    |
+| ---- | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1    | Third Party    | Contacts TryggFörsäkring to report damage caused by an insured vehicle  | Claims handler verifies the policy exists for the reported vehicle |
+| 2    | Claims Handler | Creates a third-party claim against the policyholder's trafikförsäkring | System creates a third-party claim record                          |
+| 3    | Claims Handler | Records the third party's details and the incident information          | System stores the claim with the third party as claimant           |
+| 4    | Claims Handler | Notifies the policyholder of the third-party claim                      | System sends notification to the policyholder                      |
+
+## Validation Rules
+
+| Rule        | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| VR-FNOL-001 | Incident date must not be in the future                            |
+| VR-FNOL-002 | Incident date must fall within the policy's active coverage period |
+| VR-FNOL-003 | Claim type must be covered by the policy's coverage tier           |
+| VR-FNOL-004 | At least one photo is recommended but not required at FNOL stage   |
+| VR-FNOL-005 | Police report number is required for theft and hit-and-run claims  |
+| VR-FNOL-006 | Other party information is required for multi-vehicle collisions   |
+
+## Data Model
+
+### Claim Record (Created at FNOL)
+
+| Field                      | Type      | Required       | Description                            |
+| -------------------------- | --------- | -------------- | -------------------------------------- |
+| Claim number (skadenummer) | String    | Auto-generated | Unique identifier for the claim        |
+| Policy number              | String    | Yes            | Link to the insured policy             |
+| Claim type                 | Enum      | Yes            | Type of claim (collision, theft, etc.) |
+| Status                     | Enum      | Auto-set       | Initial status: "Registered"           |
+| Incident date              | Date      | Yes            | When the event occurred                |
+| Incident time              | Time      | No             | Time of the event (if known)           |
+| Incident location          | String    | Yes            | Where the event occurred               |
+| Incident description       | Text      | Yes            | Free-text description                  |
+| Police report number       | String    | Conditional    | Required for theft, hit-and-run        |
+| Reporter                   | Reference | Yes            | Customer or third party who reported   |
+| Photos                     | File[]    | No             | Uploaded damage photos                 |
+| Other parties              | Object[]  | Conditional    | Other vehicles/persons involved        |
+| Created date               | Timestamp | Auto-set       | When the FNOL was submitted            |
+| Assigned handler           | Reference | Auto-set       | Claims handler assigned to the claim   |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: FNOL must be processed promptly; the customer must receive acknowledgement without undue delay
+- **FSA-014** — Record keeping: the complete FNOL record must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization; collect only what is necessary
+- **GDPR-001** — Identity verification via BankID for online FNOL
+- **IDD-005** — The IPID must have informed the customer about the claims reporting process before policy purchase
+
+## Related User Stories
+
+- [US-CLM-001](../user-stories/claims-fnol.md) — Report a Claim Online (FNOL)
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims
+- [US-CLM-013](../user-stories/claims-tracking.md) — Track Claim Status

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 13
+---
+
+# UC-CLM-004: Fraud Screening and Investigation
+
+## Overview
+
+This use case describes the fraud screening and investigation process for motor insurance claims. It covers automated fraud indicator detection at claim registration, manual investigation workflows, and the outcomes of fraud investigations including criminal referral.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Preconditions
+
+1. A claim has been registered in the system
+2. Automated fraud screening rules are configured
+3. Integration with the industry fraud database (GSR) is active (if available)
+
+## Postconditions
+
+**Cleared:**
+
+- Claim is cleared of fraud suspicion and proceeds through normal claims processing
+- The fraud screening result is recorded in the claim file
+
+**Fraud confirmed:**
+
+- Claim is denied with documented fraud determination
+- Criminal referral to police is initiated (if warranted)
+- Fraud indicators are recorded for future pattern detection
+- Customer is notified of the denial (without disclosing investigation details)
+
+## Main Flow: Automated Screening
+
+| Step | Actor  | Action                     | System Response                                                          |
+| ---- | ------ | -------------------------- | ------------------------------------------------------------------------ |
+| 1    | System | Claim is registered        | System automatically runs fraud screening rules against the claim        |
+| 2    | System | Evaluates fraud indicators | System calculates a fraud risk score: low, medium, or high               |
+| 3a   | System | Score is low               | Claim proceeds to normal processing; screening result is logged          |
+| 3b   | System | Score is medium            | Claim is flagged for handler review; specific indicators are highlighted |
+| 3c   | System | Score is high              | Claim is flagged for investigation; settlement processing is paused      |
+
+## Alternative Flow: Manual Investigation
+
+| Step | Actor          | Action                                                                           | System Response                                                  |
+| ---- | -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1    | Claims Handler | Reviews flagged fraud indicators on a medium/high-risk claim                     | System displays the specific indicators that triggered the flag  |
+| 2    | Claims Handler | Decides to investigate further                                                   | System records the investigation start and pauses settlement     |
+| 3    | Claims Handler | Gathers additional evidence (interviews, document verification, site inspection) | System stores investigation notes and evidence in the claim file |
+| 4    | Claims Handler | Checks the industry fraud database (GSR) for matching patterns                   | System queries GSR and displays any matches                      |
+| 5    | Claims Handler | Reviews damage assessment for consistency with reported incident                 | Claims adjuster may be asked to re-inspect                       |
+| 6    | Claims Handler | Records investigation findings                                                   | System stores the complete investigation record                  |
+| 7a   | Claims Handler | Clears the claim (no fraud found)                                                | System removes the fraud flag and resumes normal processing      |
+| 7b   | Claims Handler | Confirms fraud                                                                   | System denies the claim and records the fraud determination      |
+
+## Alternative Flow: Criminal Referral
+
+| Step | Actor          | Action                                               | System Response                                              |
+| ---- | -------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | Claims Handler | Fraud investigation confirms insurance fraud         | System records the confirmed fraud determination             |
+| 2    | Claims Handler | Decides to refer the case to police                  | System generates a criminal referral summary                 |
+| 3    | Claims Handler | Submits the referral to the Swedish Police Authority | System records the referral date and police reference number |
+| 4    | Claims Handler | Monitors the police investigation outcome            | System tracks the referral status                            |
+
+## Fraud Indicators and Scoring
+
+| Indicator                              | Weight | Description                                                                    |
+| -------------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| Recent policy inception                | Medium | Policy was purchased within 30 days of the claim                               |
+| Coverage upgrade before claim          | High   | Coverage tier was increased within 60 days of the claim                        |
+| Multiple recent claims                 | Medium | 2+ claims filed by the same policyholder within 12 months                      |
+| Inconsistent details                   | High   | FNOL details conflict with police report or physical evidence                  |
+| Disproportionate claim amount          | Medium | Claim amount significantly exceeds expected cost for the incident type         |
+| GSR match                              | High   | Policyholder, vehicle, or linked parties appear in the industry fraud database |
+| Total loss on recently insured vehicle | High   | Vehicle declared total loss shortly after being insured                        |
+| Late reporting                         | Low    | More than 30 days between incident date and FNOL                               |
+| Unusual incident location              | Low    | Incident occurred in an unusual or hard-to-verify location                     |
+
+### Scoring Logic
+
+- **Low risk:** No high-weight indicators; at most one medium-weight indicator
+- **Medium risk:** One or more medium-weight indicators; no high-weight indicators
+- **High risk:** One or more high-weight indicators; or three or more medium-weight indicators
+
+## Business Rules
+
+| Rule       | Description                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| BR-FRD-001 | Fraud screening runs automatically on every new claim                                        |
+| BR-FRD-002 | High-risk claims must be reviewed by a claims handler before settlement                      |
+| BR-FRD-003 | Investigation details must never be disclosed to the claimant during an active investigation |
+| BR-FRD-004 | Fraud investigation must not unreasonably delay settlement of legitimate claims              |
+| BR-FRD-005 | Criminal referral requires senior claims handler or manager approval                         |
+| BR-FRD-006 | Cleared fraud flags must retain the investigation log for audit purposes                     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: fraud investigation must not unreasonably delay settlement of legitimate claims; the insurer must balance fraud prevention with fair treatment
+- **FSA-014** — Record keeping: fraud investigation records must be retained for 10 years from investigation closure
+- **GDPR-006** — Fraud detection and prevention: automated screening must use pseudonymized data where possible; access to full claim details is restricted to flagged cases; the claimant has the right to object to automated profiling
+- **GDPR-003** — Claims processing: fraud investigation data is sensitive and must be protected with strict access controls; purpose limitation applies
+- **GDPR-001** — Data sharing with GSR and police must have a lawful basis; data minimization applies to all external data sharing
+
+## Related User Stories
+
+- [US-CLM-006](../user-stories/claims-fraud-screening.md) — Screen Claims for Fraud
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-002](../user-stories/claims-registration.md) — Register and Manage Claims

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 12
+---
+
+# UC-CLM-003: Settlement Calculation and Payment
+
+## Overview
+
+This use case describes the settlement calculation and payment process for approved motor insurance claims. It covers the rules for calculating settlement amounts across different claim types (repair, total loss, glass, theft, personal injury) and the payment execution flow.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare), [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad)
+
+## Preconditions
+
+1. The claim has been approved (status: "Approved" / Godkänd)
+2. Damage assessment is complete (for vehicle damage claims)
+3. Liability determination is complete (for multi-party claims)
+
+## Postconditions
+
+**Success:**
+
+- Settlement amount has been calculated and documented
+- Payment has been issued and confirmed
+- Claim status is updated to "Settled" (Reglerad)
+- Payment records are stored for audit and regulatory compliance
+
+**Failure:**
+
+- Payment fails (e.g., invalid bank details, payment provider error)
+- Claims handler is notified and payment is retried or alternative payment method is used
+
+## Main Flow: Vehicle Repair Settlement
+
+| Step | Actor          | Action                                              | System Response                                                                      |
+| ---- | -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 1    | Claims Handler | Opens the approved claim for settlement             | System displays the damage assessment with approved repair estimate                  |
+| 2    | System         | Calculates settlement: repair cost minus deductible | System displays the calculated settlement amount with breakdown                      |
+| 3    | Claims Handler | Verifies the calculation and selects payment method | System presents options: direct payment to customer or direct billing to repair shop |
+| 4a   | Claims Handler | Selects direct billing to repair shop               | System sends repair authorization to the shop; customer pays deductible to shop      |
+| 4b   | Claims Handler | Selects payment to customer                         | System initiates bank transfer to customer's registered account                      |
+| 5    | System         | Processes the payment via payment provider          | System records payment status and updates claim status                               |
+| 6    | System         | Confirms payment completion                         | Claim status changes to "Settled" (Reglerad)                                         |
+
+## Alternative Flow: Total Loss Settlement
+
+| Step | Actor           | Action                                                                        | System Response                                                       |
+| ---- | --------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1    | Claims Adjuster | Declares the vehicle a total loss (repair cost > threshold % of market value) | System flags the claim for total loss processing                      |
+| 2    | System          | Calculates vehicle market value using industry valuation data                 | System displays the market value with valuation methodology           |
+| 3    | Claims Handler  | Reviews the total loss valuation                                              | Handler may adjust within guidelines or request independent valuation |
+| 4    | System          | Calculates settlement: market value − deductible − salvage value              | System displays the total loss settlement breakdown                   |
+| 5    | Claims Handler  | Confirms the settlement and initiates payment                                 | System processes payment to the customer                              |
+| 6    | System          | Records the settlement and updates claim status                               | Claim status changes to "Settled"                                     |
+
+## Alternative Flow: Liability-Split Settlement
+
+| Step | Actor          | Action                                                  | System Response                                                                               |
+| ---- | -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 1    | Claims Handler | Opens a claim with shared liability (e.g., 70/30 split) | System displays the liability determination and damage assessment                             |
+| 2    | System         | Calculates the policyholder's share of the damage       | Settlement = (total damage × policyholder's non-fault percentage) − deductible                |
+| 3    | Claims Handler | Reviews and confirms the adjusted settlement            | System processes payment for the adjusted amount                                              |
+| 4    | Claims Handler | Initiates subrogation for the at-fault party's share    | System creates a subrogation record (see [US-CLM-009](../user-stories/claims-subrogation.md)) |
+
+## Alternative Flow: Trafikförsäkring Personal Injury Settlement
+
+| Step | Actor          | Action                                                   | System Response                                                                        |
+| ---- | -------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1    | Claims Handler | Opens a personal injury claim with medical documentation | System displays injury details and compensation components                             |
+| 2    | Claims Handler | Enters compensation amounts per component                | System calculates total: medical costs + income loss + pain and suffering + disability |
+| 3    | Claims Handler | Reviews the total compensation                           | No deductible applies to trafikförsäkring personal injury claims                       |
+| 4    | System         | Processes interim or final payment to the injured party  | System records the payment and tracks remaining compensation if applicable             |
+
+## Settlement Calculation Rules
+
+### Repair Settlement
+
+```text
+Settlement = Approved Repair Cost − Applicable Deductible (självrisk)
+```
+
+- Repair cost is based on the approved damage assessment estimate
+- Deductible is determined by the policy terms and claim type
+- If the policyholder is partially at fault in a multi-party incident, the settlement is adjusted by the non-fault percentage
+
+### Total Loss Settlement
+
+```text
+Settlement = Vehicle Market Value − Deductible − Salvage Value
+```
+
+- Market value is the vehicle's fair market value at the time of loss
+- Salvage value is deducted if the customer retains the damaged vehicle
+- Total loss threshold: repair cost exceeds a configurable percentage (typically 75%) of market value
+
+### Glass Settlement
+
+```text
+Settlement = Glass Repair/Replacement Cost − Glass Deductible
+```
+
+- Glass claims typically have a lower deductible than other claim types
+- Repair (if possible) is preferred over full replacement
+
+### Theft Settlement
+
+```text
+If vehicle not recovered:
+  Settlement = Vehicle Market Value at Time of Theft − Deductible
+
+If vehicle recovered with damage:
+  Settlement = Repair Cost − Deductible
+```
+
+- A waiting period may apply before settling a theft claim (to allow for recovery)
+
+## Payment Methods
+
+| Method                        | Use Case                               | Details                                       |
+| ----------------------------- | -------------------------------------- | --------------------------------------------- |
+| Bank transfer to customer     | Standard settlement payment            | Uses customer's registered bank account       |
+| Direct billing to repair shop | Network shop repair                    | Shop invoices TryggFörsäkring directly        |
+| Bank transfer to third party  | Third-party liability settlement       | Payment to the injured party or their insurer |
+| Interim payment               | Personal injury with ongoing treatment | Partial payments while claim remains open     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: settlement must be calculated fairly and paid promptly; the customer must receive a clear explanation of the calculation
+- **FSA-004** — Consumer protection: settlement breakdowns must be transparent and in plain language
+- **FSA-014** — Record keeping: all settlement calculations, payment records, and supporting documentation must be retained for 10 years
+- **GDPR-003** — Claims processing: payment data (bank accounts) must be handled securely with purpose limitation
+- **GDPR-001** — Customer bank details must be collected and stored securely; used only for claim payments
+
+## Related User Stories
+
+- [US-CLM-005](../user-stories/claims-damage-assessment.md) — Assess Vehicle Damage
+- [US-CLM-007](../user-stories/claims-decision.md) — Approve or Deny a Claim
+- [US-CLM-008](../user-stories/claims-settlement.md) — Calculate and Process Settlement
+- [US-CLM-014](../user-stories/claims-repair-authorization.md) — Authorize Repairs at Network Shops

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-bonus-impact.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-bonus-impact.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 19
+---
+
+# US-CLM-010: Update Bonus Class After Claim
+
+## User Story
+
+**As the** system,
+**I want to** recalculate the customer's bonus class after a claim is settled,
+**so that** future premiums correctly reflect the customer's updated claims history.
+
+## Actors
+
+- **Primary:** System (automated process)
+- **Supporting:** [Underwriter (Riskbedömare)](../../actors/internal-actors.md#underwriter-riskbedömare), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Bonus class is the primary premium adjustment mechanism in Swedish motor insurance.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled (status "Settled" / Reglerad)
+  **WHEN** the system processes the settlement
+  **THEN** the system recalculates the policyholder's bonus class according to the bonus class rules, applying the appropriate penalty for the claim type
+
+- **GIVEN** a claim type that does not affect bonus (e.g., glass-only, animal collision)
+  **WHEN** the system evaluates bonus impact
+  **THEN** the bonus class remains unchanged and the system records that the claim was bonus-neutral
+
+- **GIVEN** a claim type that does affect bonus (e.g., collision at fault)
+  **WHEN** the system recalculates the bonus class
+  **THEN** the bonus class is reduced by the configured number of steps (typically 3 steps down for a collision claim) and the new bonus class is recorded on the policy
+
+- **GIVEN** a bonus class change has been applied
+  **WHEN** the customer views their policy
+  **THEN** the updated bonus class is displayed along with a notification explaining the change and its effect on the next renewal premium
+
+- **GIVEN** a claim is denied or withdrawn
+  **WHEN** the system evaluates bonus impact
+  **THEN** the bonus class is not affected
+
+## Bonus Class Rules (Typical)
+
+| Event                                  | Bonus Impact            |
+| -------------------------------------- | ----------------------- |
+| Claim-free year                        | +1 step (up to maximum) |
+| At-fault collision (vagnskada)         | −3 steps                |
+| Third-party liability claim (at fault) | −3 steps                |
+| Glass-only claim (glasskada)           | No impact               |
+| Animal collision (viltskada)           | No impact               |
+| Theft (stöld)                          | No impact               |
+| Fire (brand)                           | No impact               |
+| Natural damage                         | No impact               |
+| Roadside assistance (vägassistans)     | No impact               |
+
+## Bonus Class Scale (Example)
+
+| Class       | Premium Discount  | Years Claim-Free to Reach            |
+| ----------- | ----------------- | ------------------------------------ |
+| 1 (lowest)  | 0% (base premium) | N/A (entry or after multiple claims) |
+| 2           | ~10%              | 1 claim-free year from class 1       |
+| 3           | ~20%              | 1 claim-free year from class 2       |
+| 4           | ~30%              | 1 claim-free year from class 3       |
+| 5           | ~40%              | 1 claim-free year from class 4       |
+| 6           | ~50%              | 1 claim-free year from class 5       |
+| 7 (highest) | ~60%              | 1 claim-free year from class 6       |
+
+## Regulatory
+
+- **FSA-004** — Consumer protection: bonus class rules must be transparent and communicated to the customer at policy inception and at renewal
+- **FSA-010** — Fair claims settlement: bonus impact must be clearly communicated to the customer after a claim
+- **FSA-014** — Record keeping: bonus class history and all changes must be retained for the duration of the policy plus 10 years
+- **GDPR-002** — Policy administration: bonus class data is part of the policy record and follows the same retention rules
+
+## Dependencies
+
+- Depends on US-CLM-008 (Settlement) — bonus is recalculated after settlement
+- Bonus class rules defined by underwriting (depends on underwriting guidelines)
+- TFF bonus class transfer process for customers switching insurers
+
+## Notes
+
+- When a customer switches insurers, TFF coordinates the transfer of bonus class history between companies
+- Some insurers offer "bonus protection" (bonusskydd) as an add-on that prevents the first claim from affecting the bonus class — if offered by TryggFörsäkring, this must be checked before applying a bonus penalty
+- Bonus class changes take effect at the next renewal (huvudförfallodag), not immediately

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-closure.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-closure.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 24
+---
+
+# US-CLM-015: Close and Review Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** perform a final review and close a claim after all settlements and recoveries are complete,
+**so that** the claim record is finalized and statistics are updated.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Actuary (Aktuarie)](../../actors/internal-actors.md#actuary)
+
+## Priority
+
+**Must Have** — Claim closure finalizes the financial record and feeds actuarial analysis.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled and all payments processed
+  **WHEN** the claims handler initiates claim closure
+  **THEN** the system verifies that: all payments have been confirmed, all subrogation cases are resolved or written off, all required documents are attached, and the bonus class impact has been applied
+
+- **GIVEN** all closure checks pass
+  **WHEN** the claims handler closes the claim
+  **THEN** the system changes the claim status to "Closed" (Stängd), records the closure date, and calculates the total claim cost (payments minus recoveries)
+
+- **GIVEN** a claim is closed
+  **WHEN** the system processes the closure
+  **THEN** the claim data feeds into actuarial reporting: claim type, total cost, time to settlement, and other key metrics are updated in the reporting dataset
+
+- **GIVEN** a closed claim needs to be reopened
+  **WHEN** the claims handler reopens the claim (e.g., new information, disputed settlement, additional injury)
+  **THEN** the system changes the status to "Reopened" (Återöppnad), records the reason for reopening, and allows further processing
+
+- **GIVEN** a personal injury claim under trafikförsäkring
+  **WHEN** the claims handler assesses whether to close the claim
+  **THEN** the system warns if the claim is being closed within the 10-year limitation period and there may be outstanding injury developments
+
+## Claim Closure Checklist
+
+| Check                  | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| All payments confirmed | Settlement payments received by payees                |
+| Subrogation resolved   | Recovery cases closed or written off                  |
+| Documents complete     | All required documents attached to the claim          |
+| Bonus impact applied   | Policyholder's bonus class updated (if applicable)    |
+| Customer notified      | Customer informed of final settlement and closure     |
+| No pending disputes    | No active complaints or disputes related to the claim |
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: claim closure must ensure the customer has received the full settlement owed
+- **FSA-014** — Record keeping: closed claim records must be retained for 10 years after closure; the record must be complete and auditable
+- **FSA-006** — Supervisory reporting: closed claims data feeds into regulatory reports (claims frequency, severity, reserves)
+- **GDPR-003** — Claims processing: closed claim data remains subject to GDPR retention rules; data must be deleted after the retention period expires
+
+## Dependencies
+
+- Depends on US-CLM-008 (Settlement) — all payments must be complete
+- Depends on US-CLM-009 (Subrogation) — recovery cases must be resolved
+- Depends on US-CLM-010 (Bonus Impact) — bonus class must be updated
+
+## Notes
+
+- Claims closed in error can be reopened with appropriate authorization
+- Personal injury claims under trafikförsäkring may be reopened within the 10-year limitation period if the injured party's condition changes
+- Claim closure triggers reserve release in the accounting system

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-coverage-verification.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-coverage-verification.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 12
+---
+
+# US-CLM-003: Verify Coverage and Check Exclusions
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** verify that the policy was active at the time of the incident and that no exclusions apply,
+**so that** I can confirm or deny coverage before proceeding with the claim.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — Coverage verification is a prerequisite for all claims decisions.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been registered
+  **WHEN** the claims handler initiates coverage verification
+  **THEN** the system checks that the policy was active on the incident date and displays the result (covered / not covered / partially covered)
+
+- **GIVEN** a claim type is selected
+  **WHEN** the system verifies coverage
+  **THEN** it checks the policy's coverage tier against the claim type and confirms whether the specific coverage applies (e.g., collision damage requires helförsäkring)
+
+- **GIVEN** the policy has exclusions
+  **WHEN** the system performs coverage verification
+  **THEN** it evaluates applicable exclusions (e.g., racing, commercial use, unlicensed driver) and flags any that may apply to the reported circumstances
+
+- **GIVEN** a coverage verification is complete
+  **WHEN** the system displays the result
+  **THEN** the result includes: policy status at incident date, applicable coverage, deductible amount (självrisk), any flagged exclusions, and the coverage tier details
+
+- **GIVEN** coverage is denied due to exclusion or lapsed policy
+  **WHEN** the claims handler records the denial
+  **THEN** the system requires a documented denial reason and generates a denial notification to the customer explaining the reason in clear language
+
+## Common Exclusion Categories
+
+| Exclusion                  | Description                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| Policy not active          | Policy had not yet started or had been cancelled before the incident              |
+| Coverage tier insufficient | Claim type not covered by the policy's tier (e.g., collision on halvförsäkring)   |
+| Excluded use               | Vehicle was being used for an excluded purpose (racing, taxi without endorsement) |
+| Unlicensed driver          | Driver at the time of the incident did not hold a valid license                   |
+| Alcohol or drugs           | Driver was under the influence at the time of the incident                        |
+| Intentional damage         | Damage was caused intentionally by the policyholder or insured                    |
+| Waiting period             | Incident occurred during a waiting period after policy inception                  |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: coverage verification must be performed promptly; denial reasons must be clearly communicated
+- **FSA-004** — Consumer protection: denial notifications must use plain language and inform the customer of their right to dispute the decision
+- **FSA-011** — Complaints handling: denial notifications must include information about the complaints procedure
+- **GDPR-003** — Claims processing: coverage verification decisions and their rationale must be documented and retained
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) — claim must be registered before coverage can be verified
+- Requires policy data including coverage tier, active dates, and exclusion rules
+
+## Notes
+
+- Trafikförsäkring claims have special rules: even if the policyholder's own policy has exclusions, third parties injured by the vehicle are always covered under trafikförsäkring (Trafikskadelagen)
+- Coverage verification for TFF claims follows a different process (see [US-CLM-011](claims-tff.md))

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-damage-assessment.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-damage-assessment.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 14
+---
+
+# US-CLM-005: Assess Vehicle Damage
+
+## User Story
+
+**As a** claims adjuster (värderare),
+**I want to** record damage assessment results with photos and repair estimates,
+**so that** the settlement is well-documented and based on accurate valuations.
+
+## Actors
+
+- **Primary:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare), [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad)
+
+## Priority
+
+**Must Have** — Damage assessment determines whether the vehicle is repaired or declared a total loss, and drives settlement amounts.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim requires damage assessment
+  **WHEN** the claims handler assigns the assessment
+  **THEN** the system assigns the assessment to a claims adjuster and notifies the adjuster with the claim details and customer contact information
+
+- **GIVEN** a claims adjuster inspects the vehicle
+  **WHEN** the adjuster records the assessment
+  **THEN** the system captures: damage description, affected components, repair estimate (parts and labor), photos of damage, and the adjuster's assessment of whether the damage is consistent with the reported incident
+
+- **GIVEN** a repair shop provides a repair estimate
+  **WHEN** the adjuster reviews the estimate
+  **THEN** the system allows the adjuster to upload the repair shop estimate, compare it against market rates, and approve or adjust the estimate
+
+- **GIVEN** repair costs exceed a configurable percentage of the vehicle's market value
+  **WHEN** the adjuster records the assessment
+  **THEN** the system flags the vehicle for total loss evaluation and calculates the vehicle's current market value
+
+- **GIVEN** a vehicle is assessed as a total loss (totalförlust)
+  **WHEN** the adjuster records the total loss decision
+  **THEN** the system calculates the settlement amount as the vehicle's market value minus the deductible (självrisk) and minus any salvage value
+
+- **GIVEN** the assessment is complete
+  **WHEN** the adjuster submits the assessment report
+  **THEN** the system attaches the report to the claim record and notifies the claims handler that the assessment is ready for review
+
+## Damage Assessment Data
+
+| Field                 | Required    | Description                                             |
+| --------------------- | ----------- | ------------------------------------------------------- |
+| Damage description    | Yes         | Detailed description of damage observed                 |
+| Affected components   | Yes         | List of damaged vehicle parts                           |
+| Repair estimate       | Yes         | Cost breakdown: parts, labor, paint                     |
+| Photos                | Yes         | Minimum required photos of damage                       |
+| Repair vs. total loss | Yes         | Adjuster's recommendation                               |
+| Market value          | Conditional | Required if total loss is being considered              |
+| Salvage value         | Conditional | Required if vehicle is a total loss                     |
+| Consistency check     | Yes         | Whether damage is consistent with the reported incident |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: damage assessment must be performed promptly and objectively; the assessment must support fair settlement
+- **FSA-014** — Record keeping: assessment reports, photos, and estimates must be retained for 10 years
+- **GDPR-003** — Claims processing: photos must capture damage only; incidental capture of bystanders or non-relevant personal data should be avoided
+- **GDPR-001** — Customer and third-party data processed during assessment must follow data minimization principles
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) and US-CLM-003 (Coverage Verification)
+- Repair shop integration for estimates and repair authorization
+
+## Notes
+
+- For glass-only claims (glasskada), a simplified assessment process may apply where the customer goes directly to an authorized glass repair shop without a separate adjuster inspection
+- Remote assessment via customer-submitted photos and video may be used for minor damage to reduce cycle time

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-decision.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-decision.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 16
+---
+
+# US-CLM-007: Approve or Deny a Claim
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** make an informed decision to approve, deny, or refer a claim for further investigation,
+**so that** claims are resolved fairly and in accordance with policy terms and regulations.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — The claims decision is the central step in the claims lifecycle.
+
+## Acceptance Criteria
+
+- **GIVEN** coverage has been verified, liability determined, and damage assessed
+  **WHEN** the claims handler reviews all claim evidence
+  **THEN** the system presents a decision summary showing: coverage status, liability split, damage assessment, fraud screening result, deductible amount, and calculated settlement amount
+
+- **GIVEN** a claims handler approves a claim
+  **WHEN** the handler records the approval
+  **THEN** the system changes the claim status to "Approved" (Godkänd), records the approved settlement amount, and advances the claim to settlement processing
+
+- **GIVEN** a claims handler denies a claim
+  **WHEN** the handler records the denial
+  **THEN** the system requires a denial reason from a predefined list (plus free text explanation), changes the claim status to "Denied" (Avslagen), and generates a denial letter to the customer
+
+- **GIVEN** a claim is denied
+  **WHEN** the denial notification is sent to the customer
+  **THEN** the notification includes: the specific reason for denial, the relevant policy terms or exclusions, information about the complaints procedure (FSA-011), and reference to external dispute resolution (ARN)
+
+- **GIVEN** a claim exceeds the handler's settlement authority
+  **WHEN** the handler attempts to approve the claim
+  **THEN** the system routes the claim to a senior handler or manager for approval based on configurable authority limits
+
+- **GIVEN** a claims handler refers a claim for further investigation
+  **WHEN** the handler records the referral
+  **THEN** the system changes the claim status to "Under investigation" (Under utredning) and notifies the appropriate team
+
+## Claims Decision Authority
+
+| Decision Level | Maximum Settlement Amount                        | Approver                                         |
+| -------------- | ------------------------------------------------ | ------------------------------------------------ |
+| Level 1        | Up to configurable threshold (e.g., SEK 50,000)  | Claims handler                                   |
+| Level 2        | Up to configurable threshold (e.g., SEK 250,000) | Senior claims handler                            |
+| Level 3        | Above Level 2 threshold                          | Claims manager                                   |
+| Total loss     | Any amount                                       | Requires adjuster report + Level 2 or 3 approval |
+
+## Denial Reason Categories
+
+| Category                | Example                                                         |
+| ----------------------- | --------------------------------------------------------------- |
+| Policy not active       | Policy had lapsed before the incident date                      |
+| Coverage not applicable | Claim type not covered by the policy tier                       |
+| Exclusion applies       | Excluded use, unlicensed driver, intoxication                   |
+| Fraudulent claim        | Fraud investigation confirmed                                   |
+| Insufficient evidence   | Unable to verify the claim with available evidence              |
+| Late reporting          | Claim reported beyond reasonable timeframe without valid reason |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: decisions must be made promptly; denial reasons must be clear and justified
+- **FSA-004** — Consumer protection: denial notifications must use plain language
+- **FSA-011** — Complaints handling: denial notifications must inform the customer of the complaints procedure and external dispute resolution options (ARN, Personförsäkringsnämnden)
+- **FSA-014** — Record keeping: all claims decisions, rationale, and supporting evidence must be retained for 10 years
+- **GDPR-003** — Claims processing: decision records containing personal data must follow retention and access control requirements
+
+## Dependencies
+
+- Depends on US-CLM-003 (Coverage Verification)
+- Depends on US-CLM-004 (Liability Determination)
+- Depends on US-CLM-005 (Damage Assessment)
+- Depends on US-CLM-006 (Fraud Screening)
+
+## Notes
+
+- Customers must be informed of the decision within a reasonable timeframe as defined by internal SLAs
+- All decision records must be auditable for regulatory inspection

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-fnol.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-fnol.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 10
+---
+
+# US-CLM-001: Report a Claim Online (FNOL)
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** report a motor insurance claim online with photos and incident details,
+**so that** the claims process starts immediately without waiting for office hours.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+
+## Priority
+
+**Must Have** — FNOL is the entry point for all claims processing.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active motor insurance policy
+  **WHEN** the customer opens the claims reporting form (skadeanmälan) on web or mobile
+  **THEN** the system displays claim types matching the customer's coverage tier (trafikförsäkring, halvförsäkring, or helförsäkring)
+
+- **GIVEN** a customer is filling out the FNOL form
+  **WHEN** the customer enters incident details (date, time, location, description)
+  **THEN** the system validates that the incident date falls within the policy's active coverage period
+
+- **GIVEN** a customer is reporting a claim
+  **WHEN** the customer uploads photos of the damage
+  **THEN** the system accepts common image formats (JPEG, PNG, HEIF) up to a configurable maximum file size and stores them linked to the claim record
+
+- **GIVEN** a customer has completed the FNOL form
+  **WHEN** the customer submits the claim report
+  **THEN** the system creates a claim record with a unique claim number (skadenummer), links it to the policy, and sends the customer a confirmation with the claim number
+
+- **GIVEN** a claim has been submitted
+  **WHEN** the system processes the new claim
+  **THEN** the system assigns the claim to a claims handler based on claim type and workload rules
+
+- **GIVEN** a customer must verify their identity for the claim
+  **WHEN** the customer signs in
+  **THEN** the system authenticates the customer via [BankID](../../actors/external-actors.md#bankid)
+
+## Claim Types Supported
+
+The FNOL form must support the following motor claim types:
+
+| Claim Type            | Swedish Term | Coverage Required               |
+| --------------------- | ------------ | ------------------------------- |
+| Collision             | Vagnskada    | Helförsäkring                   |
+| Theft                 | Stöld        | Halvförsäkring or Helförsäkring |
+| Fire                  | Brand        | Halvförsäkring or Helförsäkring |
+| Glass damage          | Glasskada    | Halvförsäkring or Helförsäkring |
+| Natural damage        | Naturskada   | Halvförsäkring or Helförsäkring |
+| Animal collision      | Viltskada    | Halvförsäkring or Helförsäkring |
+| Third-party liability | Trafikskada  | Trafikförsäkring                |
+| Personal injury       | Personskada  | Trafikförsäkring                |
+| Roadside assistance   | Vägassistans | Halvförsäkring or Helförsäkring |
+
+## Data Captured at FNOL
+
+| Field                  | Required    | Description                            |
+| ---------------------- | ----------- | -------------------------------------- |
+| Incident date and time | Yes         | When the event occurred                |
+| Incident location      | Yes         | Address or coordinates                 |
+| Incident description   | Yes         | Free-text description of what happened |
+| Claim type             | Yes         | Selected from coverage-eligible types  |
+| Police report number   | Conditional | Required for theft, third-party claims |
+| Other parties involved | Conditional | Name, registration number, insurer     |
+| Witness information    | No          | Name and contact details               |
+| Photos                 | No          | Damage photos, scene photos            |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the claims process must begin promptly upon FNOL
+- **FSA-014** — Record keeping: the FNOL and all associated data must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization principles; collect only what is necessary for the claim
+- **GDPR-001** — Customer identity verification via BankID before claim submission
+- **IDD-005** — Claims handling disclosure: the IPID must have informed the customer about how to make a claim (pre-purchase)
+
+## Dependencies
+
+- Active policy must exist (depends on Quote and Bind — Issue #10)
+- Actor definitions (depends on Actors — Issue #5)
+- BankID integration for identity verification
+
+## Notes
+
+- Customers may also report claims by phone; the claims handler uses the same underlying claim registration process (see [US-CLM-002](claims-registration.md))
+- Third-party claimants (not policyholders) may also submit FNOL for trafikförsäkring claims; these follow a different identity verification flow

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-fraud-screening.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-fraud-screening.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 15
+---
+
+# US-CLM-006: Screen Claims for Fraud
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want** the system to flag potential fraud indicators on incoming claims,
+**so that** I can investigate suspicious claims before settlement.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Claims Adjuster (Värderare)](../../actors/internal-actors.md#claims-adjuster-värderare)
+
+## Priority
+
+**Should Have** — Fraud screening protects the insurance portfolio and is an industry expectation, though manual investigation can serve as an interim process.
+
+## Acceptance Criteria
+
+- **GIVEN** a new claim is registered
+  **WHEN** the system processes the claim
+  **THEN** it runs automated fraud screening rules and assigns a fraud risk score or flag (low / medium / high)
+
+- **GIVEN** a claim is flagged as medium or high fraud risk
+  **WHEN** the claims handler views the claim
+  **THEN** the system displays the specific fraud indicators that triggered the flag, allowing the handler to review and either escalate for investigation or clear the flag with documented rationale
+
+- **GIVEN** a claims handler escalates a claim for fraud investigation
+  **WHEN** the handler marks the claim for investigation
+  **THEN** the system records the escalation reason, pauses settlement processing, and notifies the designated fraud investigation team
+
+- **GIVEN** a fraud investigation is complete
+  **WHEN** the investigator records the outcome (confirmed fraud / cleared)
+  **THEN** the system updates the claim status accordingly and, if fraud is confirmed, records the decision for potential criminal referral to police
+
+## Fraud Indicators
+
+The following indicators should be evaluated during automated screening:
+
+| Indicator                        | Description                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| Recent policy inception          | Claim filed shortly after policy was purchased                                       |
+| Coverage upgrade before claim    | Coverage tier was increased shortly before the incident                              |
+| Multiple recent claims           | Policyholder has filed multiple claims in a short period                             |
+| Inconsistent incident details    | Details in the FNOL conflict with known facts (e.g., location, time)                 |
+| Claim amount disproportionate    | Claimed damage amount is disproportionate to the incident description                |
+| Known fraud network              | Policyholder, vehicle, or linked parties appear in the industry fraud database (GSR) |
+| Total loss on high-value vehicle | Vehicle declared total loss with suspicious circumstances                            |
+| Late reporting                   | Significant delay between incident date and FNOL                                     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: fraud investigation must not unreasonably delay settlement of legitimate claims
+- **GDPR-006** — Fraud detection and prevention: fraud screening must follow data minimization; access full claims details only for flagged cases; automated screening should use pseudonymized data where possible
+- **GDPR-003** — Claims processing: fraud investigation data is sensitive and must be protected with strict access controls
+- **FSA-014** — Record keeping: fraud investigation records must be retained for 10 years from investigation closure
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration) — claim must be registered before screening
+- Integration with GSR (Gemensamt skadeanmälningsregister) — industry fraud database
+
+## Notes
+
+- Automated fraud screening supplements but does not replace the claims handler's professional judgment
+- If a claim is referred to police for criminal investigation, the insurer must have a lawful basis under GDPR to share personal data with law enforcement
+- Fraud detection results must never be disclosed to the claimant during an active investigation

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-liability.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-liability.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 13
+---
+
+# US-CLM-004: Determine Liability
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** determine liability for a motor incident based on evidence and applicable rules,
+**so that** settlement responsibility is correctly assigned between parties.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Priority
+
+**Must Have** — Liability determination drives settlement calculations and subrogation.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves a collision between two or more vehicles
+  **WHEN** the claims handler assesses liability
+  **THEN** the system allows the handler to record liability as a percentage split (e.g., 100/0, 50/50, 70/30) for each party involved
+
+- **GIVEN** a claim involves a single-vehicle incident (e.g., driving off the road)
+  **WHEN** the claims handler assesses liability
+  **THEN** the system records the policyholder as fully liable and calculates settlement based on policy coverage and deductible
+
+- **GIVEN** a claim involves a third-party claimant under trafikförsäkring
+  **WHEN** the claims handler assesses liability
+  **THEN** the system records the policyholder's liability to the third party and flags the claim for potential subrogation if the third party was partially at fault
+
+- **GIVEN** a police report is available
+  **WHEN** the claims handler uploads or links the report
+  **THEN** the system attaches the report to the claim record and allows the handler to reference it in the liability determination
+
+- **GIVEN** liability has been determined
+  **WHEN** the handler records the decision
+  **THEN** the system stores the liability decision with the rationale, evidence references, and the handler's identity, and advances the claim to the next stage
+
+- **GIVEN** a multi-party incident involves another insurer
+  **WHEN** liability is shared
+  **THEN** the system records the other insurer's details (company name, claim reference) for inter-company settlement coordination
+
+## Liability Scenarios
+
+| Scenario                     | Typical Liability Split    | Notes                                               |
+| ---------------------------- | -------------------------- | --------------------------------------------------- |
+| Rear-end collision           | 100% rear driver           | Presumption under Swedish traffic law               |
+| Intersection collision       | Varies (50/50 or assessed) | Based on right-of-way rules                         |
+| Single-vehicle accident      | 100% policyholder          | Collision coverage applies if helförsäkring         |
+| Parked vehicle hit           | 100% striking vehicle      | Third-party liability claim                         |
+| Animal collision (viltskada) | No fault                   | Covered as a natural hazard                         |
+| Unknown third party          | Special handling           | May involve TFF if the other driver is unidentified |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: liability decisions must be evidence-based and documented; the claimant must be informed of the outcome
+- **FSA-014** — Record keeping: liability determinations and supporting evidence must be retained for 10 years
+- **GDPR-003** — Claims processing: police reports and third-party personal data must follow data minimization and purpose limitation
+- **GDPR-001** — Third-party personal data (names, registration numbers) collected during liability assessment must have a lawful basis
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-003 (Coverage Verification) — coverage must be confirmed before liability impacts settlement
+
+## Notes
+
+- Under Trafikskadelagen, personal injury liability for trafikförsäkring is strict — the insurer pays regardless of fault, though recovery from the at-fault party may follow (see [US-CLM-009](claims-subrogation.md))
+- Animal collisions (viltskada) are treated as no-fault events and do not affect the policyholder's bonus class

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-personal-injury.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-personal-injury.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 21
+---
+
+# US-CLM-012: Handle Personal Injury Claims Under Trafikförsäkring
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** process personal injury claims under trafikförsäkring with appropriate medical documentation and compensation schedules,
+**so that** injured parties receive fair compensation as required by Trafikskadelagen.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Medical Provider (Vårdgivare)](../../actors/external-actors.md#medical-provider-vårdgivare), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Personal injury claims under trafikförsäkring are legally mandated with a 10-year claim window.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves personal injury from a traffic incident
+  **WHEN** the claims handler registers the injury claim
+  **THEN** the system creates a personal injury claim record linked to the main claim, with separate tracking for medical documentation and injury-specific compensation
+
+- **GIVEN** a personal injury claim requires medical documentation
+  **WHEN** the claims handler requests medical records
+  **THEN** the system sends a consent-based request to the medical provider and tracks the document request status
+
+- **GIVEN** medical documentation has been received
+  **WHEN** the claims handler reviews the injury claim
+  **THEN** the system stores the medical documentation under special category data protection (GDPR Article 9) with restricted access limited to authorized claims handlers
+
+- **GIVEN** a personal injury settlement is being calculated
+  **WHEN** the claims handler processes the injury claim
+  **THEN** the system supports calculation of compensation components: medical costs (sjukvårdskostnader), income loss (inkomstförlust), pain and suffering (sveda och värk), and permanent disability (invaliditet)
+
+- **GIVEN** a personal injury claimant is not the policyholder
+  **WHEN** a third-party injured person files a claim
+  **THEN** the system allows the third party to file directly against the policyholder's trafikförsäkring, as mandated by Trafikskadelagen
+
+- **GIVEN** a personal injury claim has a long recovery period
+  **WHEN** the claims handler manages the claim over time
+  **THEN** the system supports interim payments and keeps the claim open for the duration of treatment, up to the 10-year limitation period
+
+## Compensation Components
+
+| Component            | Swedish Term            | Description                                    |
+| -------------------- | ----------------------- | ---------------------------------------------- |
+| Medical costs        | Sjukvårdskostnader      | Actual medical treatment costs                 |
+| Income loss          | Inkomstförlust          | Lost earnings during recovery                  |
+| Pain and suffering   | Sveda och värk          | Compensation for pain during the acute phase   |
+| Permanent disability | Invaliditet             | Compensation for lasting impairment            |
+| Loss of amenity      | Lyte och men            | Compensation for reduced quality of life       |
+| Future income loss   | Framtida inkomstförlust | Long-term earnings reduction due to disability |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: personal injury claims must be handled fairly with particular care given the vulnerability of injured claimants
+- **FSA-007** — Mandatory trafikförsäkring: personal injury coverage is the core purpose of trafikförsäkring under Trafikskadelagen
+- **FSA-014** — Record keeping: personal injury claim records must be retained for 10 years from claim closure (Trafikskadelagen allows claims up to 10 years after the injury)
+- **GDPR-003** — Claims processing: medical data is special category personal data (Article 9) requiring explicit consent or legal obligation basis
+- **GDPR-001** — Data minimization: collect only medical data directly relevant to the injury claim; do not request the claimant's full medical history
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-004 (Liability Determination) — though trafikförsäkring injury liability is strict
+- Medical provider integration for medical records exchange
+
+## Notes
+
+- Under Trafikskadelagen, personal injury liability is strict — the insurer must compensate the injured party regardless of fault
+- Personal injury claims often remain open for extended periods (months to years) due to ongoing treatment
+- The 10-year limitation period means claims can be filed long after the original policy period has ended
+- Medical data must be stored with the highest level of access control and is subject to DPIA requirements

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-registration.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-registration.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 11
+---
+
+# US-CLM-002: Register and Manage Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** see all policy details and coverage at claim registration,
+**so that** I can verify coverage quickly and register the claim accurately.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Must Have** — Claim registration is the foundation for all subsequent claims processing.
+
+## Acceptance Criteria
+
+- **GIVEN** a claims handler opens a new or incoming FNOL
+  **WHEN** the handler views the claim
+  **THEN** the system displays the linked policy details including: coverage tier, active coverages, deductible amounts (självrisk), policy start and end dates, bonus class, and named drivers
+
+- **GIVEN** a claims handler is registering a claim
+  **WHEN** the handler confirms the claim type
+  **THEN** the system automatically verifies that the policy's coverage tier includes the reported claim type and displays a clear coverage confirmation or denial indicator
+
+- **GIVEN** a claim involves a phone-reported incident (not self-service FNOL)
+  **WHEN** the claims handler enters the incident details manually
+  **THEN** the system creates a claim record using the same data structure and validation rules as the online FNOL form
+
+- **GIVEN** a claim has been registered
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system displays the claim status, all attached documents, the incident timeline, and the assigned handler
+
+- **GIVEN** multiple claims exist for the same policy
+  **WHEN** the claims handler views the policy
+  **THEN** the system displays the complete claim history for that policy, sortable by date and status
+
+- **GIVEN** a claim requires additional information
+  **WHEN** the claims handler requests documents from the customer
+  **THEN** the system sends a notification to the customer specifying which documents are needed and tracks the outstanding request
+
+## Claim Status Lifecycle
+
+Claims follow this status progression:
+
+| Status                 | Swedish Term          | Description                         |
+| ---------------------- | --------------------- | ----------------------------------- |
+| Registered             | Registrerad           | Claim received and recorded         |
+| Under investigation    | Under utredning       | Handler is investigating            |
+| Awaiting information   | Väntar på information | Documents or details needed         |
+| Assessment in progress | Under värdering       | Damage being assessed               |
+| Decision pending       | Beslut väntande       | Ready for approve/deny decision     |
+| Approved               | Godkänd               | Claim approved for settlement       |
+| Denied                 | Avslagen              | Claim denied with documented reason |
+| Settled                | Reglerad              | Payment made, claim completed       |
+| Closed                 | Stängd                | Claim finalized and closed          |
+| Reopened               | Återöppnad            | Previously closed claim reopened    |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: claims must be registered promptly and handled without undue delay
+- **FSA-014** — Record keeping: all claim records, status changes, and communications must be retained for 10 years after claim closure
+- **GDPR-003** — Claims processing: access to claim data must be limited to authorized claims staff; personal data must follow purpose limitation
+- **GDPR-001** — Data minimization: only collect information necessary for the claim investigation
+
+## Dependencies
+
+- Depends on US-CLM-001 (FNOL) for online-submitted claims
+- Requires access to policy data (depends on Quote and Bind — Issue #10)
+
+## Notes
+
+- Claims handlers must be able to register claims for both policyholders and third-party claimants
+- The claim record must support linking to external references: police report numbers, medical record references, repair shop estimates

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-repair-authorization.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-repair-authorization.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 23
+---
+
+# US-CLM-014: Authorize Repairs at Network Shops
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** authorize repairs at network shops with direct billing,
+**so that** the customer gets fast service and only pays the deductible.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Repair Shop (Verkstad)](../../actors/external-actors.md#repair-shop-verkstad), [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Should Have** — Direct repair authorization streamlines the customer experience and controls repair costs.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been approved and repair is needed
+  **WHEN** the claims handler selects a repair approach
+  **THEN** the system displays a list of authorized network repair shops, with the option to filter by location, availability, and specialization
+
+- **GIVEN** the claims handler selects a network repair shop
+  **WHEN** the handler authorizes the repair
+  **THEN** the system sends a repair authorization to the shop including: claim number, vehicle details, approved repair scope, maximum authorized amount, and the customer's contact information
+
+- **GIVEN** a repair authorization has been sent
+  **WHEN** the repair shop accepts the assignment
+  **THEN** the system updates the claim status and notifies the customer with the shop's name, address, and contact details
+
+- **GIVEN** the repair is complete
+  **WHEN** the repair shop submits the final invoice
+  **THEN** the system validates the invoice against the authorized amount, processes payment to the shop (minus the customer's deductible), and records the transaction
+
+- **GIVEN** the repair cost exceeds the authorized amount
+  **WHEN** the repair shop requests additional authorization
+  **THEN** the system routes the request to the claims handler for approval before the shop proceeds with additional work
+
+- **GIVEN** the customer chooses a non-network repair shop
+  **WHEN** the customer submits the repair invoice for reimbursement
+  **THEN** the system processes reimbursement to the customer (repair cost minus deductible) after validation of the invoice
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: customers must have the option to choose their own repair shop, even if direct billing is only available at network shops
+- **FSA-004** — Consumer protection: the customer must be informed of the difference between network and non-network repair options
+- **GDPR-003** — Claims processing: personal data shared with repair shops must be limited to what is necessary for the repair (data minimization)
+- **GDPR-001** — Data processing agreements must be in place with all network repair shops
+
+## Dependencies
+
+- Depends on US-CLM-007 (Claims Decision) — claim must be approved
+- Depends on US-CLM-005 (Damage Assessment) — repair scope must be defined
+- Repair shop integration for authorization and invoicing
+
+## Notes
+
+- Network repair shops have pre-agreed labor rates and parts pricing, which helps control costs
+- Glass-only claims typically go directly to authorized glass repair shops (e.g., Carglass, Ryds Bilglas) with a simplified authorization process
+- Rental car arrangement during repair may be covered under the policy — this should be coordinated with the repair authorization

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-settlement.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-settlement.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 17
+---
+
+# US-CLM-008: Calculate and Process Settlement
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** calculate the correct settlement amount including deductibles, depreciation, and applicable rules,
+**so that** the customer receives a fair and accurate payment.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [Payment Provider (Betalningsleverantör)](../../actors/external-actors.md#payment-provider)
+
+## Priority
+
+**Must Have** — Settlement calculation and payment are the core outcome of the claims process.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been approved
+  **WHEN** the system calculates the settlement
+  **THEN** the calculation includes: repair cost (or market value for total loss), minus the applicable deductible (självrisk), minus depreciation if applicable, adjusted for the liability split
+
+- **GIVEN** a customer wants to know their deductible before proceeding
+  **WHEN** the customer views claim details
+  **THEN** the system displays the applicable deductible amount (självrisk) based on the claim type and policy terms
+
+- **GIVEN** a claim is for vehicle repair
+  **WHEN** the settlement is calculated
+  **THEN** the system uses the approved repair estimate from the damage assessment (US-CLM-005) and subtracts the deductible
+
+- **GIVEN** a claim is for a total loss (totalförlust)
+  **WHEN** the settlement is calculated
+  **THEN** the system calculates: vehicle market value at time of loss, minus deductible, minus salvage value (if the customer retains the vehicle)
+
+- **GIVEN** a settlement has been calculated
+  **WHEN** the claims handler approves the payment
+  **THEN** the system initiates payment to the designated payee (customer bank account, repair shop, or third party) via the payment provider
+
+- **GIVEN** a settlement payment is for direct repair shop billing
+  **WHEN** the claims handler authorizes the repair
+  **THEN** the system sends a repair authorization to the repair shop with the approved repair scope and amount, and the customer pays only the deductible to the shop
+
+- **GIVEN** a settlement is paid
+  **WHEN** the payment is confirmed by the payment provider
+  **THEN** the system updates the claim status to "Settled" (Reglerad) and records the payment details (amount, date, payee, payment reference)
+
+## Settlement Calculation Rules
+
+| Claim Type            | Calculation                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Repair (vagnskada)    | Approved repair cost − deductible                                                                                  |
+| Total loss            | Market value − deductible − salvage value                                                                          |
+| Glass (glasskada)     | Repair/replacement cost − glass deductible (often lower)                                                           |
+| Theft (stöld)         | Market value at time of theft − deductible (if not recovered); repair cost − deductible (if recovered with damage) |
+| Third-party liability | Actual damage to third party (no deductible for trafikförsäkring injury claims)                                    |
+| Personal injury       | Per Trafikskadelagen compensation schedule (medical costs, income loss, pain and suffering)                        |
+
+## Deductible (Självrisk) Structure
+
+| Coverage                           | Typical Deductible Range | Notes                                           |
+| ---------------------------------- | ------------------------ | ----------------------------------------------- |
+| Collision (vagnskada)              | SEK 3,000–10,000         | Selected at policy purchase                     |
+| Theft (stöld)                      | SEK 1,500–3,000          | May vary by policy                              |
+| Fire (brand)                       | SEK 1,500–3,000          | May vary by policy                              |
+| Glass (glasskada)                  | SEK 500–2,000            | Often a lower deductible                        |
+| Trafikförsäkring (personal injury) | No deductible            | Mandatory coverage, no excess for injury claims |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: settlement amounts must be fair and calculated transparently; payment must be made without undue delay
+- **FSA-004** — Consumer protection: the settlement calculation must be explained to the customer in plain language
+- **FSA-014** — Record keeping: settlement calculations, payment records, and all supporting documentation must be retained for 10 years
+- **GDPR-003** — Claims processing: payment data (bank account details) must be handled securely and retained per GDPR requirements
+
+## Dependencies
+
+- Depends on US-CLM-007 (Claims Decision) — claim must be approved before settlement
+- Depends on US-CLM-005 (Damage Assessment) — for repair cost or total loss valuation
+- Payment provider integration for disbursement
+
+## Notes
+
+- For multi-party claims where liability is shared, the settlement amount is adjusted according to the liability split (e.g., if the policyholder is 30% at fault, they bear 30% of their own damage)
+- VAT handling on repair costs must follow applicable rules
+- Customers may dispute settlement amounts through the complaints procedure (FSA-011)

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-subrogation.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-subrogation.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 18
+---
+
+# US-CLM-009: Recover Costs Through Subrogation
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** initiate recovery of settlement costs from at-fault third parties or their insurers,
+**so that** TryggFörsäkring recovers costs it is entitled to under Swedish law.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)
+
+## Priority
+
+**Should Have** — Subrogation recovery directly impacts the company's loss ratio and financial performance.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim has been settled where a third party was at fault
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system flags the claim as eligible for subrogation (regressrätt) and displays the recoverable amount based on the liability split
+
+- **GIVEN** a subrogation-eligible claim is identified
+  **WHEN** the claims handler initiates subrogation
+  **THEN** the system records the target party (at-fault driver, their insurer), the amount to be recovered, and the legal basis for recovery
+
+- **GIVEN** subrogation involves another Swedish insurer
+  **WHEN** the claims handler sends a recovery request
+  **THEN** the system supports inter-company claims settlement via TFF-defined processes and formats
+
+- **GIVEN** a subrogation payment is received
+  **WHEN** the payment is recorded
+  **THEN** the system updates the claim record with the recovered amount, adjusts the net claim cost, and closes the subrogation case
+
+- **GIVEN** a subrogation attempt is unsuccessful
+  **WHEN** the claims handler records the outcome
+  **THEN** the system records the reason (uninsured party, disputed liability, uncollectible) and closes the subrogation case with the unrecovered amount documented
+
+## Regulatory
+
+- **FSA-010** — Fair claims settlement: subrogation activities must not delay settlement to the policyholder; the policyholder must be made whole first
+- **FSA-014** — Record keeping: all subrogation records, communications, and outcomes must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data shared with third-party insurers for subrogation must have a lawful basis (contract performance, legal obligation)
+- **GDPR-001** — Data shared in subrogation must follow data minimization — only share what is necessary for the recovery claim
+
+## Dependencies
+
+- Depends on US-CLM-004 (Liability Determination) — liability must be established before subrogation
+- Depends on US-CLM-008 (Settlement) — settlement must be paid before pursuing recovery
+- TFF integration for inter-company settlement
+
+## Notes
+
+- Under Swedish law, the insurer may subrogate to the policyholder's rights against a third party after paying the claim
+- Subrogation does not apply to trafikförsäkring personal injury claims between insurers in the same way — these follow Trafikskadelagen rules
+- The customer's deductible should also be recovered in the subrogation process where possible

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-tff.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-tff.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 20
+---
+
+# US-CLM-011: Process TFF Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** process claims involving uninsured, unknown, or foreign vehicles via TFF,
+**so that** victims are compensated even when the at-fault vehicle lacks valid Swedish insurance.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare)
+- **Supporting:** [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff), [Police (Polis)](../../actors/external-actors.md#police-polis)
+
+## Priority
+
+**Should Have** — TFF claims are a regulatory requirement for trafikförsäkring participation, though volume is lower than standard claims.
+
+## Acceptance Criteria
+
+- **GIVEN** a claim involves a vehicle that is not insured with any Swedish insurer
+  **WHEN** the claims handler identifies the vehicle as uninsured
+  **THEN** the system allows the claim to be flagged as a TFF claim and routes it through the TFF claims process
+
+- **GIVEN** a claim involves an unidentified vehicle (hit-and-run, smitning)
+  **WHEN** the claims handler records the claim
+  **THEN** the system allows the claim to be registered without an opposing party's vehicle details and flags it for TFF processing, requiring a police report reference
+
+- **GIVEN** a claim involves a foreign-registered vehicle
+  **WHEN** the claims handler identifies the vehicle as foreign
+  **THEN** the system supports recording the foreign vehicle details and insurer (if known), and routes the claim through TFF's international claims coordination (green card system)
+
+- **GIVEN** a TFF claim has been processed
+  **WHEN** the claims handler submits the claim to TFF
+  **THEN** the system transmits the claim data to TFF in the required format and tracks the TFF response (acceptance, request for additional information, or rejection)
+
+- **GIVEN** TFF has settled a claim
+  **WHEN** TFF communicates the settlement decision
+  **THEN** the system records the TFF settlement details and closes the claim accordingly
+
+## TFF Claim Scenarios
+
+| Scenario                              | Description                                                  | Special Requirements                                     |
+| ------------------------------------- | ------------------------------------------------------------ | -------------------------------------------------------- |
+| Uninsured vehicle (oförsäkrat fordon) | At-fault vehicle has no valid trafikförsäkring               | Police report recommended; TFF covers the victim         |
+| Unidentified vehicle (okänt fordon)   | Hit-and-run where the vehicle cannot be identified           | Police report required; TFF covers personal injury only  |
+| Foreign vehicle                       | Vehicle registered abroad, involved in an incident in Sweden | Green card or other international insurance coordination |
+| TFF cost recovery                     | TFF recovers costs from the uninsured vehicle owner          | Not handled by TryggFörsäkring — TFF pursues directly    |
+
+## Regulatory
+
+- **FSA-007** — Mandatory trafikförsäkring: the TFF system exists to ensure victims are always compensated, even when the at-fault vehicle is uninsured
+- **FSA-008** — TFF membership: TryggFörsäkring must participate in TFF's claims coordination as a condition of selling trafikförsäkring
+- **FSA-010** — Fair claims settlement: TFF claims must be handled with the same fairness and timeliness standards as standard claims
+- **FSA-014** — Record keeping: TFF claim records, communications, and outcomes must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data shared with TFF must follow data minimization; share only required fields
+- **GDPR-004** — TFF reporting: data exchange with TFF is based on legal obligation under Trafikskadelagen
+
+## Dependencies
+
+- Depends on US-CLM-002 (Claim Registration)
+- Depends on US-CLM-004 (Liability Determination)
+- TFF system integration for claim submission and response handling
+
+## Notes
+
+- TFF claims can take longer to resolve due to the inter-organization coordination
+- For hit-and-run claims where the vehicle is unidentified, TFF only covers personal injury (not vehicle damage)
+- Foreign vehicle claims may involve correspondence with the vehicle's home-country insurer through the green card system

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-tracking.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/claims-tracking.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 22
+---
+
+# US-CLM-013: Track Claim Status
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** track my claim status online,
+**so that** I know what is happening with my claim without calling customer service.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+
+## Priority
+
+**Should Have** — Claim tracking improves customer experience and reduces call center volume.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active claim
+  **WHEN** the customer logs in and navigates to claims
+  **THEN** the system displays all the customer's claims with their current status, claim number, and claim type
+
+- **GIVEN** a customer views a specific claim
+  **WHEN** the customer opens the claim details
+  **THEN** the system displays: claim status, a timeline of status changes with dates, the assigned handler's name, any outstanding information requests, the applicable deductible (självrisk), and estimated settlement amount (when available)
+
+- **GIVEN** a claim status changes
+  **WHEN** the system updates the claim
+  **THEN** the customer receives a notification (email or push notification based on preferences) with the new status and any action required from the customer
+
+- **GIVEN** a claim has an outstanding information request
+  **WHEN** the customer views the claim
+  **THEN** the system clearly displays what additional information or documents are needed and allows the customer to upload them directly
+
+- **GIVEN** a claim has been settled
+  **WHEN** the customer views the claim
+  **THEN** the system displays the final settlement amount, payment date, and payment method
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: customers must be kept informed of claim progress
+- **FSA-004** — Consumer protection: claim status information must be clear and in plain language
+- **GDPR-003** — Claims processing: the customer's view must only display their own claim data; access requires authentication via BankID
+
+## Dependencies
+
+- Depends on US-CLM-001 (FNOL) and US-CLM-002 (Claim Registration)
+- BankID integration for customer authentication
+
+## Notes
+
+- Third-party claimants (not policyholders) should also have limited claim tracking capability for their filed claims
+- The claims handler's internal notes and fraud investigation details must never be visible to the customer

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
@@ -45,3 +45,26 @@ Mid-term adjustments and policy lifecycle management — see [Policy Administrat
 | US-PA-012 | Reissue Policy Document                     | Customer       |
 | US-PA-013 | Manage Policy Status                        | Underwriter    |
 | US-PA-014 | Review High-Risk Amendments                 | Underwriter    |
+
+## Claims Handling
+
+User stories covering the full motor insurance claims lifecycle, from first
+notification of loss through settlement and closure.
+
+| ID                                            | Title                                                | Priority    |
+| --------------------------------------------- | ---------------------------------------------------- | ----------- |
+| [US-CLM-001](claims-fnol.md)                  | Report a Claim Online (FNOL)                         | Must Have   |
+| [US-CLM-002](claims-registration.md)          | Register and Manage Claims                           | Must Have   |
+| [US-CLM-003](claims-coverage-verification.md) | Verify Coverage and Check Exclusions                 | Must Have   |
+| [US-CLM-004](claims-liability.md)             | Determine Liability                                  | Must Have   |
+| [US-CLM-005](claims-damage-assessment.md)     | Assess Vehicle Damage                                | Must Have   |
+| [US-CLM-006](claims-fraud-screening.md)       | Screen Claims for Fraud                              | Should Have |
+| [US-CLM-007](claims-decision.md)              | Approve or Deny a Claim                              | Must Have   |
+| [US-CLM-008](claims-settlement.md)            | Calculate and Process Settlement                     | Must Have   |
+| [US-CLM-009](claims-subrogation.md)           | Recover Costs Through Subrogation                    | Should Have |
+| [US-CLM-010](claims-bonus-impact.md)          | Update Bonus Class After Claim                       | Must Have   |
+| [US-CLM-011](claims-tff.md)                   | Process TFF Claims                                   | Should Have |
+| [US-CLM-012](claims-personal-injury.md)       | Handle Personal Injury Claims Under Trafikförsäkring | Must Have   |
+| [US-CLM-013](claims-tracking.md)              | Track Claim Status                                   | Should Have |
+| [US-CLM-014](claims-repair-authorization.md)  | Authorize Repairs at Network Shops                   | Should Have |
+| [US-CLM-015](claims-closure.md)               | Close and Review Claims                              | Must Have   |


### PR DESCRIPTION
## Summary
- Documents the full motor insurance claims handling lifecycle with 15 user stories and 4 use cases
- Covers FNOL, registration, coverage verification, liability, damage assessment, fraud screening, claims decision, settlement, subrogation, bonus class impact, TFF claims, personal injury, claim tracking, repair authorization, and closure
- Every user story includes acceptance criteria with GIVEN/WHEN/THEN format, regulatory traceability (FSA, GDPR, IDD), actor references, and data models

## Changes
- **15 new user stories** (US-CLM-001 through US-CLM-015) in `phase-1-motor/user-stories/`
- **4 new use cases** (UC-CLM-001 through UC-CLM-004) in `phase-1-motor/use-cases/`
- Updated `user-stories/index.md` and `use-cases/index.md` with claims handling tables
- All files mirrored in both `versioned_docs/version-phase-1/` and `docs/`

## Testing
- [x] markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] Docusaurus build succeeds (no broken links or references)

Closes #12

🤖 Generated with Claude Code