### PR TITLE
docs(#44): Create dedicated trafikforsakring user stories and use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/index.md
+++ b/docs/phase-1-motor/use-cases/index.md
@@ -43,16 +43,15 @@ processing.
 
 ## Trafikforsakring (Mandatory Third-Party Liability)
 
-The [Trafikforsakring](trafikforsakring.md) use case (UC-TF-001) describes
-the management of mandatory third-party liability insurance under
-Trafikskadelagen (1975:1410). It covers:
+The [Trafikforsakring Compliance Lifecycle](trafikforsakring.md) use case
+(UC-TRF-001) describes the end-to-end management of mandatory third-party
+liability insurance under Trafikskadelagen (1975:1410). It covers:
 
-- Transportstyrelsen registration upon policy binding
-- Coverage gap prevention at cancellation
-- Personal injury claims under strict liability (Trafikskadelagen)
-- TFF statutory reporting obligations
-- Uninsured and foreign vehicle claims handling
-- Cross-border coverage via the Green Card system
+- Policy issuance: mandatory coverage check and Transportstyrelsen registration
+- Ongoing monitoring: coverage gap detection and TFF reporting
+- Claims: personal injury processing under strict liability and TFF coordination
+- Cross-border: Green Card issuance and EU motor insurance directive compliance
+- Cancellation: replacement coverage verification and TFF notification
 
 ## Renewals
 

--- a/docs/phase-1-motor/use-cases/trafikforsakring.md
+++ b/docs/phase-1-motor/use-cases/trafikforsakring.md
@@ -2,7 +2,7 @@
 sidebar_position: 3
 ---
 
-# Use Case: Trafikforsakring (Mandatory Third-Party Liability)
+# Use Case: Trafikforsakring Compliance Lifecycle
 
 End-to-end use case for managing mandatory third-party liability insurance
 (trafikforsakring) at TryggForsakring. Covers Transportstyrelsen registration,
@@ -14,8 +14,8 @@ via the Green Card system.
 
 | Field                | Value                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------- |
-| **Use Case ID**      | UC-TF-001                                                                             |
-| **Name**             | Manage Trafikforsakring (Mandatory Third-Party Liability)                             |
+| **Use Case ID**      | UC-TRF-001                                                                            |
+| **Name**             | Trafikforsakring Compliance Lifecycle                                                 |
 | **Primary Actor**    | System (automated processes)                                                          |
 | **Secondary Actors** | Claims Handler, Compliance Officer, Private Customer                                  |
 | **Goal**             | Ensure continuous mandatory coverage, compliant reporting, and proper claims handling |
@@ -25,19 +25,19 @@ via the Green Card system.
 
 ## Stakeholders and Interests
 
-| Stakeholder        | Interest                                                                 |
-| ------------------ | ------------------------------------------------------------------------ |
-| Private Customer   | Continuous legal coverage; clear information about mandatory obligations |
-| Claims Handler     | Correct claim classification; clear personal injury process              |
-| Compliance Officer | Timely TFF reporting; regulatory compliance evidence                     |
-| Underwriter        | Accurate trafikforsakring pricing within product tiers                   |
-| Transportstyrelsen | Timely and accurate insurance status notifications                       |
-| TFF                | Membership reporting compliance; uninsured vehicle claims cooperation    |
-| FSA                | Regulatory oversight of mandatory insurance obligations                  |
+| Stakeholder                                                                                      | Interest                                                                 |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)                     | Continuous legal coverage; clear information about mandatory obligations |
+| [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare) | Correct claim classification; clear personal injury process              |
+| [Compliance Officer](../../actors/internal-actors.md#compliance-officer)                         | Timely TFF reporting; regulatory compliance evidence                     |
+| Underwriter                                                                                      | Accurate trafikforsakring pricing within product tiers                   |
+| [Transportstyrelsen](../../actors/external-actors.md#transportstyrelsen)                         | Timely and accurate insurance status notifications                       |
+| [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)                           | Membership reporting compliance; uninsured vehicle claims cooperation    |
+| FSA                                                                                              | Regulatory oversight of mandatory insurance obligations                  |
 
 ## Main Success Scenario
 
-### 1. Trafikforsakring Registration at Binding
+### 1. Policy Issuance — Mandatory Coverage Check and Registration
 
 1. A motor insurance policy is bound (any tier: trafik, halv, or hel)
 2. System validates that trafikforsakring is included as mandatory base
@@ -54,16 +54,20 @@ via the Green Card system.
 6. Vehicle registry now reflects valid trafikforsakring with
    TryggForsakring
 
-### 2. Continuous Coverage Enforcement
+### 2. Ongoing Monitoring — Coverage Gap Detection and TFF Reporting
 
-1. When a cancellation request is received, system queries
+1. System continuously monitors for vehicles where trafikforsakring
+   coverage is about to end without confirmed replacement
+2. When a cancellation request is received, system queries
    Transportstyrelsen for replacement coverage status
-2. If replacement coverage is confirmed, system processes the cancellation
+3. If replacement coverage is confirmed, system processes the cancellation
    with aligned coverage dates
-3. System notifies Transportstyrelsen of the coverage end date
-4. System records the cancellation details and replacement policy reference
+4. System notifies Transportstyrelsen of the coverage end date
+5. System records the cancellation details and replacement policy reference
+6. At each reporting period, system generates TFF statutory reports
+7. Compliance officer reviews and submits reports to TFF
 
-### 3. Personal Injury Claim Processing
+### 3. Claims — Personal Injury Processing Under Strict Liability
 
 1. A traffic accident is reported and a claim is registered
 2. Claims handler classifies the claim type (personal injury, property
@@ -80,19 +84,16 @@ via the Green Card system.
 7. System processes the payment to the injured person
 8. Claim data is included in TFF reporting
 
-### 4. TFF Statutory Reporting
+### 4. Claims — TFF Claims Coordination
 
-1. Reporting period end date is reached
-2. System generates the TFF report with:
-   - Active trafikforsakring policy count
-   - Premium income
-   - Claims paid and reserved
-   - Uninsured vehicle claims data
-3. Compliance officer reviews and validates the report
-4. Report is submitted to TFF in the required format
-5. System records the submission and any acknowledgement
+1. Claims handler identifies a claim involving an uninsured, unidentified,
+   or foreign vehicle
+2. System verifies the vehicle's insurance status via Transportstyrelsen
+3. System generates a TFF referral with all required claim documentation
+4. TFF processes the claim and provides settlement decision
+5. System records the TFF settlement and closes the claim
 
-### 5. Cross-Border Coverage
+### 5. Cross-Border — Green Card Issuance and EU Compliance
 
 1. Customer requests a Green Card for international travel
 2. System generates a Green Card document with policy details and
@@ -231,10 +232,10 @@ via the Green Card system.
 
 ## Related User Stories
 
-- [TF-01: Register Trafikforsakring with Transportstyrelsen](../user-stories/trafikforsakring.md#tf-01-register-trafikforsakring-with-transportstyrelsen)
-- [TF-02: Automatic Trafikforsakring Inclusion](../user-stories/trafikforsakring.md#tf-02-automatic-trafikforsakring-inclusion)
-- [TF-03: Process Personal Injury Claims Under Trafikskadelagen](../user-stories/trafikforsakring.md#tf-03-process-personal-injury-claims-under-trafikskadelagen)
-- [TF-04: Prevent Coverage Gaps](../user-stories/trafikforsakring.md#tf-04-prevent-coverage-gaps)
-- [TF-05: Generate TFF Statutory Reports](../user-stories/trafikforsakring.md#tf-05-generate-tff-statutory-reports)
-- [TF-06: Route Uninsured and Foreign Vehicle Claims to TFF](../user-stories/trafikforsakring.md#tf-06-route-uninsured-and-foreign-vehicle-claims-to-tff)
-- [TF-07: Cross-Border Coverage via Green Card System](../user-stories/trafikforsakring.md#tf-07-cross-border-coverage-via-green-card-system)
+- [US-TRF-001: Ensure Continuous Mandatory Coverage](../user-stories/trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)
+- [US-TRF-002: Report to TFF](../user-stories/trafikforsakring.md#us-trf-002-report-to-tff)
+- [US-TRF-003: Handle TFF Data Exchange](../user-stories/trafikforsakring.md#us-trf-003-handle-tff-data-exchange)
+- [US-TRF-004: Process Personal Injury Under Trafikskadelagen](../user-stories/trafikforsakring.md#us-trf-004-process-personal-injury-under-trafikskadelagen)
+- [US-TRF-005: Issue Green Card for EU Travel](../user-stories/trafikforsakring.md#us-trf-005-issue-green-card-for-eu-travel)
+- [US-TRF-006: Handle Trafikforsakringsavgift Notification](../user-stories/trafikforsakring.md#us-trf-006-handle-trafikforsakringsavgift-notification)
+- [US-TRF-007: Verify TFF Membership Compliance](../user-stories/trafikforsakring.md#us-trf-007-verify-tff-membership-compliance)

--- a/docs/phase-1-motor/user-stories/index.md
+++ b/docs/phase-1-motor/user-stories/index.md
@@ -74,18 +74,20 @@ notification of loss through settlement and closure.
 
 The [trafikforsakring user stories](trafikforsakring.md) cover mandatory
 third-party liability insurance under Trafikskadelagen (1975:1410), including
-Transportstyrelsen registration, coverage gap prevention, personal injury
-claims, TFF reporting, and cross-border coverage:
+continuous coverage monitoring, TFF reporting and data exchange, personal injury
+claims, Green Card issuance, and TFF membership compliance. See also the
+[cross-reference index](trafikforsakring-cross-references.md) for
+trafikforsakring content in other epics.
 
-| ID    | Actor              | Summary                                                  |
-| ----- | ------------------ | -------------------------------------------------------- |
-| TF-01 | System             | Register trafikforsakring with Transportstyrelsen        |
-| TF-02 | Customer           | Automatic trafikforsakring inclusion in any motor policy |
-| TF-03 | Claims Handler     | Process personal injury claims under Trafikskadelagen    |
-| TF-04 | System             | Prevent policy cancellation without replacement coverage |
-| TF-05 | Compliance Officer | Generate TFF statutory reports                           |
-| TF-06 | Claims Handler     | Route uninsured/foreign vehicle claims to TFF            |
-| TF-07 | Customer           | Cross-border coverage via Green Card system              |
+| ID         | Actor              | Summary                                        |
+| ---------- | ------------------ | ---------------------------------------------- |
+| US-TRF-001 | System             | Ensure continuous mandatory coverage           |
+| US-TRF-002 | System             | Report to TFF                                  |
+| US-TRF-003 | System             | Handle TFF data exchange                       |
+| US-TRF-004 | Claims Handler     | Process personal injury under Trafikskadelagen |
+| US-TRF-005 | Customer           | Issue Green Card for EU travel                 |
+| US-TRF-006 | System             | Handle trafikforsakringsavgift notification    |
+| US-TRF-007 | Compliance Officer | Verify TFF membership compliance               |
 
 ## Renewals
 

--- a/docs/phase-1-motor/user-stories/trafikforsakring-cross-references.md
+++ b/docs/phase-1-motor/user-stories/trafikforsakring-cross-references.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+---
+
+# Trafikforsakring — Cross-Reference Index
+
+Trafikforsakring (mandatory third-party liability) requirements are spread
+across multiple epics. This page provides a consolidated index linking to all
+trafikforsakring-related content, so that compliance reviewers and developers
+can find everything from one place.
+
+For the dedicated trafikforsakring user stories, see
+[Trafikforsakring User Stories](trafikforsakring.md). For the consolidated use
+case, see
+[UC-TRF-001: Trafikforsakring Compliance Lifecycle](../use-cases/trafikforsakring.md).
+
+## Quote and Bind
+
+| Reference | Title                     | Trafikforsakring Relevance                                                             |
+| --------- | ------------------------- | -------------------------------------------------------------------------------------- |
+| QNB-01    | Get a Quick Quote         | Trafikforsakring is the mandatory base tier included in every quote                    |
+| QNB-04    | Compare Coverage Tiers    | All tiers include trafikforsakring as the non-removable base; tier comparison explains |
+| QNB-08    | Notify Transportstyrelsen | Transportstyrelsen is notified of new trafikforsakring upon policy binding             |
+
+## Policy Administration
+
+| Reference | Title                                                                   | Trafikforsakring Relevance                                          |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| US-PA-011 | [Notify Transportstyrelsen of Policy Changes](policy-administration.md) | Transportstyrelsen is notified when trafikforsakring status changes |
+
+## Policy Cancellations
+
+| Reference  | Title                                                                                  | Trafikforsakring Relevance                                                 |
+| ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| US-CAN-005 | [Verify Replacement Trafikforsakring](cancellation-replacement-coverage.md)            | Replacement trafikforsakring must be verified before cancellation proceeds |
+| US-CAN-006 | [Notify Transportstyrelsen of Policy Cancellation](cancellation-transportstyrelsen.md) | Transportstyrelsen notified when trafikforsakring coverage ends            |
+
+## Claims Handling
+
+| Reference  | Title                                                                             | Trafikforsakring Relevance                                               |
+| ---------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| US-CLM-011 | [Process TFF Claims](claims-tff.md)                                               | TFF claims for uninsured, unknown, and foreign vehicles                  |
+| US-CLM-012 | [Handle Personal Injury Claims Under Trafikforsakring](claims-personal-injury.md) | Personal injury claims processed under Trafikskadelagen strict liability |
+
+## Underwriting Rules and Bonus System
+
+| Reference | Title                     | Trafikforsakring Relevance                                    |
+| --------- | ------------------------- | ------------------------------------------------------------- |
+| UWB-01    | Coverage Tier Definitions | Defines trafikforsakring scope within coverage tier structure |
+
+## Regulatory Requirements
+
+| Reference | Title                                                                   | Trafikforsakring Relevance                                    |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| FSA-007   | [Mandatory Trafikforsakring](../../regulatory/fsa-requirements.md)      | Legal requirement for all registered vehicles                 |
+| FSA-008   | [TFF Membership Obligation](../../regulatory/fsa-requirements.md)       | TFF membership required for insurers selling trafikforsakring |
+| FSA-009   | [Transportstyrelsen Notification](../../regulatory/fsa-requirements.md) | Timely notification of insurance status changes               |
+| FSA-010   | [Fair Claims Settlement](../../regulatory/fsa-requirements.md)          | Personal injury claims must be handled fairly                 |
+| FSA-013   | [Cooling-Off Period Rules](../../regulatory/fsa-requirements.md)        | Coverage gap prevention during cooling-off cancellations      |
+
+## Mapping to Dedicated Trafikforsakring Stories
+
+The following table maps cross-referenced content to the dedicated
+trafikforsakring user stories, showing where each topic is covered in depth.
+
+| Topic                              | Other Epic References         | Dedicated Story                                                                             |
+| ---------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| Mandatory base tier                | QNB-01, QNB-04, UWB-01        | [US-TRF-001](trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)           |
+| Transportstyrelsen notifications   | QNB-08, US-PA-011, US-CAN-006 | [US-TRF-001](trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)           |
+| TFF reporting                      | FSA-008                       | [US-TRF-002](trafikforsakring.md#us-trf-002-report-to-tff)                                  |
+| TFF data exchange                  | US-CLM-011                    | [US-TRF-003](trafikforsakring.md#us-trf-003-handle-tff-data-exchange)                       |
+| Personal injury (strict liability) | US-CLM-012                    | [US-TRF-004](trafikforsakring.md#us-trf-004-process-personal-injury-under-trafikskadelagen) |
+| Green Card / cross-border          | FSA-007, EU Motor Ins. Dir.   | [US-TRF-005](trafikforsakring.md#us-trf-005-issue-green-card-for-eu-travel)                 |
+| Coverage gap / penalty fee         | US-CAN-005                    | [US-TRF-006](trafikforsakring.md#us-trf-006-handle-trafikforsakringsavgift-notification)    |
+| TFF membership compliance          | FSA-008                       | [US-TRF-007](trafikforsakring.md#us-trf-007-verify-tff-membership-compliance)               |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
@@ -72,16 +72,15 @@ management process. It covers:
 
 ## Trafikforsakring (Mandatory Third-Party Liability)
 
-The [Trafikforsakring](trafikforsakring.md) use case (UC-TF-001) describes
-the management of mandatory third-party liability insurance under
-Trafikskadelagen (1975:1410). It covers:
+The [Trafikforsakring Compliance Lifecycle](trafikforsakring.md) use case
+(UC-TRF-001) describes the end-to-end management of mandatory third-party
+liability insurance under Trafikskadelagen (1975:1410). It covers:
 
-- Transportstyrelsen registration upon policy binding
-- Coverage gap prevention at cancellation
-- Personal injury claims under strict liability (Trafikskadelagen)
-- TFF statutory reporting obligations
-- Uninsured and foreign vehicle claims handling
-- Cross-border coverage via the Green Card system
+- Policy issuance: mandatory coverage check and Transportstyrelsen registration
+- Ongoing monitoring: coverage gap detection and TFF reporting
+- Claims: personal injury processing under strict liability and TFF coordination
+- Cross-border: Green Card issuance and EU motor insurance directive compliance
+- Cancellation: replacement coverage verification and TFF notification
 
 ## Renewals
 

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/trafikforsakring.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/trafikforsakring.md
@@ -2,7 +2,7 @@
 sidebar_position: 3
 ---
 
-# Use Case: Trafikforsakring (Mandatory Third-Party Liability)
+# Use Case: Trafikforsakring Compliance Lifecycle
 
 End-to-end use case for managing mandatory third-party liability insurance
 (trafikforsakring) at TryggForsakring. Covers Transportstyrelsen registration,
@@ -14,8 +14,8 @@ via the Green Card system.
 
 | Field                | Value                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------- |
-| **Use Case ID**      | UC-TF-001                                                                             |
-| **Name**             | Manage Trafikforsakring (Mandatory Third-Party Liability)                             |
+| **Use Case ID**      | UC-TRF-001                                                                            |
+| **Name**             | Trafikforsakring Compliance Lifecycle                                                 |
 | **Primary Actor**    | System (automated processes)                                                          |
 | **Secondary Actors** | Claims Handler, Compliance Officer, Private Customer                                  |
 | **Goal**             | Ensure continuous mandatory coverage, compliant reporting, and proper claims handling |
@@ -25,19 +25,19 @@ via the Green Card system.
 
 ## Stakeholders and Interests
 
-| Stakeholder        | Interest                                                                 |
-| ------------------ | ------------------------------------------------------------------------ |
-| Private Customer   | Continuous legal coverage; clear information about mandatory obligations |
-| Claims Handler     | Correct claim classification; clear personal injury process              |
-| Compliance Officer | Timely TFF reporting; regulatory compliance evidence                     |
-| Underwriter        | Accurate trafikforsakring pricing within product tiers                   |
-| Transportstyrelsen | Timely and accurate insurance status notifications                       |
-| TFF                | Membership reporting compliance; uninsured vehicle claims cooperation    |
-| FSA                | Regulatory oversight of mandatory insurance obligations                  |
+| Stakeholder                                                                                      | Interest                                                                 |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [Customer (Privatkund)](../../actors/internal-actors.md#customer-privatkund)                     | Continuous legal coverage; clear information about mandatory obligations |
+| [Claims Handler (Skadereglerare)](../../actors/internal-actors.md#claims-handler-skadereglerare) | Correct claim classification; clear personal injury process              |
+| [Compliance Officer](../../actors/internal-actors.md#compliance-officer)                         | Timely TFF reporting; regulatory compliance evidence                     |
+| Underwriter                                                                                      | Accurate trafikforsakring pricing within product tiers                   |
+| [Transportstyrelsen](../../actors/external-actors.md#transportstyrelsen)                         | Timely and accurate insurance status notifications                       |
+| [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)                           | Membership reporting compliance; uninsured vehicle claims cooperation    |
+| FSA                                                                                              | Regulatory oversight of mandatory insurance obligations                  |
 
 ## Main Success Scenario
 
-### 1. Trafikforsakring Registration at Binding
+### 1. Policy Issuance — Mandatory Coverage Check and Registration
 
 1. A motor insurance policy is bound (any tier: trafik, halv, or hel)
 2. System validates that trafikforsakring is included as mandatory base
@@ -54,16 +54,20 @@ via the Green Card system.
 6. Vehicle registry now reflects valid trafikforsakring with
    TryggForsakring
 
-### 2. Continuous Coverage Enforcement
+### 2. Ongoing Monitoring — Coverage Gap Detection and TFF Reporting
 
-1. When a cancellation request is received, system queries
+1. System continuously monitors for vehicles where trafikforsakring
+   coverage is about to end without confirmed replacement
+2. When a cancellation request is received, system queries
    Transportstyrelsen for replacement coverage status
-2. If replacement coverage is confirmed, system processes the cancellation
+3. If replacement coverage is confirmed, system processes the cancellation
    with aligned coverage dates
-3. System notifies Transportstyrelsen of the coverage end date
-4. System records the cancellation details and replacement policy reference
+4. System notifies Transportstyrelsen of the coverage end date
+5. System records the cancellation details and replacement policy reference
+6. At each reporting period, system generates TFF statutory reports
+7. Compliance officer reviews and submits reports to TFF
 
-### 3. Personal Injury Claim Processing
+### 3. Claims — Personal Injury Processing Under Strict Liability
 
 1. A traffic accident is reported and a claim is registered
 2. Claims handler classifies the claim type (personal injury, property
@@ -80,19 +84,16 @@ via the Green Card system.
 7. System processes the payment to the injured person
 8. Claim data is included in TFF reporting
 
-### 4. TFF Statutory Reporting
+### 4. Claims — TFF Claims Coordination
 
-1. Reporting period end date is reached
-2. System generates the TFF report with:
-   - Active trafikforsakring policy count
-   - Premium income
-   - Claims paid and reserved
-   - Uninsured vehicle claims data
-3. Compliance officer reviews and validates the report
-4. Report is submitted to TFF in the required format
-5. System records the submission and any acknowledgement
+1. Claims handler identifies a claim involving an uninsured, unidentified,
+   or foreign vehicle
+2. System verifies the vehicle's insurance status via Transportstyrelsen
+3. System generates a TFF referral with all required claim documentation
+4. TFF processes the claim and provides settlement decision
+5. System records the TFF settlement and closes the claim
 
-### 5. Cross-Border Coverage
+### 5. Cross-Border — Green Card Issuance and EU Compliance
 
 1. Customer requests a Green Card for international travel
 2. System generates a Green Card document with policy details and
@@ -231,10 +232,10 @@ via the Green Card system.
 
 ## Related User Stories
 
-- [TF-01: Register Trafikforsakring with Transportstyrelsen](../user-stories/trafikforsakring.md#tf-01-register-trafikforsakring-with-transportstyrelsen)
-- [TF-02: Automatic Trafikforsakring Inclusion](../user-stories/trafikforsakring.md#tf-02-automatic-trafikforsakring-inclusion)
-- [TF-03: Process Personal Injury Claims Under Trafikskadelagen](../user-stories/trafikforsakring.md#tf-03-process-personal-injury-claims-under-trafikskadelagen)
-- [TF-04: Prevent Coverage Gaps](../user-stories/trafikforsakring.md#tf-04-prevent-coverage-gaps)
-- [TF-05: Generate TFF Statutory Reports](../user-stories/trafikforsakring.md#tf-05-generate-tff-statutory-reports)
-- [TF-06: Route Uninsured and Foreign Vehicle Claims to TFF](../user-stories/trafikforsakring.md#tf-06-route-uninsured-and-foreign-vehicle-claims-to-tff)
-- [TF-07: Cross-Border Coverage via Green Card System](../user-stories/trafikforsakring.md#tf-07-cross-border-coverage-via-green-card-system)
+- [US-TRF-001: Ensure Continuous Mandatory Coverage](../user-stories/trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)
+- [US-TRF-002: Report to TFF](../user-stories/trafikforsakring.md#us-trf-002-report-to-tff)
+- [US-TRF-003: Handle TFF Data Exchange](../user-stories/trafikforsakring.md#us-trf-003-handle-tff-data-exchange)
+- [US-TRF-004: Process Personal Injury Under Trafikskadelagen](../user-stories/trafikforsakring.md#us-trf-004-process-personal-injury-under-trafikskadelagen)
+- [US-TRF-005: Issue Green Card for EU Travel](../user-stories/trafikforsakring.md#us-trf-005-issue-green-card-for-eu-travel)
+- [US-TRF-006: Handle Trafikforsakringsavgift Notification](../user-stories/trafikforsakring.md#us-trf-006-handle-trafikforsakringsavgift-notification)
+- [US-TRF-007: Verify TFF Membership Compliance](../user-stories/trafikforsakring.md#us-trf-007-verify-tff-membership-compliance)

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/index.md
@@ -109,18 +109,20 @@ acceptance criteria:
 
 The [trafikforsakring user stories](trafikforsakring.md) cover mandatory
 third-party liability insurance under Trafikskadelagen (1975:1410), including
-Transportstyrelsen registration, coverage gap prevention, personal injury
-claims, TFF reporting, and cross-border coverage:
+continuous coverage monitoring, TFF reporting and data exchange, personal injury
+claims, Green Card issuance, and TFF membership compliance. See also the
+[cross-reference index](trafikforsakring-cross-references.md) for
+trafikforsakring content in other epics.
 
-| ID    | Actor              | Summary                                                  |
-| ----- | ------------------ | -------------------------------------------------------- |
-| TF-01 | System             | Register trafikforsakring with Transportstyrelsen        |
-| TF-02 | Customer           | Automatic trafikforsakring inclusion in any motor policy |
-| TF-03 | Claims Handler     | Process personal injury claims under Trafikskadelagen    |
-| TF-04 | System             | Prevent policy cancellation without replacement coverage |
-| TF-05 | Compliance Officer | Generate TFF statutory reports                           |
-| TF-06 | Claims Handler     | Route uninsured/foreign vehicle claims to TFF            |
-| TF-07 | Customer           | Cross-border coverage via Green Card system              |
+| ID         | Actor              | Summary                                        |
+| ---------- | ------------------ | ---------------------------------------------- |
+| US-TRF-001 | System             | Ensure continuous mandatory coverage           |
+| US-TRF-002 | System             | Report to TFF                                  |
+| US-TRF-003 | System             | Handle TFF data exchange                       |
+| US-TRF-004 | Claims Handler     | Process personal injury under Trafikskadelagen |
+| US-TRF-005 | Customer           | Issue Green Card for EU travel                 |
+| US-TRF-006 | System             | Handle trafikforsakringsavgift notification    |
+| US-TRF-007 | Compliance Officer | Verify TFF membership compliance               |
 
 ## Renewals
 

--- a/versioned_docs/version-phase-1/phase-1-motor/user-stories/trafikforsakring-cross-references.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/user-stories/trafikforsakring-cross-references.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+---
+
+# Trafikforsakring — Cross-Reference Index
+
+Trafikforsakring (mandatory third-party liability) requirements are spread
+across multiple epics. This page provides a consolidated index linking to all
+trafikforsakring-related content, so that compliance reviewers and developers
+can find everything from one place.
+
+For the dedicated trafikforsakring user stories, see
+[Trafikforsakring User Stories](trafikforsakring.md). For the consolidated use
+case, see
+[UC-TRF-001: Trafikforsakring Compliance Lifecycle](../use-cases/trafikforsakring.md).
+
+## Quote and Bind
+
+| Reference | Title                                          | Trafikforsakring Relevance                                                             |
+| --------- | ---------------------------------------------- | -------------------------------------------------------------------------------------- |
+| QNB-01    | [Get a Quick Quote](quote-and-bind.md)         | Trafikforsakring is the mandatory base tier included in every quote                    |
+| QNB-04    | [Compare Coverage Tiers](quote-and-bind.md)    | All tiers include trafikforsakring as the non-removable base; tier comparison explains |
+| QNB-08    | [Notify Transportstyrelsen](quote-and-bind.md) | Transportstyrelsen is notified of new trafikforsakring upon policy binding             |
+
+## Policy Administration
+
+| Reference | Title                                                                   | Trafikforsakring Relevance                                          |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| US-PA-011 | [Notify Transportstyrelsen of Policy Changes](policy-administration.md) | Transportstyrelsen is notified when trafikforsakring status changes |
+
+## Policy Cancellations
+
+| Reference  | Title                                                                                  | Trafikforsakring Relevance                                                 |
+| ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| US-CAN-005 | [Verify Replacement Trafikforsakring](cancellation-replacement-coverage.md)            | Replacement trafikforsakring must be verified before cancellation proceeds |
+| US-CAN-006 | [Notify Transportstyrelsen of Policy Cancellation](cancellation-transportstyrelsen.md) | Transportstyrelsen notified when trafikforsakring coverage ends            |
+
+## Claims Handling
+
+| Reference  | Title                                                                             | Trafikforsakring Relevance                                               |
+| ---------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| US-CLM-011 | [Process TFF Claims](claims-tff.md)                                               | TFF claims for uninsured, unknown, and foreign vehicles                  |
+| US-CLM-012 | [Handle Personal Injury Claims Under Trafikforsakring](claims-personal-injury.md) | Personal injury claims processed under Trafikskadelagen strict liability |
+
+## Underwriting Rules and Bonus System
+
+| Reference | Title                                              | Trafikforsakring Relevance                                    |
+| --------- | -------------------------------------------------- | ------------------------------------------------------------- |
+| UWB-01    | [Coverage Tier Definitions](underwriting-bonus.md) | Defines trafikforsakring scope within coverage tier structure |
+
+## Regulatory Requirements
+
+| Reference | Title                                                                   | Trafikforsakring Relevance                                    |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| FSA-007   | [Mandatory Trafikforsakring](../../regulatory/fsa-requirements.md)      | Legal requirement for all registered vehicles                 |
+| FSA-008   | [TFF Membership Obligation](../../regulatory/fsa-requirements.md)       | TFF membership required for insurers selling trafikforsakring |
+| FSA-009   | [Transportstyrelsen Notification](../../regulatory/fsa-requirements.md) | Timely notification of insurance status changes               |
+| FSA-010   | [Fair Claims Settlement](../../regulatory/fsa-requirements.md)          | Personal injury claims must be handled fairly                 |
+| FSA-013   | [Cooling-Off Period Rules](../../regulatory/fsa-requirements.md)        | Coverage gap prevention during cooling-off cancellations      |
+
+## Mapping to Dedicated Trafikforsakring Stories
+
+The following table maps cross-referenced content to the dedicated
+trafikforsakring user stories, showing where each topic is covered in depth.
+
+| Topic                              | Other Epic References         | Dedicated Story                                                                             |
+| ---------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| Mandatory base tier                | QNB-01, QNB-04, UWB-01        | [US-TRF-001](trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)           |
+| Transportstyrelsen notifications   | QNB-08, US-PA-011, US-CAN-006 | [US-TRF-001](trafikforsakring.md#us-trf-001-ensure-continuous-mandatory-coverage)           |
+| TFF reporting                      | FSA-008                       | [US-TRF-002](trafikforsakring.md#us-trf-002-report-to-tff)                                  |
+| TFF data exchange                  | US-CLM-011                    | [US-TRF-003](trafikforsakring.md#us-trf-003-handle-tff-data-exchange)                       |
+| Personal injury (strict liability) | US-CLM-012                    | [US-TRF-004](trafikforsakring.md#us-trf-004-process-personal-injury-under-trafikskadelagen) |
+| Green Card / cross-border          | FSA-007, EU Motor Ins. Dir.   | [US-TRF-005](trafikforsakring.md#us-trf-005-issue-green-card-for-eu-travel)                 |
+| Coverage gap / penalty fee         | US-CAN-005                    | [US-TRF-006](trafikforsakring.md#us-trf-006-handle-trafikforsakringsavgift-notification)    |
+| TFF membership compliance          | FSA-008                       | [US-TRF-007](trafikforsakring.md#us-trf-007-verify-tff-membership-compliance)               |


### PR DESCRIPTION
## Summary

- Restructures trafikforsakring user stories with dedicated US-TRF-001..007 IDs (was TF-01..07), adding actor links, priority sections, and aligned story descriptions per issue #44 requirements
- Renames use case to UC-TRF-001 (Trafikforsakring Compliance Lifecycle) with updated scenario structure covering policy issuance, ongoing monitoring, claims, TFF coordination, and cross-border coverage
- Creates a new cross-reference index page linking to all trafikforsakring-related content across Quote & Bind, Policy Admin, Cancellations, Claims, Underwriting, and Regulatory epics

## Changes

- `versioned_docs/.../user-stories/trafikforsakring.md` — 7 user stories with US-TRF-XXX IDs, actor links, priority, data model, process flows, regulatory traceability matrix
- `versioned_docs/.../use-cases/trafikforsakring.md` — UC-TRF-001 with 5 main scenarios, 8 alternative flows, business rules, NFRs, compliance summary
- `versioned_docs/.../user-stories/trafikforsakring-cross-references.md` — New cross-reference index
- `versioned_docs/.../user-stories/index.md` — Updated ID table and cross-reference link
- `versioned_docs/.../use-cases/index.md` — Updated use case description
- Matching updates in `docs/` for Phase 2 draft

## Testing

- [x] markdownlint passes with zero warnings
- [x] prettier passes with zero warnings
- [x] `npm run build` succeeds with zero errors

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)