### PR TITLE
docs(#55): Sync docs/ with versioned_docs/ and fix index gaps

### DIFF
--- a/docs/personas/anna-marcus-johansson.md
+++ b/docs/personas/anna-marcus-johansson.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 3
+---
+
+# Anna & Marcus Johansson, 38/40 — Family with Multiple Vehicles
+
+> _"We just want one place to see both cars, both policies, and know that
+> everything is sorted. We don't have time to manage insurance separately."_
+
+## Avatar Description
+
+A couple in their late thirties, standing in front of a suburban house with a
+driveway containing two cars: a larger family SUV and a smaller commuter
+hatchback. They look busy but organized.
+
+## Demographics
+
+| Field      | Details                                                     |
+| ---------- | ----------------------------------------------------------- |
+| Ages       | Anna 38, Marcus 40                                          |
+| Location   | Suburban Stockholm (Täby)                                   |
+| Occupation | Anna: project manager at a consulting firm; Marcus: teacher |
+| Income     | Dual-income household, middle-to-upper range                |
+
+## Insurance Situation
+
+| Field            | Details                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| Current coverage | Two active policies with TryggFörsäkring                                                    |
+| Vehicle 1        | 2022 Volkswagen ID.4 (family SUV) — helförsäkring                                           |
+| Vehicle 2        | 2017 Toyota Yaris (commuter) — halvförsäkring                                               |
+| Bonus class      | Anna: class 6 (12 years claim-free); Marcus: class 5 (10 years claim-free)                  |
+| Coverage goal    | Keep helförsäkring on the newer car; evaluate if halvförsäkring is enough for the older car |
+
+## Goals
+
+- Manage both policies from a single household view — one login, one overview
+- Easily compare coverage levels and adjust if circumstances change (e.g., new
+  car, teenager starts driving)
+- Receive a single consolidated invoice or coordinated payment schedule
+- Retain their high bonus class and understand how a claim on one car affects
+  the other
+
+## Frustrations / Pain Points
+
+- **Fragmented experience** — each policy is managed independently with no
+  household concept; updating an address requires doing it twice
+- **Bonus class confusion** — unclear whether Marcus's bonus class is affected
+  if Anna has an accident in the shared vehicle
+- **Coverage comparison difficulty** — hard to see at a glance what each policy
+  covers and where the gaps are
+- **Renewal timing** — the two policies renew on different dates, making it easy
+  to miss a renewal or overlook a price increase
+
+## Tech Comfort Level
+
+**Medium-high.** Both Anna and Marcus are comfortable with digital services.
+They prefer self-service via a web portal or app but will call customer service
+for complex questions (e.g., adding a teenage driver to a policy). They
+authenticate with BankID and expect a responsive experience on both desktop and
+mobile.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Each policy change or new purchase requires a demands-and-needs assessment (IDD-001); the family's combined situation should inform recommendations. |
+| **IDD**    | IPIDs (IDD-002) must be provided for each coverage tier so Anna and Marcus can compare helförsäkring and halvförsäkring clearly.                     |
+| **FSA**    | Both vehicles must have valid trafikförsäkring at all times (FSA-007).                                                                               |
+| **FSA**    | Renewal terms and any premium changes must be communicated in advance (FSA-004).                                                                     |
+| **GDPR**   | Both Anna and Marcus are data subjects; if they share a login or household view, consent and data access rights apply to each individual (GDPR-001). |
+| **GDPR**   | Adding a teenage driver requires processing the child's personal data with appropriate legal basis (GDPR-001).                                       |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Anna
+  and Marcus are private customers with multiple policies.

--- a/docs/personas/erik-lindstrom.md
+++ b/docs/personas/erik-lindstrom.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 2
+---
+
+# Erik Lindström, 19 — New Young Driver
+
+> _"I just want the cheapest insurance so I can drive legally. Why is it so
+> expensive when I haven't even done anything wrong?"_
+
+## Avatar Description
+
+Young man, casually dressed, holding car keys with a slightly worried expression.
+Standing next to a used silver Volvo V40 in a suburban parking lot.
+
+## Demographics
+
+| Field      | Details                                               |
+| ---------- | ----------------------------------------------------- |
+| Age        | 19                                                    |
+| Location   | Örebro, Sweden                                        |
+| Occupation | University student (part-time job at a grocery store) |
+| Income     | Low — dependent on study grants and part-time wages   |
+
+## Insurance Situation
+
+| Field            | Details                                                      |
+| ---------------- | ------------------------------------------------------------ |
+| Current coverage | None — first-time buyer                                      |
+| Vehicle          | Used 2016 Volvo V40 (purchased from a relative)              |
+| Bonus class      | 0 (no claims history, starting at the lowest discount level) |
+| Coverage goal    | Trafikförsäkring (mandatory minimum) or halvförsäkring       |
+
+## Goals
+
+- Get legally insured as quickly and cheaply as possible
+- Understand the difference between trafikförsäkring, halvförsäkring, and
+  helförsäkring without insurance jargon
+- Complete the entire purchase process on his phone
+- Build up a bonus class over time to lower premiums
+
+## Frustrations / Pain Points
+
+- **High premiums** — young drivers in bonus class 0 pay the highest rates,
+  which feels unfair when he has no claims history at all
+- **Confusing terminology** — Swedish insurance terms are difficult to parse
+  without prior experience
+- **Lack of transparency** — unclear why the premium is so high or what factors
+  drive pricing
+- **Desktop-oriented flows** — if the quote-and-bind process requires a desktop
+  browser, he may abandon it
+
+## Tech Comfort Level
+
+**High (digital native).** Erik does everything on his smartphone. He expects a
+mobile-first experience with instant feedback, minimal form fields, and the
+ability to authenticate with BankID via the mobile app. He has no interest in
+calling a phone line or visiting a physical office.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Erik must receive a demands-and-needs assessment (IDD-001) and an IPID (IDD-002) before purchasing, even for the cheapest option.              |
+| **IDD**    | Pre-contractual information must be clear and not misleading (IDD-003), especially important for a first-time buyer.                           |
+| **FSA**    | Trafikförsäkring is mandatory for every registered vehicle (FSA-007); Erik must be insured before driving on public roads.                     |
+| **FSA**    | Erik has a 14-day cooling-off period (ångerrätt) after purchasing a distance-sold policy (FSA-013).                                            |
+| **GDPR**   | Erik's personal data (identity, driving license, vehicle ownership) requires lawful processing and transparent privacy information (GDPR-001). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Erik
+  is a private customer purchasing his first policy.

--- a/docs/personas/fatima-al-rashid.md
+++ b/docs/personas/fatima-al-rashid.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 4
+---
+
+# Fatima Al-Rashid, 45 — Small Business Fleet Manager
+
+> _"I need to know instantly which van is covered, who's driving it, and what
+> happens if one of my employees has an accident on the job."_
+
+## Avatar Description
+
+A professional woman in business attire, standing in front of a row of branded
+cleaning-company vans. She holds a tablet and looks focused, managing logistics.
+
+## Demographics
+
+| Field      | Details                                                |
+| ---------- | ------------------------------------------------------ |
+| Age        | 45                                                     |
+| Location   | Gothenburg (Göteborg), Sweden                          |
+| Occupation | Owner and manager of a cleaning company (Ren & Fin AB) |
+| Income     | Business income, mid-range (reinvesting in growth)     |
+
+## Insurance Situation
+
+| Field            | Details                                                           |
+| ---------------- | ----------------------------------------------------------------- |
+| Current coverage | Fleet policy covering 8 service vans                              |
+| Vehicles         | 8 × Volkswagen Caddy vans (2018–2023 models)                      |
+| Bonus class      | Fleet-level bonus; varies per vehicle based on claims history     |
+| Drivers          | 12 employees authorized to drive; drivers rotate between vehicles |
+| Coverage goal    | Commercial helförsäkring with liability coverage for business use |
+
+## Goals
+
+- Add or remove vehicles from the fleet without lengthy administrative processes
+- Track which employees are authorized drivers and update the list easily
+- Get a clear fleet-level overview: total premium, claims history per vehicle,
+  upcoming renewals
+- File claims quickly when an employee reports a vehicle incident
+- Understand how a claim on one vehicle affects the fleet's overall premium
+
+## Frustrations / Pain Points
+
+- **Administrative burden** — adding a new van or a new employee as a driver
+  requires multiple phone calls and forms; no self-service fleet management
+- **Driver tracking** — no clear view of which employee is assigned to which
+  vehicle; when a claim occurs, determining the responsible driver is manual
+- **Employee claims** — when an employee has an accident, the claims process is
+  confusing regarding liability (business vs. personal)
+- **Lack of fleet reporting** — no consolidated dashboard showing claims
+  frequency, cost per vehicle, or fleet-wide bonus status
+- **Multiple contacts** — different departments handle fleet policy changes vs.
+  claims, and they don't always share context
+
+## Tech Comfort Level
+
+**Medium.** Fatima uses a tablet and smartphone for day-to-day business
+management. She is comfortable with digital tools but prefers straightforward
+interfaces over complex dashboards. For complex fleet changes, she expects to
+speak to a dedicated business account manager. She authenticates with BankID for
+both personal and business matters.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GDPR**   | Fatima processes employee personal data (names, driving licenses, employment details) as a data controller; employee consent or legitimate interest is required (GDPR-001). |
+| **GDPR**   | Employee driver data shared with TryggFörsäkring requires a data processing agreement and transparent privacy information (GDPR-001, GDPR-004).                             |
+| **IDD**    | Demands-and-needs assessment (IDD-001) requirements may differ for commercial customers; Fatima's fleet needs must be documented.                                           |
+| **FSA**    | Every van in the fleet must have valid trafikförsäkring (FSA-007); adding a new vehicle must trigger immediate coverage.                                                    |
+| **FSA**    | Commercial fleet policies are subject to product oversight and governance (FSA-005).                                                                                        |
+
+## Related Actors
+
+- [Corporate Customer (Företagskund)](../actors/internal-actors#corporate-customer-företagskund)
+  — Fatima acts as the corporate customer managing fleet insurance for Ren &
+  Fin AB.

--- a/docs/personas/gunnar-pettersson.md
+++ b/docs/personas/gunnar-pettersson.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 5
+---
+
+# Gunnar Pettersson, 72 — Senior Renewing Long-Standing Policy
+
+> _"I've been with the same company for over twenty years. I just want fair
+> treatment and someone who explains things clearly — not a website."_
+
+## Avatar Description
+
+An older gentleman in a knitted sweater, sitting at a kitchen table with
+paperwork spread out. A classic dark-green Saab 900 is visible through the
+window. He looks thoughtful, reviewing an insurance renewal letter.
+
+## Demographics
+
+| Field      | Details                                                   |
+| ---------- | --------------------------------------------------------- |
+| Age        | 72                                                        |
+| Location   | Linköping, Sweden                                         |
+| Occupation | Retired (former mechanical engineer at Saab in Linköping) |
+| Income     | Pension income, stable but fixed                          |
+
+## Insurance Situation
+
+| Field            | Details                                                                |
+| ---------------- | ---------------------------------------------------------------------- |
+| Current coverage | Helförsäkring (comprehensive) — has been with TryggFörsäkring 22 years |
+| Vehicle          | 1993 Saab 900 Turbo (classic car, well-maintained, low mileage)        |
+| Bonus class      | Maximum (class 7) — over 20 years without a claim                      |
+| Annual mileage   | Approximately 5,000 km/year                                            |
+| Coverage goal    | Maintain helförsäkring with agreed-value coverage for the classic car  |
+
+## Goals
+
+- Keep his policy without unexpected premium increases at renewal
+- Receive clear, written communication about any changes to terms or pricing
+- Speak to a knowledgeable person when he has questions — not navigate a chatbot
+- Ensure his classic Saab is properly valued (agreed value, not market value)
+- Understand what he is actually paying for, in plain language
+
+## Frustrations / Pain Points
+
+- **Automatic renewals with hidden increases** — premiums have increased year
+  over year, but the renewal letter does not clearly highlight what changed or
+  why
+- **Digital-first bias** — the insurer pushes online self-service, but Gunnar
+  prefers phone calls and physical mail; online portals feel confusing
+- **Classic car valuation** — standard pricing models undervalue his
+  well-maintained Saab; he worries about receiving market value instead of
+  agreed value in a total loss
+- **Loyalty not rewarded** — after 22 years as a customer, he feels he should
+  receive better treatment, but there is no visible loyalty program or benefit
+- **Fine print** — policy documents are long and filled with legal language that
+  is hard to parse
+
+## Tech Comfort Level
+
+**Low.** Gunnar has a smartphone but uses it mainly for calls and SMS. He can
+log in with BankID but finds web portals stressful. He strongly prefers
+receiving paper letters and speaking to a human on the phone. If forced to use a
+digital channel, he needs large text, simple navigation, and clear instructions.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Renewal communications must include clear, non-misleading information about coverage and pricing changes (IDD-003).                                                 |
+| **IDD**    | Even at renewal, a demands-and-needs assessment should confirm that Gunnar's coverage still matches his situation (IDD-001).                                        |
+| **FSA**    | Consumer protection rules require fair treatment of long-standing customers; premium increases must be justified and communicated (FSA-004).                        |
+| **FSA**    | Gunnar has a right to cancel and switch insurer; the process must not create unfair barriers (FSA-013).                                                             |
+| **GDPR**   | Gunnar's long history with TryggFörsäkring means extensive personal data is stored; he has the right to access, correct, and request deletion (GDPR-001, GDPR-003). |
+| **GDPR**   | Communication preference (paper mail) must be respected and recorded (GDPR-001).                                                                                    |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) —
+  Gunnar is a long-standing private customer.

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -4,6 +4,32 @@ sidebar_position: 1
 
 # Personas
 
-This section defines the personas for the TryggFörsäkring insurance platform.
+Personas bring actors to life with realistic profiles that help development teams
+understand user needs, motivations, and pain points. They are referenced
+throughout user stories to provide empathy and context for design and
+implementation decisions.
 
-_Content will be added in a subsequent issue._
+Each persona represents a key customer segment or internal user role within the
+motor insurance domain. Together they cover the range of interactions that the
+TryggFörsäkring platform must support.
+
+## Persona Summary
+
+| Persona                                          | Age   | Role                  | Key Need                                      |
+| ------------------------------------------------ | ----- | --------------------- | --------------------------------------------- |
+| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance         |
+| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies       |
+| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                |
+| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
+| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
+| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
+
+## How Personas Are Used
+
+- **User stories** reference personas by name to ground requirements in real
+  user context (e.g., _"As Erik, I want to compare trafikförsäkring and
+  halvförsäkring so I can choose the cheapest option that meets my needs."_)
+- **Acceptance criteria** consider each persona's tech comfort level and
+  communication preferences.
+- **Regulatory touchpoints** listed on each persona page highlight which
+  regulations are most relevant to that user segment.

--- a/docs/personas/lars-svensson.md
+++ b/docs/personas/lars-svensson.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 7
+---
+
+# Lars Svensson, 55 — Claims Handler (Internal)
+
+> _"I know every workaround in the old system. What I need is a new system that
+> doesn't require workarounds in the first place."_
+
+## Avatar Description
+
+A middle-aged man in a collared shirt, sitting at a desk with dual monitors
+showing a claims management interface. He has reading glasses pushed up on his
+forehead and a coffee mug nearby. His expression is focused and experienced.
+
+## Demographics
+
+| Field      | Details                                             |
+| ---------- | --------------------------------------------------- |
+| Age        | 55                                                  |
+| Location   | Stockholm, Sweden                                   |
+| Occupation | Senior claims handler at TryggFörsäkring (20 years) |
+| Income     | Mid-range, salaried employee                        |
+
+## Insurance Situation
+
+Lars is not a customer — he is an internal user of the insurance platform. His
+"insurance situation" is his professional context.
+
+| Field             | Details                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| Role              | Senior claims handler (skadereglerare)                         |
+| Daily volume      | Processes 15–20 claims per day                                 |
+| System experience | 20 years using the current legacy policy administration system |
+| Specialization    | Motor vehicle damage claims, total loss assessments            |
+
+## Goals
+
+- Process claims efficiently with fewer manual steps and less switching between
+  systems
+- Have all relevant information (policy details, customer history, vehicle data,
+  coverage limits) on one screen
+- Easily document decisions and rationale for audit trails
+- Reduce time spent on administrative tasks (data entry, form filling) and
+  increase time spent on actual claims assessment
+- Share knowledge with junior colleagues through structured processes rather
+  than tribal knowledge
+
+## Frustrations / Pain Points
+
+- **Tribal knowledge dependency** — critical business rules exist only in Lars's
+  head and those of a few senior colleagues; when he is on vacation, claims
+  processing slows down
+- **Legacy system workarounds** — the current system requires numerous manual
+  workarounds (e.g., overriding fields that should not exist, using comment
+  fields for structured data)
+- **System fragmentation** — claims handling requires switching between the
+  policy system, a separate claims system, email, Excel spreadsheets, and
+  sometimes paper files
+- **No decision support** — the system does not flag potential fraud indicators,
+  suggest similar past claims, or validate coverage automatically
+- **Training burden** — onboarding new claims handlers takes months because the
+  process is undocumented and dependent on shadowing experienced staff
+
+## Tech Comfort Level
+
+**Medium.** Lars is proficient with the current legacy system (having used it
+for 20 years) and standard office tools (Outlook, Excel). He is open to a new
+system if it genuinely makes his job easier, but he is skeptical of change for
+change's sake. He does not want a flashy interface — he wants a functional one
+that supports his workflow. He is not comfortable with mobile interfaces for
+work tasks and prefers a desktop application.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Lars must ensure fair and timely claims settlement in accordance with FSA requirements (FSA-010).                                                                    |
+| **FSA**    | Claims decisions and rationale must be documented for regulatory record-keeping (FSA-014).                                                                           |
+| **FSA**    | Complaints about claims decisions must be handled through the regulated complaints procedure (FSA-011).                                                              |
+| **GDPR**   | Lars processes sensitive personal data daily (injury details, police reports, medical records); data minimization and purpose limitation apply (GDPR-001, GDPR-004). |
+| **GDPR**   | Customers have the right to access their claims data and understand how decisions were made (GDPR-002).                                                              |
+| **IDD**    | Claims handling quality is part of the product oversight and governance framework (IDD-004).                                                                         |
+
+## Related Actors
+
+- [Claims Handler (Skadereglerare)](../actors/internal-actors#claims-handler-skadereglerare)
+  — Lars is the persona representing this actor role.
+- [Claims Adjuster (Värderare)](../actors/internal-actors#claims-adjuster-värderare)
+  — Lars coordinates with claims adjusters for damage assessments.
+- [Repair Shop (Verkstad)](../actors/external-actors#repair-shop-verkstad) —
+  Lars assigns repair work to authorized repair shops.

--- a/docs/personas/sofia-chen.md
+++ b/docs/personas/sofia-chen.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 6
+---
+
+# Sofia Chen, 32 — Recent Immigrant
+
+> _"I had excellent insurance in Germany with a high bonus class. Starting from
+> zero in Sweden feels wrong — there must be a way to transfer my history."_
+
+## Avatar Description
+
+A young professional woman standing near a parked car, holding both a German and
+a Swedish driving license. She looks determined but slightly frustrated, reading
+a document in Swedish with a translation app on her phone.
+
+## Demographics
+
+| Field      | Details                                      |
+| ---------- | -------------------------------------------- |
+| Age        | 32                                           |
+| Location   | Malmö, Sweden                                |
+| Occupation | Software engineer at a multinational company |
+| Income     | Upper-middle, professional salary            |
+
+## Insurance Situation
+
+| Field            | Details                                                                   |
+| ---------------- | ------------------------------------------------------------------------- |
+| Current coverage | None in Sweden — had helförsäkring in Germany for 7 years                 |
+| Vehicle          | 2021 BMW 3 Series (brought from Germany, re-registered in Sweden)         |
+| Bonus class      | Would be SF-Klasse 7 in Germany (roughly equivalent to Swedish class 5–6) |
+| Coverage goal    | Helförsäkring with transferred bonus class from German insurer            |
+
+## Goals
+
+- Transfer her German no-claims bonus (Schadenfreiheitsklasse) to a Swedish
+  bonus class so she does not start at class 0
+- Understand the Swedish insurance system — coverage tiers, terminology, and
+  regulatory requirements — without needing fluent Swedish
+- Complete the insurance purchase process in English or with clear bilingual
+  support
+- Re-register her German car in Sweden and get insured seamlessly as part of
+  that process
+
+## Frustrations / Pain Points
+
+- **Bonus class transfer** — the process for proving foreign claims history is
+  unclear; different insurers have different requirements for documentation
+  from the German insurer
+- **Language barrier** — policy documents, terms, and conditions are only
+  available in Swedish; online translation tools struggle with insurance
+  jargon
+- **System unfamiliarity** — the Swedish insurance tiers (trafikförsäkring,
+  halvförsäkring, helförsäkring) do not map directly to the German system
+  (Haftpflicht, Teilkasko, Vollkasko), causing confusion
+- **Re-registration complexity** — coordinating vehicle re-registration with
+  Transportstyrelsen and insurance purchase involves multiple steps with
+  different authorities
+- **Distrust of starting over** — being offered class 0 pricing despite 7
+  years of claim-free driving feels punitive and may push her to competitors
+  who accept foreign history
+
+## Tech Comfort Level
+
+**High.** Sofia is a software engineer and comfortable with any digital
+interface. She prefers online self-service and expects a modern, well-designed
+experience. She authenticates with BankID (obtained after receiving her Swedish
+personnummer). Language toggle or English-language support is important.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IDD**    | Demands-and-needs assessment (IDD-001) must account for Sofia's existing coverage history and specific situation as a new entrant to the Swedish market.               |
+| **IDD**    | Pre-contractual information (IDD-003) should be comprehensible; providing information in English supports the "clear, fair, and not misleading" requirement.           |
+| **FSA**    | Trafikförsäkring is mandatory (FSA-007); Sofia must be insured before driving her re-registered vehicle on Swedish roads.                                              |
+| **FSA**    | TFF manages the bonus class transfer process between insurers, including cross-border transfers (FSA-008).                                                             |
+| **GDPR**   | Sofia's personal data includes foreign documents (German driving license, insurance history); processing requires lawful basis and transparent information (GDPR-001). |
+| **GDPR**   | Cross-border data transfer from the German insurer must comply with GDPR data transfer rules (GDPR-001).                                                               |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal-actors#customer-privatkund) — Sofia
+  is a new private customer entering the Swedish insurance market.
+- [Transportstyrelsen](../actors/external-actors#transportstyrelsen) — involved
+  in vehicle re-registration.
+- [TFF](../actors/external-actors#trafikförsäkringsföreningen-tff) — manages
+  cross-border bonus class transfer.

--- a/docs/phase-1-motor/use-cases/index.md
+++ b/docs/phase-1-motor/use-cases/index.md
@@ -6,6 +6,20 @@ sidebar_position: 1
 
 Use cases for Phase 1 — Motor Insurance. Each use case describes the detailed interaction flow including actors, preconditions, main flow, exception flows, postconditions, and regulatory references.
 
+## Quote and Bind
+
+The [Quote and Bind Motor Insurance](quote-and-bind.md) use case (UC-QNB-001)
+describes the complete flow from customer identification through policy
+issuance and Transportstyrelsen notification. It covers:
+
+- Customer identification and vehicle data lookup
+- Demands-and-needs assessment (IDD-001)
+- Premium calculation and coverage comparison
+- BankID digital signing
+- Policy issuance and insurance certificate delivery
+- Transportstyrelsen notification
+- Agent-assisted and broker-assisted alternative flows
+
 ## Policy Administration (MTAs)
 
 Mid-term adjustment and policy lifecycle use cases — see [Policy Administration Use Cases](policy-administration.md).
@@ -34,12 +48,28 @@ processing and premium refund calculation.
 Use cases describing the detailed workflows for motor insurance claims
 processing.
 
-| ID                                         | Title                              | Scope                                         |
-| ------------------------------------------ | ---------------------------------- | --------------------------------------------- |
-| [UC-CLM-001](uc-claims-lifecycle.md)       | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
-| [UC-CLM-002](uc-fnol-processing.md)        | FNOL Processing                    | First notification of loss — online and phone |
-| [UC-CLM-003](uc-settlement-calculation.md) | Settlement Calculation and Payment | Settlement rules and payment execution        |
-| [UC-CLM-004](uc-fraud-screening.md)        | Fraud Screening and Investigation  | Automated and manual fraud detection          |
+| ID                                          | Title                              | Scope                                         |
+| ------------------------------------------- | ---------------------------------- | --------------------------------------------- |
+| [UC-CLM-001](uc-claims-lifecycle.md)        | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
+| [UC-CLM-002](uc-fnol-processing.md)         | FNOL Processing                    | First notification of loss — online and phone |
+| [UC-CLM-003](uc-settlement-calculation.md)  | Settlement Calculation and Payment | Settlement rules and payment execution        |
+| [UC-CLM-004](uc-fraud-screening.md)         | Fraud Screening and Investigation  | Automated and manual fraud detection          |
+| [UC-CLM-005](uc-liability-determination.md) | Liability Determination            | Fault assessment and liability allocation     |
+| [UC-CLM-006](uc-damage-assessment.md)       | Damage Assessment                  | Vehicle damage evaluation and cost estimation |
+| [UC-CLM-007](uc-claims-closure.md)          | Claims Closure                     | Final review, closure, and archiving          |
+
+## Underwriting and Bonus Assessment
+
+The [Motor Underwriting and Bonus Assessment](underwriting-bonus.md) use case
+(UC-UWB-001) describes the risk evaluation, premium calculation, and bonus class
+management process. It covers:
+
+- Bonus class determination and transfer verification
+- Risk evaluation using vehicle, customer, and usage factors
+- Risk acceptance, referral, and decline decisions
+- Premium calculation with rating factor application
+- Bonus class progression and regression rules
+- Referral handling for non-standard risks
 
 ## Trafikforsakring (Mandatory Third-Party Liability)
 

--- a/docs/phase-1-motor/use-cases/quote-and-bind.md
+++ b/docs/phase-1-motor/use-cases/quote-and-bind.md
@@ -1,0 +1,272 @@
+---
+sidebar_position: 2
+---
+
+# Use Case: Quote and Bind Motor Insurance
+
+End-to-end use case for quoting and binding a motor insurance policy at
+TryggFörsäkring. Covers the complete flow from customer identification through
+policy issuance and Transportstyrelsen notification.
+
+## Use Case Summary
+
+| Field                | Value                                                            |
+| -------------------- | ---------------------------------------------------------------- |
+| **Use Case ID**      | UC-QNB-001                                                       |
+| **Name**             | Quote and Bind Motor Insurance                                   |
+| **Primary Actor**    | Private Customer (Privatkund)                                    |
+| **Secondary Actors** | Insurance Agent, Insurance Broker, Underwriter                   |
+| **Goal**             | Obtain a motor insurance quote and bind a policy                 |
+| **Preconditions**    | Customer has a Swedish personnummer and a registered vehicle     |
+| **Postconditions**   | Policy is bound, certificate issued, Transportstyrelsen notified |
+| **Trigger**          | Customer initiates a motor insurance quote request               |
+
+## Stakeholders and Interests
+
+| Stakeholder            | Interest                                                             |
+| ---------------------- | -------------------------------------------------------------------- |
+| Private Customer       | Quick, transparent quote; fair pricing; immediate proof of insurance |
+| Insurance Agent/Broker | Efficient tool for customer advisory; compliant workflow             |
+| Underwriter            | Correct risk assessment and bonus class application                  |
+| Compliance Officer     | IDD assessment completed; all records retained                       |
+| TryggFörsäkring        | New policy sale; regulatory compliance; accurate data                |
+| Transportstyrelsen     | Timely notification of insurance status changes                      |
+
+## Main Success Scenario
+
+### 1. Customer Identification
+
+1. Customer enters registreringsnummer (vehicle registration number)
+2. Customer enters personnummer (personal identity number)
+3. System verifies customer identity
+4. System retrieves vehicle data from Transportstyrelsen:
+   - Make, model, year, VIN
+   - Registered owner
+   - Current insurance status
+
+### 2. Customer Data Retrieval
+
+1. System retrieves the customer's current bonus class (bonusklass) from the
+   internal claims database
+2. If the customer is new, system assigns the default starting bonus class
+3. System retrieves any existing policies for the same vehicle
+
+### 3. Demands-and-Needs Assessment
+
+1. System presents the structured demands-and-needs assessment form
+   (krav- och behovsanalys)
+2. Customer completes the assessment:
+   - Vehicle usage pattern (commuting, business, leisure)
+   - Annual mileage estimate
+   - Parking situation (garage, carport, street)
+   - Deductible tolerance (low, medium, high)
+   - Need for add-on coverages
+3. System generates a coverage recommendation with rationale:
+   - Recommended coverage tier (trafik/halv/hel)
+   - Recommended deductible level
+   - Relevant add-ons
+
+### 4. Premium Calculation and Coverage Comparison
+
+1. System calculates premiums for all three coverage tiers using:
+   - Vehicle risk factors (make, model, year, value)
+   - Customer risk factors (age, driving history, bonus class)
+   - Geographic risk factors (postal code)
+   - Deductible levels
+2. System presents a side-by-side tier comparison showing:
+   - Coverage details per tier
+   - Premium per tier
+   - Deductible per tier
+   - IPID access link per tier
+3. System highlights the recommended tier from the assessment
+4. System presents available add-ons with individual pricing
+
+### 5. Coverage Selection
+
+1. Customer selects a coverage tier
+2. Customer selects a deductible level
+3. Customer selects or declines optional add-ons
+4. If the customer deviates from the recommendation, system records the
+   deviation
+5. System calculates the final premium (base + add-ons)
+
+### 6. Pre-contractual Review and Signing
+
+1. System presents the binding summary:
+   - Selected coverage tier and details
+   - Premium amount and payment frequency
+   - Deductible amount
+   - Policy effective date and huvudförfallodag (anniversary)
+   - Pre-contractual information (IDD-003):
+     - Insurer identity (TryggFörsäkring AB)
+     - FSA registration status
+     - Complaints handling procedures
+     - Dispute resolution options (ARN)
+   - IPID delivery confirmation (IDD-002)
+   - Demands-and-needs assessment reference (IDD-001)
+   - 14-day cooling-off right (ångerrätt) information (FSA-013)
+2. Customer initiates BankID signing
+3. System sends the policy document hash to BankID
+4. Customer completes BankID authentication and signing
+5. System records the BankID transaction reference and timestamp
+
+### 7. Policy Issuance
+
+1. System generates a unique policy number
+2. System creates the policy record with all binding details
+3. System generates the insurance certificate (försäkringsbevis)
+4. System initiates payment setup with the payment provider:
+   - Monthly autogiro setup, or
+   - Annual invoice generation
+5. System calculates the ångerrätt (cooling-off) expiry date (14 days)
+
+### 8. Transportstyrelsen Notification
+
+1. System sends insurance notification to Transportstyrelsen:
+   - Registreringsnummer
+   - Policy number
+   - Insurance company identifier
+   - Coverage start date
+   - Coverage type
+2. System records the Transportstyrelsen acknowledgement reference
+
+### 9. Confirmation
+
+1. System sends confirmation to the customer:
+   - Insurance certificate (PDF)
+   - Full policy document
+   - IPID for the selected tier
+   - Payment instructions
+   - Cooling-off information
+2. Policy documents are available in the self-service portal
+
+## Extensions (Alternative Flows)
+
+### 1a. Vehicle Not Found in Transportstyrelsen
+
+1. System displays a message that the vehicle was not found
+2. Customer is offered manual vehicle entry (make, model, year)
+3. Manual entry requires underwriter review before binding
+4. Flow continues from step 5
+
+### 2a. Customer Transferring Bonus from Another Insurer
+
+1. Customer indicates they have a bonus class from another insurer
+2. System allows manual entry of the transferred bonus class
+3. Customer provides supporting documentation (e.g., insurance certificate
+   from previous insurer)
+4. Transferred bonus is applied provisionally, subject to verification via
+   TFF
+5. Flow continues from step 8
+
+### 3a. Agent-Assisted Quote
+
+1. Agent authenticates via BankID
+2. System verifies the agent's competence certification (IDD-009)
+3. Agent enters the customer's registreringsnummer and personnummer
+4. Agent completes the demands-and-needs assessment on behalf of the
+   customer
+5. System records the agent's identity and distribution channel
+6. Agent provides a personal recommendation with documented rationale
+   (IDD-006)
+7. System records the distribution status disclosure (IDD-005)
+8. Flow continues from step 11 (Premium Calculation)
+9. At signing, the customer (not the agent) signs via BankID
+
+### 3b. Broker-Assisted Quote
+
+1. Broker authenticates via BankID
+2. Broker discloses independence, fee structure, and duty to act in the
+   customer's interest (IDD-005)
+3. Broker enters the customer's registreringsnummer and personnummer
+4. Broker conducts an independent demands-and-needs assessment
+5. Broker provides a personalized recommendation with documented rationale
+   (IDD-006)
+6. System records the broker's identity, distribution channel, and
+   disclosures
+7. Flow continues from step 11 (Premium Calculation)
+8. At signing, the customer signs via BankID
+
+### 6a. BankID Signing Fails
+
+1. System displays an error message indicating the signing failed
+2. The quote remains valid for the configured validity period
+3. Customer can retry signing without re-entering data
+4. If the failure persists, customer is offered to save the quote and
+   complete later
+
+### 8a. Transportstyrelsen Notification Fails
+
+1. System logs the failure and queues the notification for retry
+2. Automatic retry with exponential backoff
+3. After a configured number of failures, an alert is raised for
+   operations staff
+4. The policy remains valid regardless of notification status; the
+   notification is a post-binding obligation
+
+### 5a. Customer Selects Trafikförsäkring Only
+
+1. If the customer selects only trafikförsäkring (mandatory minimum)
+2. System presents a confirmation that this provides third-party liability
+   only and no own-damage coverage
+3. System records the customer's informed decision
+4. Flow continues from step 19
+
+## Business Rules
+
+| Rule ID | Rule                                                                                                    |
+| ------- | ------------------------------------------------------------------------------------------------------- |
+| BR-01   | The demands-and-needs assessment must be completed before any quote is finalized                        |
+| BR-02   | The IPID for the selected tier must be provided before binding                                          |
+| BR-03   | The customer must be informed of the 14-day cooling-off right (ångerrätt) before signing                |
+| BR-04   | Bonus class must be verified or defaulted before premium calculation                                    |
+| BR-05   | Transportstyrelsen must be notified within the same business day of policy binding                      |
+| BR-06   | Quotes have a configurable validity period (default: 30 days)                                           |
+| BR-07   | Minimum age for policyholder is 18 years (verified via personnummer)                                    |
+| BR-08   | All vehicles on Swedish roads must have at least trafikförsäkring                                       |
+| BR-09   | Add-on pricing must be itemized separately from the base premium                                        |
+| BR-10   | Agent/broker-assisted sales must record the distribution channel, advisor identity, and all disclosures |
+
+## Non-functional Requirements
+
+| Requirement                     | Target                                                      |
+| ------------------------------- | ----------------------------------------------------------- |
+| Vehicle data lookup             | Response within 3 seconds (Transportstyrelsen SLA)          |
+| Quote calculation               | Complete within 5 seconds                                   |
+| BankID signing                  | Timeout after 2 minutes; allow retry                        |
+| Transportstyrelsen notification | Sent within 1 hour of policy binding                        |
+| Quote validity                  | Configurable; default 30 days                               |
+| Audit trail                     | All steps logged with timestamps and actor identity         |
+| Availability                    | Quote-and-bind flow available 24/7 for digital self-service |
+
+## Regulatory Compliance Summary
+
+| Regulation   | Requirements Addressed                                                      |
+| ------------ | --------------------------------------------------------------------------- |
+| **FSA-004**  | Fair treatment through demands-and-needs assessment and transparent pricing |
+| **FSA-007**  | Mandatory trafikförsäkring verified and offered                             |
+| **FSA-009**  | Transportstyrelsen notification within regulated timeframes                 |
+| **FSA-012**  | Pre-contractual disclosure before binding                                   |
+| **FSA-013**  | Cooling-off right (ångerrätt) communicated at binding                       |
+| **GDPR-001** | Personal data collected under Article 6(1)(b) for quote generation          |
+| **GDPR-002** | Policy data processed under Article 6(1)(b) for contract performance        |
+| **GDPR-004** | Transportstyrelsen data sharing under legal obligation                      |
+| **IDD-001**  | Demands-and-needs assessment completed before quote finalization            |
+| **IDD-002**  | IPID provided for each tier before binding                                  |
+| **IDD-003**  | Pre-contractual information presented before signing                        |
+| **IDD-005**  | Distribution status disclosed for agent/broker channels                     |
+| **IDD-006**  | Advice documented with rationale for agent/broker channels                  |
+| **IDD-007**  | Add-on pricing itemized separately                                          |
+| **IDD-008**  | All distribution records retained per retention requirements                |
+| **IDD-009**  | Agent/broker competence verified before quote initiation                    |
+
+## Related User Stories
+
+- [QNB-01: Get a Quick Quote](../user-stories/quote-and-bind.md#qnb-01-get-a-quick-quote)
+- [QNB-02: Agent-Assisted Quote](../user-stories/quote-and-bind.md#qnb-02-agent-assisted-quote)
+- [QNB-03: Demands-and-Needs Assessment](../user-stories/quote-and-bind.md#qnb-03-demands-and-needs-assessment)
+- [QNB-04: Compare Coverage Tiers](../user-stories/quote-and-bind.md#qnb-04-compare-coverage-tiers)
+- [QNB-05: Sign Policy with BankID](../user-stories/quote-and-bind.md#qnb-05-sign-policy-with-bankid)
+- [QNB-06: Receive Insurance Certificate Immediately](../user-stories/quote-and-bind.md#qnb-06-receive-insurance-certificate-immediately)
+- [QNB-07: Automatic Bonus Class Calculation](../user-stories/quote-and-bind.md#qnb-07-automatic-bonus-class-calculation)
+- [QNB-08: Notify Transportstyrelsen of New Policy](../user-stories/quote-and-bind.md#qnb-08-notify-transportstyrelsen-of-new-policy)

--- a/docs/phase-1-motor/use-cases/underwriting-bonus.md
+++ b/docs/phase-1-motor/use-cases/underwriting-bonus.md
@@ -1,0 +1,236 @@
+---
+sidebar_position: 3
+---
+
+# Use Case: Motor Underwriting and Bonus Assessment
+
+End-to-end use case for assessing risk, calculating premiums, and managing the
+bonus class system for motor insurance at TryggFörsäkring. Covers the flow from
+risk evaluation through premium calculation, including bonus class management
+and referral handling.
+
+## Use Case Summary
+
+| Field                | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| **Use Case ID**      | UC-UWB-001                                                                 |
+| **Name**             | Motor Underwriting and Bonus Assessment                                    |
+| **Primary Actor**    | System (Rating Engine)                                                     |
+| **Secondary Actors** | Underwriter, Private Customer, Actuary, Compliance Officer                 |
+| **Goal**             | Assess risk, calculate a fair premium, and apply the correct bonus class   |
+| **Preconditions**    | Customer and vehicle data are available; bonus class is known or defaulted |
+| **Postconditions**   | Premium is calculated; risk decision (accept/refer/decline) is recorded    |
+| **Trigger**          | A motor insurance quote is requested (links to UC-QNB-001, step 4)         |
+
+## Stakeholders and Interests
+
+| Stakeholder        | Interest                                                              |
+| ------------------ | --------------------------------------------------------------------- |
+| Private Customer   | Fair, transparent premium reflecting their individual risk profile    |
+| Underwriter        | Consistent risk assessment; high-risk cases flagged for manual review |
+| Actuary            | Pricing rules are actuarially sound and documented                    |
+| Compliance Officer | Non-discriminatory rating; transparent premium calculation            |
+| TryggFörsäkring    | Profitable portfolio; competitive pricing; regulatory compliance      |
+
+## Main Success Scenario
+
+### 1. Bonus Class Determination
+
+1. System retrieves the customer's current bonus class from the internal
+   database
+2. If the customer is new with no prior history, system assigns the default
+   starting class (class 7)
+3. If the customer is transferring from another insurer, system uses the
+   provisional or verified transferred class (see Extension 1a)
+4. System confirms the bonus class and its corresponding discount percentage
+   from the bonus table
+
+### 2. Risk Evaluation
+
+1. System retrieves the vehicle risk classification:
+   - Vehicle group (make, model, year)
+   - Safety rating (Euro NCAP)
+   - Theft risk index
+   - Repair cost group
+2. System retrieves the customer risk profile:
+   - Age band (from personnummer)
+   - Postal code risk zone
+   - Occupation group (if provided)
+3. System retrieves usage factors:
+   - Annual mileage band
+   - Parking type
+   - Vehicle usage pattern
+4. System evaluates risk acceptance rules against the risk profile
+
+### 3. Risk Decision
+
+1. System checks all acceptance, referral, and decline rules:
+   - If all rules pass → **Accept** (proceed to step 4)
+   - If one or more referral rules trigger → **Refer** (proceed to Extension
+     3a)
+   - If a decline rule triggers → **Decline** (proceed to Extension 3b)
+2. System records the risk decision and any triggered rules
+
+### 4. Premium Calculation
+
+1. System selects the base premium for the requested coverage tier
+   (trafik/halv/hel)
+2. System applies rating factors multiplicatively:
+   - Vehicle group multiplier
+   - Safety rating multiplier
+   - Theft risk multiplier
+   - Repair cost multiplier
+   - Age multiplier (including young driver surcharge if applicable)
+   - Postal code risk zone multiplier
+   - Annual mileage multiplier
+   - Parking type multiplier
+   - Vehicle usage multiplier
+   - Occupation multiplier (if applicable)
+3. System applies the bonus class discount percentage to the adjusted premium
+4. System applies the deductible (självrisk) adjustment factor
+5. System enforces minimum and maximum premium limits
+6. System calculates the final annual premium
+
+### 5. Premium Presentation
+
+1. System generates the premium for each of the three coverage tiers
+   (trafik/halv/hel)
+2. System prepares the premium breakdown showing each factor's contribution
+3. System stores the calculated premium with all applied factors for audit
+   purposes
+4. Premium data is returned to the quote flow (UC-QNB-001, step 4)
+
+### 6. Bonus Class Progression (Post-Period)
+
+1. At the huvudförfallodag (policy anniversary), system reviews the claims
+   history for the policy period
+2. If no at-fault claims: system advances the bonus class by one step (max
+   class 15)
+3. If one at-fault claim: system reduces the bonus class by 3 steps (min
+   class 1)
+4. If additional at-fault claims: system reduces the bonus class by 5 steps per
+   additional claim (min class 1)
+5. System records the new bonus class with the effective date
+6. Updated bonus class is applied at the next renewal
+
+## Extensions (Alternative Flows)
+
+### 1a. Bonus Class Transfer from Another Insurer
+
+1. Customer indicates they have a bonus class from a previous insurer
+2. System records the claimed bonus class as provisional
+3. System initiates a verification request via TFF
+4. Provisional class is used for the initial quote and policy
+5. When verification is received:
+   - If confirmed: system updates the status to confirmed
+   - If different from claimed: system adjusts the bonus class and
+     recalculates the premium; customer is notified of the change
+   - If not confirmed within 30 days: underwriter is alerted for manual
+     review
+6. Flow continues from step 4 (Premium Calculation)
+
+### 1b. EU/EEA Bonus Transfer
+
+1. Customer provides documentation of claims-free history from an EU/EEA
+   insurer
+2. System flags the case for underwriter review
+3. Underwriter reviews the documentation and assigns an equivalent Swedish
+   bonus class
+4. Assigned class is recorded with the source as "Manual" and verification
+   status as "Confirmed"
+5. Flow continues from step 4 (Premium Calculation)
+
+### 3a. Referral to Underwriter
+
+1. System identifies one or more triggered referral rules
+2. System places the application in the underwriter referral queue with:
+   - Customer and vehicle summary
+   - List of triggered referral rules
+   - Preliminary premium calculation (for reference)
+3. Underwriter reviews the application and:
+   - **Approves** the quote (optionally with modified terms or premium
+     loading)
+   - **Declines** the application with a documented reason
+4. If approved: flow returns to step 5 (Premium Presentation) with any
+   modifications applied
+5. If declined: flow continues to Extension 3b
+
+### 3b. Application Declined
+
+1. System records the decline decision with the decline rule(s) and reason
+2. System notifies the customer that coverage cannot be offered, with a clear
+   explanation of the reason
+3. If the decline applies to halvförsäkring or helförsäkring only, system
+   informs the customer that trafikförsäkring (mandatory minimum) is still
+   available
+4. Decline record is stored for regulatory reporting and future reference
+
+### 4a. Premium Below Minimum
+
+1. System detects that the calculated premium is below the configured minimum
+   for the coverage tier
+2. System sets the premium to the minimum threshold
+3. System logs the minimum premium override for actuarial analysis
+4. Flow continues from step 5 (Premium Presentation)
+
+### 4b. Premium Above Maximum
+
+1. System detects that the calculated premium exceeds the configured maximum
+   for the coverage tier
+2. System sets the premium to the maximum threshold
+3. System flags the case for actuarial review (pricing may need adjustment)
+4. Flow continues from step 5 (Premium Presentation)
+
+## Business Rules
+
+| Rule ID | Rule                                                                                     |
+| ------- | ---------------------------------------------------------------------------------------- |
+| BR-11   | Bonus class must be determined before premium calculation begins                         |
+| BR-12   | New customers with no Swedish insurance history start at bonus class 7                   |
+| BR-13   | Claim-free year advances the bonus class by 1 step; at-fault claim reduces it by 3 steps |
+| BR-14   | Each additional at-fault claim in the same period reduces the bonus class by 5 steps     |
+| BR-15   | Not-at-fault claims do not affect the bonus class                                        |
+| BR-16   | Transferred bonus classes are provisional until verified via TFF                         |
+| BR-17   | Rating factors are applied multiplicatively to the base premium                          |
+| BR-18   | Bonus class discount is applied after all other rating factors                           |
+| BR-19   | Minimum and maximum premium limits are enforced after all adjustments                    |
+| BR-20   | Modified vehicles, imported vehicles, and classic cars require underwriter referral      |
+| BR-21   | Trafikförsäkring cannot be declined except in cases defined by law (FSA-007)             |
+| BR-22   | All decline decisions must include a clear reason communicated to the customer           |
+| BR-23   | Rating factor changes require approval from underwriting manager and actuarial team      |
+
+## Non-functional Requirements
+
+| Requirement               | Target                                                    |
+| ------------------------- | --------------------------------------------------------- |
+| Premium calculation       | Complete within 2 seconds for all three tiers             |
+| Risk evaluation           | Complete within 1 second                                  |
+| Referral queue assignment | Underwriter notified within 5 minutes of referral         |
+| Referral turnaround       | Target 24-hour response from underwriter                  |
+| Bonus class update        | Processed on the huvudförfallodag (batch or event-driven) |
+| Rating factor versioning  | All changes auditable with full version history           |
+| Premium breakdown storage | Every calculated premium stored with factor-level detail  |
+
+## Regulatory Compliance Summary
+
+| Regulation   | Requirements Addressed                                               |
+| ------------ | -------------------------------------------------------------------- |
+| **FSA-004**  | Fair treatment through transparent, non-discriminatory pricing       |
+| **FSA-005**  | Product governance: documented rules, annual review, version control |
+| **FSA-006**  | Underwriting rules accessible for supervisory reporting              |
+| **FSA-007**  | Trafikförsäkring cannot be refused; mandatory coverage preserved     |
+| **FSA-012**  | Premium calculation basis disclosed to customers                     |
+| **GDPR-001** | Personal data used in rating processed under Article 6(1)(b)         |
+| **GDPR-003** | Transfer data (claims history) processed with data minimization      |
+| **IDD-001**  | Premium transparency supports informed decision-making               |
+| **IDD-004**  | Pricing and acceptance rules aligned with target market definitions  |
+
+## Related User Stories
+
+- [UWB-01: Bonus Class Table and Progression Rules](../user-stories/underwriting-bonus.md#uwb-01-bonus-class-table-and-progression-rules)
+- [UWB-02: Transfer Bonus Class from Another Insurer](../user-stories/underwriting-bonus.md#uwb-02-transfer-bonus-class-from-another-insurer)
+- [UWB-03: Calculate Premium Using Rating Factors](../user-stories/underwriting-bonus.md#uwb-03-calculate-premium-using-rating-factors)
+- [UWB-04: Risk Acceptance and Referral Rules](../user-stories/underwriting-bonus.md#uwb-04-risk-acceptance-and-referral-rules)
+- [UWB-05: Premium Calculation Transparency](../user-stories/underwriting-bonus.md#uwb-05-premium-calculation-transparency)
+- [UWB-06: Documented Underwriting Rules for Actuarial Review](../user-stories/underwriting-bonus.md#uwb-06-documented-underwriting-rules-for-actuarial-review)
+- [UWB-07: Non-Discriminatory Underwriting Verification](../user-stories/underwriting-bonus.md#uwb-07-non-discriminatory-underwriting-verification)

--- a/docs/phase-1-motor/user-stories/index.md
+++ b/docs/phase-1-motor/user-stories/index.md
@@ -6,6 +6,22 @@ sidebar_position: 1
 
 User stories for Phase 1 — Motor Insurance. Each user story follows the format _"As a \<role\>, I want \<goal\> so that \<benefit\>"_ and includes acceptance criteria in Given/When/Then format, business rules, data requirements, and regulatory traceability.
 
+## Quote and Bind
+
+The [quote-and-bind user stories](quote-and-bind.md) cover the primary sales
+flow from initial customer inquiry through policy issuance:
+
+| ID     | Actor            | Summary                                   |
+| ------ | ---------------- | ----------------------------------------- |
+| QNB-01 | Private Customer | Get a quick quote by registration number  |
+| QNB-02 | Insurance Agent  | Create a quote on behalf of a customer    |
+| QNB-03 | System           | Perform demands-and-needs assessment      |
+| QNB-04 | Private Customer | Compare coverage tiers side by side       |
+| QNB-05 | Private Customer | Sign policy with BankID                   |
+| QNB-06 | Private Customer | Receive insurance certificate immediately |
+| QNB-07 | Underwriter      | Apply bonus class rules automatically     |
+| QNB-08 | System           | Notify Transportstyrelsen of new policy   |
+
 ## Policy Administration (MTAs)
 
 Mid-term adjustments and policy lifecycle management — see [Policy Administration User Stories](policy-administration.md).
@@ -69,6 +85,22 @@ notification of loss through settlement and closure.
 | [US-CLM-013](claims-tracking.md)              | Track Claim Status                                   | Should Have |
 | [US-CLM-014](claims-repair-authorization.md)  | Authorize Repairs at Network Shops                   | Should Have |
 | [US-CLM-015](claims-closure.md)               | Close and Review Claims                              | Must Have   |
+
+## Underwriting Rules and Bonus System
+
+The [underwriting and bonus user stories](underwriting-bonus.md) cover
+underwriting rules, the bonus class system, premium calculation, and risk
+acceptance criteria:
+
+| ID     | Actor              | Summary                                         |
+| ------ | ------------------ | ----------------------------------------------- |
+| UWB-01 | Underwriter        | Manage bonus class table and progression rules  |
+| UWB-02 | Private Customer   | Transfer bonus class from another insurer       |
+| UWB-03 | System             | Calculate premium using rating factors          |
+| UWB-04 | Underwriter        | Define risk acceptance and referral rules       |
+| UWB-05 | Private Customer   | Understand premium calculation breakdown        |
+| UWB-06 | Actuary            | Review documented underwriting rules            |
+| UWB-07 | Compliance Officer | Verify non-discriminatory underwriting practice |
 
 ## Trafikforsakring (Mandatory Third-Party Liability)
 

--- a/docs/phase-1-motor/user-stories/quote-and-bind.md
+++ b/docs/phase-1-motor/user-stories/quote-and-bind.md
@@ -1,0 +1,680 @@
+---
+sidebar_position: 2
+---
+
+# Quote and Bind — User Stories
+
+User stories for the motor insurance quote-and-bind process. This is the primary
+sales flow where a customer (or agent/broker) provides vehicle and personal
+details, receives a premium quote, and binds a policy.
+
+## Overview
+
+| ID     | Actor            | Summary                                   |
+| ------ | ---------------- | ----------------------------------------- |
+| QNB-01 | Private Customer | Get a quick quote by registration number  |
+| QNB-02 | Insurance Agent  | Create a quote on behalf of a customer    |
+| QNB-03 | System           | Perform demands-and-needs assessment      |
+| QNB-04 | Private Customer | Compare coverage tiers side by side       |
+| QNB-05 | Private Customer | Sign policy with BankID                   |
+| QNB-06 | Private Customer | Receive insurance certificate immediately |
+| QNB-07 | Underwriter      | Apply bonus class rules automatically     |
+| QNB-08 | System           | Notify Transportstyrelsen of new policy   |
+
+---
+
+## QNB-01: Get a Quick Quote
+
+**As a** private customer (privatkund),
+**I want to** get a motor insurance quote by entering my registration number
+(registreringsnummer) and personnummer,
+**so that** I can see pricing quickly without manual data entry.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer enters a valid registreringsnummer
+  **WHEN** the system looks up the vehicle via Transportstyrelsen
+  **THEN** vehicle details (make, model, year, owner) are pre-populated
+  automatically
+
+- **GIVEN** the customer enters a valid personnummer
+  **WHEN** the system verifies identity
+  **THEN** the customer's existing bonus class (bonusklass) is retrieved from
+  the internal claims database
+
+- **GIVEN** vehicle and customer data are available
+  **WHEN** the system calculates the premium
+  **THEN** quotes are presented for all three coverage tiers:
+  trafikförsäkring, halvförsäkring, and helförsäkring
+
+- **GIVEN** the vehicle is not found in the Transportstyrelsen registry
+  **WHEN** the customer submits the registration number
+  **THEN** the system displays an error message and allows manual vehicle
+  entry as a fallback
+
+- **GIVEN** the customer is a new customer with no claims history
+  **WHEN** the premium is calculated
+  **THEN** the system applies the default starting bonus class per
+  underwriting guidelines
+
+### Data Requirements
+
+| Data Element        | Source             | Required |
+| ------------------- | ------------------ | -------- |
+| Registreringsnummer | Customer input     | Yes      |
+| Personnummer        | Customer input     | Yes      |
+| Vehicle make/model  | Transportstyrelsen | Yes      |
+| Vehicle year        | Transportstyrelsen | Yes      |
+| Vehicle owner       | Transportstyrelsen | Yes      |
+| Bonus class         | Internal database  | Yes      |
+| Driving history     | Internal database  | No       |
+
+### External Integrations
+
+- **Transportstyrelsen** — Vehicle data lookup via registreringsnummer
+- **BankID** — Customer identity verification (if strong auth is required at
+  quote stage)
+
+### Regulatory
+
+- **GDPR-001** — Personal data collection for quote generation; legal basis is
+  Article 6(1)(b) pre-contractual steps
+- **FSA-007** — System must verify that the vehicle requires trafikförsäkring
+- **IDD-001** — Demands-and-needs assessment must precede final quote
+  presentation (see QNB-03)
+
+---
+
+## QNB-02: Agent-Assisted Quote
+
+**As an** insurance agent (försäkringsagent),
+**I want to** create a motor insurance quote on behalf of a customer,
+**so that** I can advise them on the appropriate coverage level.
+
+### Acceptance Criteria
+
+- **GIVEN** the agent is authenticated and has valid competence certification
+  **WHEN** the agent enters the customer's registreringsnummer and
+  personnummer
+  **THEN** the system retrieves vehicle and customer data as in QNB-01
+
+- **GIVEN** the agent completes the demands-and-needs assessment (QNB-03) on
+  behalf of the customer
+  **WHEN** the assessment is submitted
+  **THEN** the system generates a coverage recommendation linked to the
+  assessment responses
+
+- **GIVEN** the agent creates a quote
+  **WHEN** the quote is saved
+  **THEN** the system records the agent's identity, the distribution channel
+  (agent-assisted), and a timestamp for IDD record-keeping
+
+- **GIVEN** the agent provides a personal recommendation to the customer
+  **WHEN** the recommendation is recorded
+  **THEN** the system captures the recommended tier, the rationale, and
+  whether the customer followed or deviated from the recommendation
+
+- **GIVEN** the agent's competence certification has expired
+  **WHEN** the agent attempts to initiate a new quote
+  **THEN** the system blocks access and displays a message requiring
+  certification renewal
+
+### Data Requirements
+
+| Data Element             | Source             | Required |
+| ------------------------ | ------------------ | -------- |
+| Agent identity           | Platform login     | Yes      |
+| Agent competence status  | HR/training system | Yes      |
+| Customer personnummer    | Customer/agent     | Yes      |
+| Distribution channel     | System (automatic) | Yes      |
+| Recommendation rationale | Agent input        | Yes      |
+
+### External Integrations
+
+- **Transportstyrelsen** — Vehicle data lookup (same as QNB-01)
+- **BankID** — Agent authentication
+
+### Regulatory
+
+- **IDD-001** — Agent must perform demands-and-needs assessment before
+  recommending a product
+- **IDD-005** — Agent must disclose distribution status and remuneration
+- **IDD-006** — Personalized recommendation must be documented with rationale
+- **IDD-008** — All distribution records must be retained for 5+ years
+- **IDD-009** — Agent must have current competence certification
+- **FSA-004** — Fair treatment of the customer
+- **GDPR-001** — Personal data collection; agent acts under TryggFörsäkring's
+  controllership
+
+---
+
+## QNB-03: Demands-and-Needs Assessment
+
+**As the** system,
+**I want to** perform a structured demands-and-needs assessment
+(krav- och behovsanalys) before presenting coverage options,
+**so that** we comply with IDD and recommend appropriate coverage.
+
+### Acceptance Criteria
+
+- **GIVEN** a customer (or agent on their behalf) has entered vehicle and
+  personal details
+  **WHEN** the quote flow proceeds to coverage selection
+  **THEN** the system presents the demands-and-needs assessment form before
+  any coverage options are shown
+
+- **GIVEN** the assessment form is presented
+  **WHEN** the customer completes all required fields
+  **THEN** the system captures responses covering:
+  - Vehicle usage pattern (commuting, business, leisure)
+  - Annual mileage estimate
+  - Parking situation (garage, street, carport)
+  - Financial situation regarding deductible (självrisk) tolerance
+  - Need for add-on coverages (rental car, roadside assistance, legal
+    protection)
+
+- **GIVEN** the assessment is completed
+  **WHEN** the system processes the responses
+  **THEN** a coverage recommendation is generated indicating:
+  - Recommended coverage tier (trafik/halv/hel) with rationale
+  - Recommended deductible level with rationale
+  - Relevant add-ons based on stated needs
+
+- **GIVEN** the customer deviates from the system recommendation
+  **WHEN** the customer selects a different tier or deductible
+  **THEN** the system records the deviation and any additional explanation
+  provided by the customer
+
+- **GIVEN** the assessment is completed
+  **WHEN** the quote is finalized
+  **THEN** the assessment record is stored with a unique reference ID and
+  linked to the resulting quote and policy
+
+### Data Requirements
+
+| Data Element          | Source         | Required |
+| --------------------- | -------------- | -------- |
+| Vehicle usage pattern | Customer input | Yes      |
+| Annual mileage        | Customer input | Yes      |
+| Parking situation     | Customer input | Yes      |
+| Deductible tolerance  | Customer input | Yes      |
+| Add-on needs          | Customer input | Yes      |
+| Recommendation result | System         | Yes      |
+| Deviation record      | Customer input | No       |
+
+### Regulatory
+
+- **IDD-001** — This story directly implements the demands-and-needs assessment
+  requirement; assessment must be completed before quote finalization
+- **IDD-006** — The generated recommendation constitutes advice and must be
+  documented per advice requirements
+- **IDD-008** — Assessment records must be retained for 5+ years after end of
+  customer relationship
+- **GDPR-001** — Assessment data is personal data collected under Article
+  6(1)(b) pre-contractual steps
+- **FSA-004** — Assessment ensures fair treatment by recommending suitable
+  products
+- **FSA-012** — Assessment is part of the pre-contractual disclosure obligation
+
+---
+
+## QNB-04: Compare Coverage Tiers
+
+**As a** private customer (privatkund),
+**I want to** compare trafikförsäkring, halvförsäkring, and helförsäkring
+coverage tiers side by side,
+**so that** I can make an informed choice about my coverage level.
+
+### Acceptance Criteria
+
+- **GIVEN** the demands-and-needs assessment (QNB-03) is completed
+  **WHEN** the system presents coverage options
+  **THEN** all three tiers are displayed in a side-by-side comparison with:
+  - What is covered in each tier
+  - What is not covered in each tier
+  - Premium (premie) for each tier
+  - Deductible (självrisk) amount for each tier
+
+- **GIVEN** the comparison is displayed
+  **WHEN** the customer views the options
+  **THEN** the system highlights the recommended tier based on the
+  demands-and-needs assessment (QNB-03)
+
+- **GIVEN** optional add-ons are available
+  **WHEN** the customer views the comparison
+  **THEN** each add-on (rental car, roadside assistance, legal protection)
+  is listed with its individual price, clearly separated from the base
+  premium
+
+- **GIVEN** the customer selects a coverage tier
+  **WHEN** the system updates the quote
+  **THEN** the total premium is recalculated including the selected tier and
+  any add-ons
+
+- **GIVEN** the IPID for each tier has been generated
+  **WHEN** the customer views a coverage tier
+  **THEN** the customer can access the corresponding IPID document for that
+  tier
+
+### Data Requirements
+
+| Data Element              | Source          | Required |
+| ------------------------- | --------------- | -------- |
+| Coverage details per tier | Product catalog | Yes      |
+| Premium per tier          | Rating engine   | Yes      |
+| Deductible per tier       | Product catalog | Yes      |
+| Add-on pricing            | Rating engine   | Yes      |
+| IPID per tier             | Document store  | Yes      |
+| Recommendation highlight  | QNB-03 output   | Yes      |
+
+### Regulatory
+
+- **IDD-002** — IPID must be provided for each product tier before binding
+- **IDD-007** — Add-ons must be presented with separate pricing; customer must
+  be informed they are optional
+- **IDD-001** — Comparison must follow from the demands-and-needs assessment
+- **FSA-004** — Comparison must support fair treatment and informed
+  decision-making
+- **FSA-012** — Coverage terms and exclusions must be clearly disclosed
+
+---
+
+## QNB-05: Sign Policy with BankID
+
+**As a** private customer (privatkund),
+**I want to** sign my insurance policy digitally using BankID,
+**so that** the process is fully digital and legally binding.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has selected a coverage tier, deductible, and add-ons
+  **WHEN** the customer proceeds to signing
+  **THEN** the system presents a binding summary showing:
+  - Selected coverage tier and coverage details
+  - Premium amount and payment frequency (monthly/annual)
+  - Deductible amount
+  - Policy effective date
+  - Pre-contractual information (IDD-003)
+  - Confirmation that the IPID has been provided (IDD-002)
+  - Confirmation that the demands-and-needs assessment is recorded (IDD-001)
+
+- **GIVEN** the binding summary is presented
+  **WHEN** the customer initiates signing
+  **THEN** the system triggers a BankID signing request with the policy
+  document hash
+
+- **GIVEN** the customer completes BankID signing
+  **WHEN** the signature is verified
+  **THEN** the policy is bound with the signing timestamp and BankID
+  transaction reference stored
+
+- **GIVEN** BankID signing fails or times out
+  **WHEN** the system detects the failure
+  **THEN** the customer is shown an error message and can retry without
+  re-entering data; the quote remains valid for the configured validity
+  period
+
+- **GIVEN** the customer is under 18 years of age
+  **WHEN** the system checks the customer's age from personnummer
+  **THEN** the system prevents policy binding and displays a message
+  indicating that a legal guardian must be the policyholder
+
+### Data Requirements
+
+| Data Element              | Source       | Required |
+| ------------------------- | ------------ | -------- |
+| BankID transaction ref    | BankID       | Yes      |
+| Signing timestamp         | BankID       | Yes      |
+| Policy document hash      | System       | Yes      |
+| Customer age verification | Personnummer | Yes      |
+| Binding summary content   | System       | Yes      |
+
+### External Integrations
+
+- **BankID** — Digital signing and identity verification
+
+### Regulatory
+
+- **IDD-003** — Pre-contractual information must be presented before signing
+- **IDD-002** — IPID delivery must be confirmed before signing
+- **IDD-001** — Demands-and-needs assessment must be completed before signing
+- **IDD-008** — Signing record must be retained as part of distribution records
+- **FSA-012** — Contract terms and conditions must be disclosed before binding
+- **FSA-013** — Customer must be informed of the 14-day cooling-off right
+  (ångerrätt) at the point of signing
+- **GDPR-001** — BankID transaction data is personal data; legal basis is
+  Article 6(1)(b) contract performance
+
+---
+
+## QNB-06: Receive Insurance Certificate Immediately
+
+**As a** private customer (privatkund),
+**I want to** receive my insurance certificate (försäkringsbevis) immediately
+after binding,
+**so that** I can prove I have valid insurance and drive legally.
+
+### Acceptance Criteria
+
+- **GIVEN** the policy has been bound successfully (QNB-05 completed)
+  **WHEN** the binding is confirmed
+  **THEN** the system generates a policy number in the format defined by
+  TryggFörsäkring's numbering convention
+
+- **GIVEN** the policy number has been assigned
+  **WHEN** the system generates confirmation documents
+  **THEN** the customer receives:
+  - Insurance certificate (försäkringsbevis) with policy number, coverage
+    dates, and vehicle details
+  - Full policy document with terms and conditions
+  - IPID for the selected coverage tier
+  - Payment instructions (first premium or direct debit setup)
+
+- **GIVEN** confirmation documents are generated
+  **WHEN** the documents are delivered
+  **THEN** they are sent via the customer's preferred channel (email,
+  digital portal, or both)
+
+- **GIVEN** the policy is bound
+  **WHEN** the system processes the new policy
+  **THEN** payment setup is initiated per the customer's selected payment
+  method (monthly autogiro or annual invoice)
+
+- **GIVEN** the insurance certificate is generated
+  **WHEN** the customer views their policy in the self-service portal
+  **THEN** the certificate is available for download as a PDF
+
+### Data Requirements
+
+| Data Element            | Source         | Required |
+| ----------------------- | -------------- | -------- |
+| Policy number           | System         | Yes      |
+| Coverage effective date | System/quote   | Yes      |
+| Coverage expiry date    | System/quote   | Yes      |
+| Vehicle details         | Quote data     | Yes      |
+| Customer contact info   | Customer data  | Yes      |
+| Payment method          | Customer input | Yes      |
+
+### External Integrations
+
+- **Payment Provider** — Set up recurring premium collection (autogiro) or
+  generate invoice
+
+### Regulatory
+
+- **FSA-012** — Policy documents must be provided to the customer after
+  binding
+- **FSA-007** — Insurance certificate proves the vehicle has valid
+  trafikförsäkring
+- **FSA-013** — Documents must include information about the 14-day
+  cooling-off right (ångerrätt)
+- **GDPR-002** — Policy data processing; legal basis is Article 6(1)(b)
+  contract performance
+
+---
+
+## QNB-07: Automatic Bonus Class Calculation
+
+**As an** underwriter (riskbedömare),
+**I want the** system to apply bonus class (bonusklass) rules automatically
+during quoting,
+**so that** premiums are calculated correctly based on the customer's
+claims-free driving history.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has an existing bonus class in the system
+  **WHEN** a new quote is generated
+  **THEN** the current bonus class is applied to the premium calculation
+
+- **GIVEN** the customer is transferring from another insurer
+  **WHEN** the customer provides proof of their current bonus class
+  **THEN** the system allows manual entry of the transferred bonus class
+  subject to verification
+
+- **GIVEN** a new customer with no previous insurance history
+  **WHEN** a quote is generated
+  **THEN** the system applies the starting bonus class per underwriting
+  guidelines
+
+- **GIVEN** the bonus class system uses a scale from 1 (highest premium) to
+  a configured maximum (lowest premium)
+  **WHEN** the premium is calculated
+  **THEN** the correct discount percentage is applied per the published
+  bonus table
+
+- **GIVEN** the customer has had claims in the current or previous policy
+  period
+  **WHEN** the system recalculates the bonus class
+  **THEN** the bonus class is reduced according to the claims penalty rules
+  defined in underwriting guidelines
+
+### Data Requirements
+
+| Data Element           | Source                | Required |
+| ---------------------- | --------------------- | -------- |
+| Current bonus class    | Internal database     | Yes      |
+| Claims history         | Internal database     | Yes      |
+| Transferred bonus      | Customer/prev insurer | No       |
+| Bonus scale definition | Underwriting rules    | Yes      |
+| Claims penalty rules   | Underwriting rules    | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Bonus class rules must be transparent and applied
+  consistently for fair treatment
+- **FSA-005** — Bonus rules are part of the product governance framework
+- **IDD-004** — Pricing logic including bonus must align with target market
+  definitions
+- **GDPR-001** — Claims history and bonus class are personal data; processing
+  based on Article 6(1)(b) contract performance
+
+---
+
+## QNB-08: Notify Transportstyrelsen of New Policy
+
+**As the** system,
+**I want to** notify Transportstyrelsen when a new motor insurance policy is
+bound,
+**so that** the vehicle registry reflects the current insurance status and the
+vehicle is legally insured.
+
+### Acceptance Criteria
+
+- **GIVEN** a new motor insurance policy has been bound (QNB-05 completed)
+  **WHEN** the system processes the policy binding event
+  **THEN** a notification is sent to Transportstyrelsen containing:
+  - Registreringsnummer
+  - Policy number
+  - Insurance company identifier (TryggFörsäkring)
+  - Coverage start date
+  - Coverage type (trafikförsäkring, halvförsäkring, or helförsäkring)
+
+- **GIVEN** the notification is sent
+  **WHEN** Transportstyrelsen acknowledges receipt
+  **THEN** the system records the acknowledgement reference and timestamp
+
+- **GIVEN** the notification fails (network error, validation error)
+  **WHEN** the system detects the failure
+  **THEN** the notification is queued for automatic retry with exponential
+  backoff, and an alert is raised for operations staff after a configured
+  number of failures
+
+- **GIVEN** the policy replaces an existing policy from another insurer
+  **WHEN** the notification is processed by Transportstyrelsen
+  **THEN** the previous insurer's coverage end date is updated in the
+  vehicle registry
+
+- **GIVEN** the notification must be sent within regulated timeframes
+  **WHEN** the policy is bound
+  **THEN** the notification is sent within the same business day or within
+  the timeframe specified by Transportstyrelsen's integration
+  requirements
+
+### Data Requirements
+
+| Data Element              | Source             | Required |
+| ------------------------- | ------------------ | -------- |
+| Registreringsnummer       | Policy data        | Yes      |
+| Policy number             | System             | Yes      |
+| Insurance company ID      | System config      | Yes      |
+| Coverage start date       | Policy data        | Yes      |
+| Coverage type             | Policy data        | Yes      |
+| Acknowledgement reference | Transportstyrelsen | Yes      |
+
+### External Integrations
+
+- **Transportstyrelsen** — Insurance status notification API
+
+### Regulatory
+
+- **FSA-009** — Insurers must notify Transportstyrelsen of policy changes
+  within regulated timeframes
+- **FSA-007** — Notification ensures the vehicle registry reflects valid
+  trafikförsäkring status
+- **GDPR-004** — Data sharing with Transportstyrelsen is based on legal
+  obligation under Trafikskadelagen
+
+---
+
+## Data Model
+
+The following data entities are central to the quote-and-bind process.
+
+### Quote
+
+| Attribute             | Type     | Description                                   |
+| --------------------- | -------- | --------------------------------------------- |
+| Quote ID              | String   | Unique identifier for the quote               |
+| Customer personnummer | String   | Swedish personal identity number              |
+| Registreringsnummer   | String   | Vehicle registration number                   |
+| Vehicle make          | String   | From Transportstyrelsen lookup                |
+| Vehicle model         | String   | From Transportstyrelsen lookup                |
+| Vehicle year          | Integer  | Model year from Transportstyrelsen            |
+| Coverage tier         | Enum     | Trafik / Halv / Hel                           |
+| Deductible amount     | Decimal  | Selected självrisk in SEK                     |
+| Base premium          | Decimal  | Annual premium before add-ons                 |
+| Add-ons               | List     | Selected optional coverages with pricing      |
+| Total premium         | Decimal  | Base premium + add-on premiums                |
+| Payment frequency     | Enum     | Monthly / Annual                              |
+| Bonus class applied   | Integer  | Bonus class used for premium calculation      |
+| Validity period       | Date     | Quote expiry date                             |
+| Assessment reference  | String   | Link to demands-and-needs assessment (QNB-03) |
+| IPID version          | String   | Version of IPID provided                      |
+| Created timestamp     | DateTime | When the quote was created                    |
+| Distribution channel  | Enum     | Digital / Agent / Broker                      |
+| Agent ID              | String   | If agent-assisted (nullable)                  |
+
+### Policy
+
+| Attribute              | Type     | Description                             |
+| ---------------------- | -------- | --------------------------------------- |
+| Policy number          | String   | Unique policy identifier                |
+| Quote ID               | String   | Reference to originating quote          |
+| Customer personnummer  | String   | Policyholder identity                   |
+| Registreringsnummer    | String   | Insured vehicle                         |
+| Coverage tier          | Enum     | Trafik / Halv / Hel                     |
+| Deductible amount      | Decimal  | Självrisk in SEK                        |
+| Total premium          | Decimal  | Bound premium amount                    |
+| Payment frequency      | Enum     | Monthly / Annual                        |
+| Effective date         | Date     | Coverage start date                     |
+| Expiry date            | Date     | Huvudförfallodag (policy anniversary)   |
+| Bonus class            | Integer  | Bonus class at time of binding          |
+| Status                 | Enum     | Active / Cancelled / Expired            |
+| BankID transaction ref | String   | Signing reference                       |
+| Signing timestamp      | DateTime | When the policy was signed              |
+| Transportstyrelsen ref | String   | Notification acknowledgement reference  |
+| Distribution channel   | Enum     | Digital / Agent / Broker                |
+| Agent ID               | String   | If agent-assisted (nullable)            |
+| Assessment reference   | String   | Link to demands-and-needs assessment    |
+| Cooling-off expiry     | Date     | Ångerrätt expiry (14 days from binding) |
+
+### Demands-and-Needs Assessment
+
+| Attribute                | Type     | Description                                   |
+| ------------------------ | -------- | --------------------------------------------- |
+| Assessment ID            | String   | Unique identifier                             |
+| Customer personnummer    | String   | Assessed customer                             |
+| Vehicle usage            | Enum     | Commuting / Business / Leisure                |
+| Annual mileage           | Integer  | Estimated yearly kilometers                   |
+| Parking situation        | Enum     | Garage / Carport / Street / Other             |
+| Deductible tolerance     | Enum     | Low / Medium / High                           |
+| Add-on needs             | List     | Stated needs for optional coverages           |
+| Recommended tier         | Enum     | System recommendation: Trafik / Halv / Hel    |
+| Recommended deductible   | Decimal  | Recommended självrisk in SEK                  |
+| Recommendation rationale | Text     | Why this tier and deductible were recommended |
+| Customer decision        | Enum     | Followed / Deviated                           |
+| Deviation explanation    | Text     | Customer's reason for deviating (nullable)    |
+| Completed by             | String   | Customer / Agent ID                           |
+| Completed timestamp      | DateTime | When the assessment was completed             |
+
+---
+
+## Process Flow
+
+The quote-and-bind process follows this sequence:
+
+1. **Customer identification** — Customer enters registreringsnummer and
+   personnummer; system verifies identity (QNB-01 or QNB-02)
+2. **Vehicle data lookup** — System retrieves vehicle details from
+   Transportstyrelsen
+3. **Bonus class retrieval** — System retrieves or calculates the customer's
+   current bonus class (QNB-07)
+4. **Demands-and-needs assessment** — System guides the customer through the
+   structured assessment (QNB-03)
+5. **Premium calculation** — System calculates premiums for all three tiers
+   using vehicle data, bonus class, and risk factors
+6. **Coverage comparison** — Customer reviews and compares tiers with IPID
+   access (QNB-04)
+7. **Coverage selection** — Customer selects tier, deductible, and optional
+   add-ons
+8. **Pre-contractual review** — System presents binding summary with all
+   required pre-contractual information (IDD-003)
+9. **BankID signing** — Customer signs the policy digitally (QNB-05)
+10. **Policy issuance** — System generates policy number and insurance
+    certificate (QNB-06)
+11. **Payment setup** — System initiates premium collection via payment
+    provider (QNB-06)
+12. **Transportstyrelsen notification** — System notifies the vehicle
+    registry (QNB-08)
+13. **Confirmation** — Customer receives policy documents, insurance
+    certificate, and IPID
+
+---
+
+## Regulatory Traceability Matrix
+
+| Requirement | QNB-01 | QNB-02 | QNB-03 | QNB-04 | QNB-05 | QNB-06 | QNB-07 | QNB-08 |
+| ----------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| FSA-004     |        | X      | X      | X      | X      |        | X      |        |
+| FSA-005     |        |        |        |        |        |        | X      |        |
+| FSA-007     | X      |        |        |        |        | X      |        | X      |
+| FSA-009     |        |        |        |        |        |        |        | X      |
+| FSA-012     |        |        | X      | X      | X      | X      |        |        |
+| FSA-013     |        |        |        |        | X      | X      |        |        |
+| GDPR-001    | X      | X      | X      |        | X      |        | X      |        |
+| GDPR-002    |        |        |        |        |        | X      |        |        |
+| GDPR-004    |        |        |        |        |        |        |        | X      |
+| IDD-001     | X      | X      | X      | X      | X      |        |        |        |
+| IDD-002     |        |        |        | X      | X      |        |        |        |
+| IDD-003     |        |        |        |        | X      |        |        |        |
+| IDD-004     |        |        |        |        |        |        | X      |        |
+| IDD-005     |        | X      |        |        |        |        |        |        |
+| IDD-006     |        | X      | X      |        |        |        |        |        |
+| IDD-007     |        |        |        | X      |        |        |        |        |
+| IDD-008     |        | X      | X      |        | X      |        |        |        |
+| IDD-009     |        | X      |        |        |        |        |        |        |
+
+---
+
+## External System Integration Summary
+
+| System             | Integration Point                 | Stories        |
+| ------------------ | --------------------------------- | -------------- |
+| Transportstyrelsen | Vehicle data lookup               | QNB-01, QNB-02 |
+| Transportstyrelsen | Insurance status notification     | QNB-08         |
+| BankID             | Customer identity verification    | QNB-01         |
+| BankID             | Agent authentication              | QNB-02         |
+| BankID             | Digital policy signing            | QNB-05         |
+| Payment Provider   | Premium collection setup          | QNB-06         |
+| TFF                | Bonus class transfer verification | QNB-07         |

--- a/docs/phase-1-motor/user-stories/underwriting-bonus.md
+++ b/docs/phase-1-motor/user-stories/underwriting-bonus.md
@@ -1,0 +1,654 @@
+---
+sidebar_position: 3
+---
+
+# Underwriting Rules and Bonus System — User Stories
+
+User stories for the motor insurance underwriting rules and bonus class system
+(bonusklasser). These rules determine who gets insured, at what price, and under
+what terms. The bonus class system is the primary mechanism for rewarding
+claim-free driving with premium discounts.
+
+## Overview
+
+| ID     | Actor              | Summary                                         |
+| ------ | ------------------ | ----------------------------------------------- |
+| UWB-01 | Underwriter        | Manage bonus class table and progression rules  |
+| UWB-02 | Private Customer   | Transfer bonus class from another insurer       |
+| UWB-03 | System             | Calculate premium using rating factors          |
+| UWB-04 | Underwriter        | Define risk acceptance and referral rules       |
+| UWB-05 | Private Customer   | Understand premium calculation breakdown        |
+| UWB-06 | Actuary            | Review documented underwriting rules            |
+| UWB-07 | Compliance Officer | Verify non-discriminatory underwriting practice |
+
+---
+
+## UWB-01: Bonus Class Table and Progression Rules
+
+**As an** underwriter (riskbedömare),
+**I want** the system to maintain a complete bonus class table with progression
+and regression rules,
+**so that** all customers are rated consistently according to their claims-free
+driving history.
+
+### Acceptance Criteria
+
+- **GIVEN** the bonus class system uses a scale from class 1 (no discount) to
+  class 15 (maximum discount)
+  **WHEN** the system loads the bonus table
+  **THEN** each class has a defined discount percentage, with class 1 at 0%
+  discount and class 15 at the maximum configured discount
+
+- **GIVEN** a customer has been claim-free for a full policy year
+  **WHEN** the huvudförfallodag (policy anniversary) is reached
+  **THEN** the system advances the customer's bonus class by one step (e.g.,
+  class 5 to class 6), up to the maximum class 15
+
+- **GIVEN** a customer has one at-fault claim during the policy year
+  **WHEN** the huvudförfallodag is reached
+  **THEN** the system reduces the customer's bonus class by 3 steps (e.g.,
+  class 10 to class 7), with a minimum of class 1
+
+- **GIVEN** a customer has more than one at-fault claim during the policy year
+  **WHEN** the huvudförfallodag is reached
+  **THEN** the system reduces the customer's bonus class by 5 steps per
+  additional claim, with a minimum of class 1
+
+- **GIVEN** a new customer with no previous insurance history in Sweden
+  **WHEN** the first policy is created
+  **THEN** the system assigns the default starting bonus class (class 7, as
+  defined by underwriting guidelines)
+
+- **GIVEN** only at-fault claims affect the bonus class
+  **WHEN** a claim is classified as not-at-fault (e.g., parked vehicle hit by
+  third party)
+  **THEN** the customer's bonus class is not reduced
+
+### Bonus Class Table
+
+| Class | Discount (%) | Years claim-free from class 1 |
+| ----- | ------------ | ----------------------------- |
+| 1     | 0            | 0                             |
+| 2     | 5            | 1                             |
+| 3     | 10           | 2                             |
+| 4     | 15           | 3                             |
+| 5     | 20           | 4                             |
+| 6     | 25           | 5                             |
+| 7     | 30           | 6 (default start)             |
+| 8     | 35           | 7                             |
+| 9     | 40           | 8                             |
+| 10    | 45           | 9                             |
+| 11    | 50           | 10                            |
+| 12    | 55           | 11                            |
+| 13    | 60           | 12                            |
+| 14    | 65           | 13                            |
+| 15    | 70           | 14                            |
+
+### Data Requirements
+
+| Data Element            | Source             | Required |
+| ----------------------- | ------------------ | -------- |
+| Bonus class table       | System config      | Yes      |
+| Current bonus class     | Internal database  | Yes      |
+| Claims history          | Internal database  | Yes      |
+| At-fault classification | Claims system      | Yes      |
+| Huvudförfallodag        | Policy data        | Yes      |
+| Progression/regression  | Underwriting rules | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Bonus rules must be transparent and consistently applied for
+  fair treatment of all customers
+- **FSA-005** — Bonus class system is part of the product governance framework;
+  rules must be reviewed annually
+- **IDD-004** — Pricing logic including bonus must align with target market
+  definitions
+- **GDPR-001** — Claims history and bonus class are personal data; processing
+  based on Article 6(1)(b) contract performance
+
+---
+
+## UWB-02: Transfer Bonus Class from Another Insurer
+
+**As a** private customer (privatkund),
+**I want to** transfer my bonus class when switching from another insurer,
+**so that** I retain my no-claims discount and do not pay a higher premium.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer indicates they have an existing bonus class from
+  another Swedish insurer
+  **WHEN** the customer provides the previous insurer's name and claimed bonus
+  class
+  **THEN** the system records the claimed bonus class as provisional, pending
+  verification
+
+- **GIVEN** a provisional bonus class has been recorded
+  **WHEN** the system processes the transfer
+  **THEN** the system requests verification from the previous insurer via TFF
+  (Trafikförsäkringsföreningen) or direct inquiry
+
+- **GIVEN** the previous insurer confirms the bonus class
+  **WHEN** the verification response is received
+  **THEN** the system updates the customer's bonus class from provisional to
+  confirmed, and recalculates the premium if the verified class differs from
+  the claimed class
+
+- **GIVEN** the previous insurer does not respond within 30 days
+  **WHEN** the verification deadline expires
+  **THEN** the system alerts an underwriter for manual review, and the
+  provisional bonus class remains in effect until resolved
+
+- **GIVEN** the customer is transferring from an EU/EEA insurer (not Swedish)
+  **WHEN** the customer provides documentation of their claims-free history
+  **THEN** the system allows the underwriter to manually assign an equivalent
+  Swedish bonus class based on the documented history, subject to underwriting
+  guidelines
+
+- **GIVEN** the verified bonus class differs from the claimed bonus class
+  **WHEN** the verification is completed
+  **THEN** the system adjusts the premium accordingly and notifies the customer
+  of the change; any premium difference is collected or refunded
+
+### Data Requirements
+
+| Data Element             | Source                 | Required |
+| ------------------------ | ---------------------- | -------- |
+| Claimed bonus class      | Customer input         | Yes      |
+| Previous insurer name    | Customer input         | Yes      |
+| Verification request     | TFF / previous insurer | Yes      |
+| Verification response    | TFF / previous insurer | Yes      |
+| Supporting documentation | Customer upload        | No       |
+| Adjusted bonus class     | System / underwriter   | Yes      |
+
+### External Integrations
+
+- **TFF** — Bonus class transfer verification between Swedish insurers
+- **Previous insurer** — Direct inquiry for EU/EEA transfers
+
+### Regulatory
+
+- **FSA-004** — Fair treatment requires honoring legitimate bonus class
+  transfers; customers must not be penalized for switching insurers
+- **GDPR-001** — Transfer data includes personal data (claims history);
+  processing based on Article 6(1)(b) pre-contractual steps
+- **GDPR-003** — Claims history from previous insurer constitutes personal data;
+  data minimization applies — request only the bonus class, not full claim
+  details
+- **IDD-004** — Transfer rules must be documented as part of product governance
+
+---
+
+## UWB-03: Calculate Premium Using Rating Factors
+
+**As the** system,
+**I want to** calculate the motor insurance premium by applying all applicable
+rating factors to the base premium,
+**so that** each customer receives a risk-adjusted price that reflects their
+individual risk profile.
+
+### Acceptance Criteria
+
+- **GIVEN** the system has the customer's vehicle and personal data
+  **WHEN** a premium calculation is triggered
+  **THEN** the system applies all rating factors in the following order:
+  1. Determine the base premium by coverage tier (trafik/halv/hel)
+  2. Apply vehicle factors (make, model, year, safety rating, theft risk,
+     repair cost group)
+  3. Apply customer factors (age, postal code, occupation)
+  4. Apply usage factors (annual mileage band, parking type, vehicle usage)
+  5. Apply the bonus class discount
+  6. Apply the deductible (självrisk) adjustment
+  7. Enforce minimum and maximum premium limits
+
+- **GIVEN** the customer's age is between 18 and 25
+  **WHEN** the age factor is applied
+  **THEN** a young driver surcharge is added, as defined in the rating factor
+  table
+
+- **GIVEN** the customer's postal code maps to a risk zone
+  **WHEN** the location factor is applied
+  **THEN** the system applies the risk zone multiplier for that postal code
+
+- **GIVEN** the vehicle's make and model are in the vehicle risk classification
+  table
+  **WHEN** the vehicle factor is applied
+  **THEN** the system applies the combined multiplier for safety rating, theft
+  risk index, and repair cost group
+
+- **GIVEN** the customer has selected a deductible (självrisk) amount
+  **WHEN** the deductible adjustment is applied
+  **THEN** a higher deductible reduces the premium and a lower deductible
+  increases it, according to the deductible factor table
+
+- **GIVEN** all rating factors have been applied
+  **WHEN** the final premium is calculated
+  **THEN** the premium is not below the configured minimum premium and not
+  above the configured maximum premium for the coverage tier
+
+### Rating Factor Catalog
+
+| Factor         | Values / Bands                                       | Impact     |
+| -------------- | ---------------------------------------------------- | ---------- |
+| Coverage tier  | Trafik / Halv / Hel                                  | Base rate  |
+| Vehicle group  | Make, model, year → risk classification group (1–50) | Multiplier |
+| Safety rating  | Euro NCAP or equivalent (1–5 stars)                  | Multiplier |
+| Theft risk     | Theft risk index per vehicle model (low/medium/high) | Multiplier |
+| Repair cost    | Repair cost group (1–20)                             | Multiplier |
+| Age            | 18–25, 26–65, 66+                                    | Multiplier |
+| Postal code    | Risk zone (1–5 based on claim frequency by area)     | Multiplier |
+| Annual mileage | 0–1000, 1001–1500, 1501–2000, 2001+ mil              | Multiplier |
+| Parking        | Garage, carport, street, other                       | Multiplier |
+| Vehicle usage  | Private, commute, business                           | Multiplier |
+| Occupation     | Occupation group (risk-correlated grouping)          | Multiplier |
+| Bonus class    | Class 1–15 → discount 0%–70%                         | Discount   |
+| Deductible     | 1 500, 3 000, 5 000, 7 500, 10 000 SEK               | Adjustment |
+
+### Data Requirements
+
+| Data Element            | Source             | Required |
+| ----------------------- | ------------------ | -------- |
+| Base premium per tier   | Rating engine      | Yes      |
+| Vehicle risk group      | Vehicle registry   | Yes      |
+| Safety rating           | Euro NCAP database | Yes      |
+| Theft risk index        | Industry data      | Yes      |
+| Repair cost group       | Industry data      | Yes      |
+| Customer age            | Personnummer       | Yes      |
+| Postal code             | Customer input     | Yes      |
+| Annual mileage estimate | Customer input     | Yes      |
+| Parking type            | Customer input     | Yes      |
+| Vehicle usage           | Customer input     | Yes      |
+| Occupation              | Customer input     | No       |
+| Bonus class             | Internal database  | Yes      |
+| Selected deductible     | Customer input     | Yes      |
+
+### External Integrations
+
+- **Transportstyrelsen** — Vehicle data for risk classification
+- **Euro NCAP** — Safety rating lookup (may be cached locally)
+
+### Regulatory
+
+- **FSA-004** — Rating factors must be transparent and non-discriminatory; the
+  premium calculation must support fair treatment
+- **FSA-005** — Rating factor definitions are part of the product governance
+  framework; factors must be reviewed annually for continued relevance
+- **IDD-004** — Premium calculation logic must align with target market
+  definitions for each coverage tier
+- **GDPR-001** — Rating factor data (age, postal code, occupation) is personal
+  data; processing based on Article 6(1)(b) pre-contractual steps
+- **FSA-012** — The premium calculation method must be disclosed to the customer
+  upon request
+
+---
+
+## UWB-04: Risk Acceptance and Referral Rules
+
+**As an** underwriter (riskbedömare),
+**I want** the system to apply risk acceptance, referral, and decline rules
+automatically,
+**so that** high-risk applications are flagged for manual review and
+unacceptable risks are declined consistently.
+
+### Acceptance Criteria
+
+- **GIVEN** a quote request meets all standard acceptance criteria
+  **WHEN** the system evaluates the risk
+  **THEN** the quote is approved automatically and proceeds to premium
+  calculation without manual intervention
+
+- **GIVEN** a quote request triggers one or more referral rules
+  **WHEN** the system evaluates the risk
+  **THEN** the quote is placed in a referral queue with the triggered rule(s)
+  listed, and an underwriter is notified for manual review
+
+- **GIVEN** a quote request triggers a decline rule
+  **WHEN** the system evaluates the risk
+  **THEN** the quote is declined automatically with a clear reason provided to
+  the customer, and the decline is logged for reporting
+
+- **GIVEN** the vehicle is a modified vehicle (e.g., engine tuning, body
+  modifications)
+  **WHEN** the system evaluates the risk
+  **THEN** the application is referred to an underwriter for manual assessment
+
+- **GIVEN** the vehicle is an imported vehicle not yet in the Swedish vehicle
+  registry
+  **WHEN** the system evaluates the risk
+  **THEN** the application is referred to an underwriter, pending
+  Transportstyrelsen registration
+
+- **GIVEN** the vehicle is classified as a classic car (30+ years old)
+  **WHEN** the system evaluates the risk
+  **THEN** the application is referred to an underwriter for specialized
+  classic car assessment, including agreed value evaluation
+
+- **GIVEN** the customer has 3 or more at-fault claims in the last 3 years
+  **WHEN** the system evaluates the risk
+  **THEN** the application is referred to an underwriter for portfolio risk
+  assessment
+
+### Risk Acceptance Matrix
+
+| Criteria                                | Action  | Notes                           |
+| --------------------------------------- | ------- | ------------------------------- |
+| Standard vehicle, driver 26–65          | Accept  | Automatic approval              |
+| Young driver (18–25)                    | Accept  | Surcharge applied automatically |
+| Senior driver (66+)                     | Accept  | Standard rates apply            |
+| Modified vehicle                        | Refer   | Underwriter assesses risk       |
+| Imported vehicle (not yet registered)   | Refer   | Pending Transportstyrelsen      |
+| Classic car (30+ years)                 | Refer   | Agreed value assessment         |
+| 3+ at-fault claims in 3 years           | Refer   | Portfolio risk review           |
+| Customer previously declined by insurer | Refer   | Review decline history          |
+| Vehicle used for racing or competition  | Decline | Outside product scope           |
+| Vehicle without valid registration      | Decline | Cannot insure unregistered      |
+| Customer under 18 years of age          | Decline | Legal minimum age requirement   |
+
+### Data Requirements
+
+| Data Element            | Source             | Required |
+| ----------------------- | ------------------ | -------- |
+| Vehicle type/category   | Transportstyrelsen | Yes      |
+| Vehicle modifications   | Customer input     | Yes      |
+| Vehicle age             | Transportstyrelsen | Yes      |
+| Customer age            | Personnummer       | Yes      |
+| Claims history (3 yr)   | Internal database  | Yes      |
+| Previous decline record | Internal database  | No       |
+| Vehicle usage           | Customer input     | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Decline decisions must be communicated clearly and fairly;
+  customers must be informed of the reason for decline
+- **FSA-005** — Risk acceptance rules are part of the product governance
+  framework; referral and decline criteria must be reviewed annually
+- **FSA-007** — Trafikförsäkring must be offered to all vehicle owners; decline
+  of trafikförsäkring is only permitted in exceptional circumstances defined by
+  law
+- **IDD-004** — Risk acceptance criteria must be consistent with target market
+  definitions; products must not be sold outside their intended market
+- **GDPR-001** — Risk assessment uses personal data; processing based on Article
+  6(1)(b) pre-contractual steps
+
+---
+
+## UWB-05: Premium Calculation Transparency
+
+**As a** private customer (privatkund),
+**I want to** see a breakdown of how my premium is calculated,
+**so that** I understand what factors influence my price and trust that the
+pricing is fair.
+
+### Acceptance Criteria
+
+- **GIVEN** the system has calculated a premium for the customer
+  **WHEN** the customer views the quote
+  **THEN** the system displays a summary showing: base premium, bonus class
+  discount applied, and total premium
+
+- **GIVEN** the customer requests a detailed breakdown
+  **WHEN** the detailed view is opened
+  **THEN** the system shows each rating factor applied, including:
+  - Vehicle group and its impact
+  - Age band and any surcharge
+  - Risk zone (postal code area)
+  - Annual mileage band
+  - Parking type
+  - Deductible (självrisk) adjustment
+  - Bonus class and discount percentage
+
+- **GIVEN** the customer's bonus class has changed since the last quote or
+  renewal
+  **WHEN** the premium breakdown is displayed
+  **THEN** the system highlights the bonus class change and its impact on the
+  premium
+
+- **GIVEN** the customer changes a configurable factor (deductible, mileage
+  band, or add-ons)
+  **WHEN** the change is applied
+  **THEN** the premium is recalculated in real time and the updated breakdown
+  is displayed
+
+### Data Requirements
+
+| Data Element              | Source        | Required |
+| ------------------------- | ------------- | -------- |
+| Premium breakdown         | Rating engine | Yes      |
+| Factor descriptions       | System config | Yes      |
+| Bonus class history       | Internal DB   | No       |
+| Previous premium (if any) | Policy data   | No       |
+
+### Regulatory
+
+- **FSA-004** — Fair treatment requires pricing transparency; customers must be
+  able to understand the basis for their premium
+- **FSA-012** — Premium calculation basis must be disclosed as part of
+  pre-contractual information obligations
+- **IDD-001** — Premium transparency supports informed decision-making following
+  the demands-and-needs assessment
+- **GDPR-001** — The customer has the right to understand how their personal
+  data (age, location, claims history) influences their premium
+
+---
+
+## UWB-06: Documented Underwriting Rules for Actuarial Review
+
+**As an** actuary (aktuarie),
+**I want** all underwriting rules to be formally documented and version
+controlled,
+**so that** I can validate the rules against our pricing models and ensure
+actuarial soundness.
+
+### Acceptance Criteria
+
+- **GIVEN** the underwriting rules include the bonus class table, rating factor
+  definitions, and risk acceptance criteria
+  **WHEN** the actuary reviews the documentation
+  **THEN** each rule has a unique identifier, effective date, approval record,
+  and version number
+
+- **GIVEN** a change is proposed to any underwriting rule (bonus table, rating
+  factor, acceptance criteria)
+  **WHEN** the change is submitted
+  **THEN** it requires approval from both the underwriting manager and the
+  actuarial team before taking effect
+
+- **GIVEN** a rule change has been approved and implemented
+  **WHEN** the new version takes effect
+  **THEN** the system retains the previous version for audit purposes and
+  records the effective date range of each version
+
+- **GIVEN** the actuary needs to compare actual claims experience against
+  expected outcomes
+  **WHEN** the actuary requests performance data
+  **THEN** the system provides claims ratios, frequency, and severity data
+  segmented by the rating factors defined in the underwriting rules
+
+### Data Requirements
+
+| Data Element           | Source             | Required |
+| ---------------------- | ------------------ | -------- |
+| Rule definitions       | Underwriting rules | Yes      |
+| Rule version history   | System config      | Yes      |
+| Approval records       | Workflow system    | Yes      |
+| Claims performance     | Claims database    | Yes      |
+| Rating factor segments | Rating engine      | Yes      |
+
+### Regulatory
+
+- **FSA-005** — Product governance requires documented, reviewed underwriting
+  rules with formal change control
+- **FSA-006** — Supervisory reporting requires access to current and historical
+  underwriting rules
+- **IDD-004** — Product oversight requires that pricing rules are documented and
+  aligned with target market definitions
+
+---
+
+## UWB-07: Non-Discriminatory Underwriting Verification
+
+**As a** compliance officer (complianceansvarig),
+**I want** underwriting rules to be verified as non-discriminatory and
+transparent,
+**so that** TryggFörsäkring meets FSA consumer protection standards and
+avoids unfair pricing practices.
+
+### Acceptance Criteria
+
+- **GIVEN** the underwriting rules include all rating factors
+  **WHEN** the compliance officer reviews the rules
+  **THEN** no rating factor is based on a protected characteristic (gender,
+  ethnicity, religion, sexual orientation, disability) as prohibited by
+  Swedish discrimination law (Diskrimineringslagen, 2008:567)
+
+- **GIVEN** the rating factor "age" is used
+  **WHEN** the compliance officer reviews the factor
+  **THEN** the age factor is justified by actuarial evidence showing a
+  statistically significant correlation with claims frequency or severity
+
+- **GIVEN** the rating factor "postal code" is used
+  **WHEN** the compliance officer reviews the factor
+  **THEN** the factor is based on area-level claims statistics and does not
+  serve as a proxy for ethnicity or socioeconomic discrimination
+
+- **GIVEN** a customer disputes their premium as unfair
+  **WHEN** the complaint is investigated
+  **THEN** the compliance team can produce the full rating factor breakdown and
+  the actuarial justification for each factor applied
+
+- **GIVEN** the annual product governance review is conducted
+  **WHEN** the compliance officer participates in the review
+  **THEN** the review includes an assessment of whether any rating factor has
+  a disproportionate impact on a protected group
+
+### Data Requirements
+
+| Data Element              | Source             | Required |
+| ------------------------- | ------------------ | -------- |
+| Rating factor definitions | Underwriting rules | Yes      |
+| Actuarial justifications  | Actuarial reports  | Yes      |
+| Complaint records         | Complaints system  | No       |
+| Product review reports    | Governance records | Yes      |
+| Discrimination law ref    | Legal/compliance   | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Consumer protection requires non-discriminatory pricing; fair
+  treatment of all customer groups
+- **FSA-005** — Product governance must include assessment of fairness and
+  non-discrimination in rating factors
+- **IDD-004** — Product oversight must ensure that pricing does not exclude or
+  disadvantage customers outside the intended risk segmentation
+- **GDPR-001** — Automated decision-making using personal data for pricing must
+  comply with GDPR Article 22 (right not to be subject to purely automated
+  decisions with legal effects); customers can request human review
+
+---
+
+## Coverage Tier Definitions
+
+The following coverage tiers are available for motor insurance at
+TryggFörsäkring. Each tier builds on the one below it.
+
+### Trafikförsäkring (Mandatory Third-Party Liability)
+
+- **Scope:** Legally required under Trafikskadelagen (1975:1410)
+- **Covers:** Personal injury to all parties (driver, passengers, pedestrians,
+  cyclists); property damage to third parties
+- **Does not cover:** Damage to the policyholder's own vehicle
+- **Deductible:** Not applicable (no own-damage coverage)
+- **Regulatory:** FSA-007
+
+### Halvförsäkring (Partial Comprehensive — Tier 2)
+
+- **Scope:** Voluntary coverage that includes trafikförsäkring plus additional
+  protections
+- **Covers:** Everything in trafikförsäkring, plus: fire damage, theft, glass
+  damage, rescue and roadside assistance (vägassistans), legal expenses
+  (rättsskydd), engine breakdown
+- **Does not cover:** Collision damage to the policyholder's own vehicle
+- **Deductible options:** 1 500, 3 000, 5 000 SEK (standard options)
+- **Typical add-ons:** Rental car coverage, personal belongings in vehicle
+
+### Helförsäkring (Full Comprehensive — Tier 3)
+
+- **Scope:** Full coverage that includes trafikförsäkring, halvförsäkring, plus
+  own-damage collision coverage
+- **Covers:** Everything in halvförsäkring, plus: collision damage
+  (vagnskadeförsäkring) to the policyholder's own vehicle regardless of fault
+- **Deductible options:** 1 500, 3 000, 5 000, 7 500, 10 000 SEK
+- **Typical add-ons:** Rental car coverage, personal belongings, diminished
+  value coverage, new car replacement (within first year)
+
+---
+
+## Data Model
+
+The following data entities are central to the underwriting and bonus system.
+
+### Bonus Class Record
+
+| Attribute             | Type    | Description                            |
+| --------------------- | ------- | -------------------------------------- |
+| Customer personnummer | String  | Policyholder identity                  |
+| Current bonus class   | Integer | Current class (1–15)                   |
+| Effective date        | Date    | Date current class took effect         |
+| Source                | Enum    | Calculated / Transferred / Manual      |
+| Verification status   | Enum    | Confirmed / Provisional / Pending      |
+| Previous insurer      | String  | If transferred (nullable)              |
+| Claims in period      | Integer | At-fault claims since last anniversary |
+| Last progression date | Date    | Date of last bonus class change        |
+
+### Rating Factor Configuration
+
+| Attribute           | Type    | Description                                |
+| ------------------- | ------- | ------------------------------------------ |
+| Factor ID           | String  | Unique identifier (e.g., RF-AGE, RF-ZONE)  |
+| Factor name         | String  | Human-readable name                        |
+| Factor type         | Enum    | Multiplier / Discount / Adjustment         |
+| Value ranges        | JSON    | Defined bands or categories with values    |
+| Effective date      | Date    | When this configuration took effect        |
+| Version             | Integer | Configuration version number               |
+| Approved by         | String  | Approver identity                          |
+| Actuarial reference | String  | Link to actuarial justification (nullable) |
+
+### Risk Assessment
+
+| Attribute        | Type     | Description                                   |
+| ---------------- | -------- | --------------------------------------------- |
+| Assessment ID    | String   | Unique identifier                             |
+| Quote ID         | String   | Link to the quote being assessed              |
+| Decision         | Enum     | Accept / Refer / Decline                      |
+| Triggered rules  | List     | List of risk rules triggered                  |
+| Referral reason  | Text     | Reason for referral (nullable)                |
+| Decline reason   | Text     | Reason for decline (nullable)                 |
+| Underwriter ID   | String   | Assigned underwriter for referrals (nullable) |
+| Review outcome   | Enum     | Approved / Declined / Pending (nullable)      |
+| Review timestamp | DateTime | When the underwriter completed review         |
+
+---
+
+## Regulatory Traceability Matrix
+
+| Requirement | UWB-01 | UWB-02 | UWB-03 | UWB-04 | UWB-05 | UWB-06 | UWB-07 |
+| ----------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| FSA-004     | X      | X      | X      | X      | X      |        | X      |
+| FSA-005     | X      |        | X      | X      |        | X      | X      |
+| FSA-006     |        |        |        |        |        | X      |        |
+| FSA-007     |        |        |        | X      |        |        |        |
+| FSA-012     |        |        | X      |        | X      |        |        |
+| GDPR-001    | X      | X      | X      | X      | X      |        | X      |
+| GDPR-003    |        | X      |        |        |        |        |        |
+| IDD-001     |        |        |        |        | X      |        |        |
+| IDD-004     | X      | X      | X      | X      |        | X      | X      |
+
+---
+
+## External System Integration Summary
+
+| System             | Integration Point                    | Stories        |
+| ------------------ | ------------------------------------ | -------------- |
+| TFF                | Bonus class transfer verification    | UWB-02         |
+| Transportstyrelsen | Vehicle data for risk classification | UWB-03, UWB-04 |
+| Euro NCAP          | Vehicle safety rating lookup         | UWB-03         |
+| Previous insurer   | EU/EEA bonus transfer documentation  | UWB-02         |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md
@@ -50,12 +50,15 @@ processing and premium refund calculation.
 Use cases describing the detailed workflows for motor insurance claims
 processing.
 
-| ID                                         | Title                              | Scope                                         |
-| ------------------------------------------ | ---------------------------------- | --------------------------------------------- |
-| [UC-CLM-001](uc-claims-lifecycle.md)       | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
-| [UC-CLM-002](uc-fnol-processing.md)        | FNOL Processing                    | First notification of loss — online and phone |
-| [UC-CLM-003](uc-settlement-calculation.md) | Settlement Calculation and Payment | Settlement rules and payment execution        |
-| [UC-CLM-004](uc-fraud-screening.md)        | Fraud Screening and Investigation  | Automated and manual fraud detection          |
+| ID                                          | Title                              | Scope                                         |
+| ------------------------------------------- | ---------------------------------- | --------------------------------------------- |
+| [UC-CLM-001](uc-claims-lifecycle.md)        | Claims Lifecycle                   | End-to-end claims flow from FNOL to closure   |
+| [UC-CLM-002](uc-fnol-processing.md)         | FNOL Processing                    | First notification of loss — online and phone |
+| [UC-CLM-003](uc-settlement-calculation.md)  | Settlement Calculation and Payment | Settlement rules and payment execution        |
+| [UC-CLM-004](uc-fraud-screening.md)         | Fraud Screening and Investigation  | Automated and manual fraud detection          |
+| [UC-CLM-005](uc-liability-determination.md) | Liability Determination            | Fault assessment and liability allocation     |
+| [UC-CLM-006](uc-damage-assessment.md)       | Damage Assessment                  | Vehicle damage evaluation and cost estimation |
+| [UC-CLM-007](uc-claims-closure.md)          | Claims Closure                     | Final review, closure, and archiving          |
 
 ## Underwriting and Bonus Assessment
 


### PR DESCRIPTION
## Summary
- Syncs `docs/` directory with `versioned_docs/version-phase-1/` by copying 10 missing files (6 personas, 2 user story files, 2 use case files)
- Replaces stub content in `docs/personas/index.md` with full persona summary
- Adds missing Quote and Bind (QNB-01–08) and Underwriting Bonus (UWB-01–07) sections to user-stories index in `docs/`
- Adds missing Quote and Bind (UC-QNB-001) and Underwriting (UC-UWB-001) sections to use-cases index in `docs/`
- Adds UC-CLM-005 (Liability Determination), UC-CLM-006 (Damage Assessment), UC-CLM-007 (Claims Closure) to claims handling table in both `docs/` and `versioned_docs/` use-cases index

## Changes
- **14 files changed**: 10 new files copied, 4 index files updated
- `docs/personas/index.md` — replaced stub with full content
- `docs/phase-1-motor/user-stories/index.md` — added QNB and UWB sections
- `docs/phase-1-motor/use-cases/index.md` — added QNB, UWB, and CLM-005/006/007
- `versioned_docs/version-phase-1/phase-1-motor/use-cases/index.md` — added CLM-005/006/007

## Testing
- [x] markdownlint passes with zero warnings
- [x] prettier passes with zero warnings
- [x] `npm run build` succeeds
- [x] File sync verified: all .md files in versioned_docs have counterparts in docs

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)