### PR TITLE
docs(#46): Move version dropdown to right side of navbar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -78,7 +78,7 @@ const config: Config = {
         },
         {
           type: "docsVersionDropdown",
-          position: "left",
+          position: "right",
         },
         {
           href: "https://github.com/Agentic-software-factory/insurance-platform-requirements",


### PR DESCRIPTION
## Summary
- Moves the version dropdown (Phase 1 / Phase 2 selector) from left to right side of the navbar
- Improves visual hierarchy: left side for navigation, right side for meta-controls
- Navbar order is now: [TryggFörsäkring] [Requirements] ... [Version Dropdown ▾] [GitHub]

## Changes
- `docusaurus.config.ts` — changed `docsVersionDropdown` position from `"left"` to `"right"`

## Testing
- [x] Markdown lint passes (zero warnings)
- [x] Prettier formatting passes
- [x] `npm run build` succeeds with zero errors

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)