### PR TITLE
docs(#43): Add cancellation user story US-CAN-012 and update cross-references

### DIFF
--- a/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -156,3 +156,4 @@ This use case describes the end-to-end policy cancellation process — from the 
 - [US-CAN-009](../user-stories/cancellation-death.md) — Cancel Due to Death of Policyholder
 - [US-CAN-010](../user-stories/cancellation-insurer-initiated.md) — Insurer-Initiated Cancellation
 - [US-CAN-011](../user-stories/cancellation-eu-online-button.md) — EU Online Cancellation Button (EU 2023/2673)
+- [US-CAN-012](../user-stories/cancellation-preview-refund.md) — View Refund Amount Before Confirming Cancellation

--- a/docs/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -119,3 +119,4 @@ This use case details the premium refund calculation and payment process followi
 - [US-CAN-001](../user-stories/cancellation-cooling-off.md) — Cancel Policy Within Cooling-Off Period (Ångerrätt)
 - [US-CAN-003](../user-stories/cancellation-vehicle-sold.md) — Cancel Due to Vehicle Sold
 - [US-CAN-004](../user-stories/cancellation-vehicle-deregistered.md) — Cancel Due to Vehicle Scrapped or Deregistered
+- [US-CAN-012](../user-stories/cancellation-preview-refund.md) — View Refund Amount Before Confirming Cancellation

--- a/docs/phase-1-motor/user-stories/cancellation-preview-refund.md
+++ b/docs/phase-1-motor/user-stories/cancellation-preview-refund.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 41
+---
+
+# US-CAN-012: View Refund Amount Before Confirming Cancellation
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** see the exact refund amount and calculation breakdown before confirming my cancellation,
+**so that** I can make an informed decision about whether to proceed with the cancellation.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** System
+
+## Priority
+
+**Must Have** — Transparent refund information before confirmation is required by consumer protection rules and the upcoming EU 2023/2673 directive.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has initiated a cancellation and the cancellation type and effective date have been determined
+  **WHEN** the system calculates the refund
+  **THEN** the system displays a detailed refund breakdown before the customer confirms the cancellation
+
+- **GIVEN** the refund breakdown is displayed
+  **WHEN** the customer reviews it
+  **THEN** the breakdown includes: annual premium, period start date, cancellation effective date, days used, days remaining, gross refund amount, any deductions, and net refund amount
+
+- **GIVEN** a cancellation where no refund is applicable (e.g., huvudförfallodag)
+  **WHEN** the system displays the cancellation summary
+  **THEN** the system clearly states that no refund applies and explains why (coverage runs to the end of the paid period)
+
+- **GIVEN** the customer has reviewed the refund breakdown
+  **WHEN** they decide not to proceed
+  **THEN** the system allows the customer to cancel the cancellation request without any penalty or change to their policy
+
+- **GIVEN** the customer confirms the cancellation after reviewing the refund
+  **WHEN** the cancellation is processed
+  **THEN** the refund amount matches the amount shown in the preview (unless the effective date changes due to processing delays)
+
+- **GIVEN** the refund preview is displayed via the online cancellation function
+  **WHEN** the customer views the summary on a mobile device or desktop
+  **THEN** the refund information is clearly formatted and accessible, meeting EU 2023/2673 transparency requirements
+
+## Business Rules
+
+| Rule       | Description                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| BR-CAN-043 | The refund amount must be displayed before the customer can confirm a cancellation              |
+| BR-CAN-044 | The refund breakdown must show the calculation method so the customer can verify the amount     |
+| BR-CAN-045 | If the refund amount changes between preview and processing, the customer must be notified      |
+| BR-CAN-046 | The cancellation request can be abandoned at any point before confirmation without consequences |
+
+## Regulatory
+
+- **FSA-004** — Consumer protection and fair treatment: transparent refund information enables informed decision-making
+- **FSA-013** — Cancellation and cooling-off rights: refund terms must be clearly communicated before the customer commits
+- **IDD-003** — Pre-contractual information: refund rules should have been disclosed before purchase; the preview reinforces transparency at point of cancellation
+- **EU 2023/2673** — Online cancellation function: the cancellation flow (including refund preview) must be clear and accessible on digital channels
+
+## Dependencies
+
+- Refund calculation logic (see [US-CAN-007](cancellation-refund.md))
+- Cancellation processing workflow (see [UC-CAN-001](../use-cases/uc-cancellation-processing.md))
+- Refund calculation use case (see [UC-CAN-002](../use-cases/uc-refund-calculation.md))
+- Online cancellation button (see [US-CAN-011](cancellation-eu-online-button.md))
+
+## Notes
+
+- This story focuses on the customer-facing refund preview experience; the underlying calculation logic is defined in [US-CAN-007](cancellation-refund.md) and [UC-CAN-002](../use-cases/uc-refund-calculation.md)
+- The refund preview is a key step in the cancellation wizard (UC-CAN-001, Step 6–7) and must not be skippable
+- For insurer-initiated cancellations, the refund preview is shown to operations staff rather than the customer

--- a/docs/phase-1-motor/user-stories/index.md
+++ b/docs/phase-1-motor/user-stories/index.md
@@ -45,6 +45,7 @@ User stories covering motor insurance policy cancellation scenarios, including c
 | [US-CAN-009](cancellation-death.md)                | Cancel Due to Death of Policyholder                     | Must Have   |
 | [US-CAN-010](cancellation-insurer-initiated.md)    | Insurer-Initiated Cancellation                          | Must Have   |
 | [US-CAN-011](cancellation-eu-online-button.md)     | EU Online Cancellation Button (EU 2023/2673)            | Must Have   |
+| [US-CAN-012](cancellation-preview-refund.md)       | View Refund Amount Before Confirming Cancellation       | Must Have   |
 
 ## Claims Handling
 

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -156,3 +156,4 @@ This use case describes the end-to-end policy cancellation process — from the 
 - [US-CAN-009](../user-stories/cancellation-death.md) — Cancel Due to Death of Policyholder
 - [US-CAN-010](../user-stories/cancellation-insurer-initiated.md) — Insurer-Initiated Cancellation
 - [US-CAN-011](../user-stories/cancellation-eu-online-button.md) — EU Online Cancellation Button (EU 2023/2673)
+- [US-CAN-012](../user-stories/cancellation-preview-refund.md) — View Refund Amount Before Confirming Cancellation

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -119,3 +119,4 @@ This use case details the premium refund calculation and payment process followi
 - [US-CAN-001](../user-stories/cancellation-cooling-off.md) — Cancel Policy Within Cooling-Off Period (Ångerrätt)
 - [US-CAN-003](../user-stories/cancellation-vehicle-sold.md) — Cancel Due to Vehicle Sold
 - [US-CAN-004](../user-stories/cancellation-vehicle-deregistered.md) — Cancel Due to Vehicle Scrapped or Deregistered
+- [US-CAN-012](../user-stories/cancellation-preview-refund.md) — View Refund Amount Before Confirming Cancellation

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/cancellation-preview-refund.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/cancellation-preview-refund.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 41
+---
+
+# US-CAN-012: View Refund Amount Before Confirming Cancellation
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** see the exact refund amount and calculation breakdown before confirming my cancellation,
+**so that** I can make an informed decision about whether to proceed with the cancellation.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)
+- **Supporting:** System
+
+## Priority
+
+**Must Have** — Transparent refund information before confirmation is required by consumer protection rules and the upcoming EU 2023/2673 directive.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has initiated a cancellation and the cancellation type and effective date have been determined
+  **WHEN** the system calculates the refund
+  **THEN** the system displays a detailed refund breakdown before the customer confirms the cancellation
+
+- **GIVEN** the refund breakdown is displayed
+  **WHEN** the customer reviews it
+  **THEN** the breakdown includes: annual premium, period start date, cancellation effective date, days used, days remaining, gross refund amount, any deductions, and net refund amount
+
+- **GIVEN** a cancellation where no refund is applicable (e.g., huvudförfallodag)
+  **WHEN** the system displays the cancellation summary
+  **THEN** the system clearly states that no refund applies and explains why (coverage runs to the end of the paid period)
+
+- **GIVEN** the customer has reviewed the refund breakdown
+  **WHEN** they decide not to proceed
+  **THEN** the system allows the customer to cancel the cancellation request without any penalty or change to their policy
+
+- **GIVEN** the customer confirms the cancellation after reviewing the refund
+  **WHEN** the cancellation is processed
+  **THEN** the refund amount matches the amount shown in the preview (unless the effective date changes due to processing delays)
+
+- **GIVEN** the refund preview is displayed via the online cancellation function
+  **WHEN** the customer views the summary on a mobile device or desktop
+  **THEN** the refund information is clearly formatted and accessible, meeting EU 2023/2673 transparency requirements
+
+## Business Rules
+
+| Rule       | Description                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| BR-CAN-043 | The refund amount must be displayed before the customer can confirm a cancellation              |
+| BR-CAN-044 | The refund breakdown must show the calculation method so the customer can verify the amount     |
+| BR-CAN-045 | If the refund amount changes between preview and processing, the customer must be notified      |
+| BR-CAN-046 | The cancellation request can be abandoned at any point before confirmation without consequences |
+
+## Regulatory
+
+- **FSA-004** — Consumer protection and fair treatment: transparent refund information enables informed decision-making
+- **FSA-013** — Cancellation and cooling-off rights: refund terms must be clearly communicated before the customer commits
+- **IDD-003** — Pre-contractual information: refund rules should have been disclosed before purchase; the preview reinforces transparency at point of cancellation
+- **EU 2023/2673** — Online cancellation function: the cancellation flow (including refund preview) must be clear and accessible on digital channels
+
+## Dependencies
+
+- Refund calculation logic (see [US-CAN-007](cancellation-refund.md))
+- Cancellation processing workflow (see [UC-CAN-001](../use-cases/uc-cancellation-processing.md))
+- Refund calculation use case (see [UC-CAN-002](../use-cases/uc-refund-calculation.md))
+- Online cancellation button (see [US-CAN-011](cancellation-eu-online-button.md))
+
+## Notes
+
+- This story focuses on the customer-facing refund preview experience; the underlying calculation logic is defined in [US-CAN-007](cancellation-refund.md) and [UC-CAN-002](../use-cases/uc-refund-calculation.md)
+- The refund preview is a key step in the cancellation wizard (UC-CAN-001, Step 6–7) and must not be skippable
+- For insurer-initiated cancellations, the refund preview is shown to operations staff rather than the customer

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
@@ -64,6 +64,7 @@ User stories covering motor insurance policy cancellation scenarios, including c
 | [US-CAN-009](cancellation-death.md)                | Cancel Due to Death of Policyholder                     | Must Have   |
 | [US-CAN-010](cancellation-insurer-initiated.md)    | Insurer-Initiated Cancellation                          | Must Have   |
 | [US-CAN-011](cancellation-eu-online-button.md)     | EU Online Cancellation Button (EU 2023/2673)            | Must Have   |
+| [US-CAN-012](cancellation-preview-refund.md)       | View Refund Amount Before Confirming Cancellation       | Must Have   |
 
 ## Claims Handling
 


### PR DESCRIPTION
## Summary

- Adds the missing US-CAN-012 user story (View Refund Amount Before Confirming Cancellation) with full acceptance criteria, business rules, and regulatory references
- Updates index files and use case cross-references (UC-CAN-001, UC-CAN-002) to include US-CAN-012
- All existing cancellation content (US-CAN-001–011, UC-CAN-001–002) was already in place; this PR completes the set

## Changes

- **New:** `cancellation-preview-refund.md` in both `versioned_docs/` and `docs/` user-stories directories
- **Updated:** `user-stories/index.md` — added US-CAN-012 row to Cancellations table
- **Updated:** `uc-cancellation-processing.md` — added US-CAN-012 to Related User Stories
- **Updated:** `uc-refund-calculation.md` — added US-CAN-012 to Related User Stories

## Testing

- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files pass
- [x] `npm run build` — builds successfully, no broken links

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)