### PR TITLE
docs(#58): Add Mermaid flowcharts and activity diagrams to all use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/policy-administration.md
+++ b/docs/phase-1-motor/use-cases/policy-administration.md
@@ -66,6 +66,35 @@ record entity provides a complete audit trail of every policy change.
 1. The customer has the registreringsnummer of the new vehicle
 1. The customer is authenticated via BankID
 
+### Vehicle Change Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer requests vehicle change] --> B[Enter new registreringsnummer]
+    B --> C[Transportstyrelsen vehicle lookup]
+    C --> D{Vehicle found?}
+    D -->|No| E[Manual entry required]
+    D -->|Yes| F[Display vehicle details for confirmation]
+    F --> G[Assess risk of new vehicle]
+    G --> H{High-risk vehicle?}
+    H -->|Yes| I[Underwriter review]
+    I --> J{Approved?}
+    J -->|No| K[Decline - notify customer]
+    J -->|Yes| L[Recalculate premium]
+    H -->|No| L
+    L --> M[Show premium change and pro-rata adjustment]
+    M --> N[Customer confirms]
+    N --> O[Update policy record]
+    O --> P[Notify Transportstyrelsen - old and new vehicle]
+    P --> Q[Trigger payment adjustment]
+    Q --> R[Reissue policy documents]
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style I fill:#fff3e0
+    style K fill:#ffebee
+```
+
 ### Main Success Scenario
 
 1. **Initiate** — Customer selects "Change vehicle" from their policy
@@ -784,6 +813,32 @@ stateDiagram-v2
 
 1. A policy amendment has been submitted that changes one or more rating factors
 1. The current premium and rating factors are known
+
+### Premium Recalculation Process Flow
+
+```mermaid
+flowchart TD
+    A["Amendment submitted
+    (trigger: rating factor changed)"] --> B[Identify changed factors]
+    B --> C[Retrieve current tariff and rating tables]
+    C --> D[Calculate new annual premium]
+    D --> E["Apply: base rate x vehicle x bonus
+    x postcode x driver x mileage factors"]
+    E --> F[Calculate pro-rata adjustment]
+    F --> G["(Remaining days / 365) x
+    (new premium - old premium)"]
+    G --> H{Net adjustment}
+    H -->|Charge| I[Collect additional premium]
+    H -->|Refund| J[Process refund to customer]
+    H -->|No change| K[No payment action]
+    I --> L[Update payment schedule]
+    J --> L
+    K --> L
+    L --> M[Store calculation with factor breakdown]
+
+    style A fill:#e1f5fe
+    style L fill:#e8f5e9
+```
 
 ### Main Success Scenario
 

--- a/docs/phase-1-motor/use-cases/quote-and-bind.md
+++ b/docs/phase-1-motor/use-cases/quote-and-bind.md
@@ -32,6 +32,35 @@ policy issuance and Transportstyrelsen notification.
 | TryggFörsäkring        | New policy sale; regulatory compliance; accurate data                |
 | Transportstyrelsen     | Timely notification of insurance status changes                      |
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer enters reg.nr + personnummer] --> B[Transportstyrelsen vehicle lookup]
+    B --> C{Vehicle found?}
+    C -->|No| D[Manual vehicle entry]
+    D --> E[Underwriter review required]
+    C -->|Yes| F[Retrieve bonus class]
+    F --> G[Demands-and-needs assessment]
+    G --> H[Coverage tier selection]
+    H --> I[Premium calculation]
+    I --> J[Quote presentation with tier comparison]
+    J --> K[Customer selects coverage and accepts]
+    K --> L[Pre-contractual review]
+    L --> M[BankID signing]
+    M --> N{BankID verified?}
+    N -->|No| O[Retry or save quote for later]
+    N -->|Yes| P[Policy issuance + payment setup]
+    P --> Q[Transportstyrelsen notification]
+    Q --> R[Confirmation sent to customer]
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style D fill:#fff3e0
+    style O fill:#fff3e0
+    style E fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Customer Identification

--- a/docs/phase-1-motor/use-cases/renewals.md
+++ b/docs/phase-1-motor/use-cases/renewals.md
@@ -6,6 +6,37 @@ sidebar_position: 3
 
 Detailed interaction flows for the motor insurance renewal lifecycle. Each use case describes the step-by-step process for pre-renewal processing, automatic renewal, customer-initiated cancellation at huvudförfallodag, and insurer switching via flyttanmälan.
 
+## Renewal Timeline
+
+```mermaid
+flowchart LR
+    A["T-60: Flag upcoming
+    renewals"] --> B["T-45: Recalculate premium
+    (bonus + rating factors)"]
+    B --> C{"Significant
+    premium change?"}
+    C -->|Yes| D["IDD reassessment
+    triggered"]
+    C -->|No| E["T-30: Send renewal
+    notice to customer"]
+    D --> E
+    E --> F["T-30 to T-0:
+    Customer response window"]
+    F --> G{Customer action}
+    G -->|No action| H["T-0: Auto-renew policy"]
+    G -->|Cancel| I["Process cancellation"]
+    G -->|Modify| J["Adjust coverage
+    and recalculate"]
+    J --> H
+    H --> K["T+1: New policy period
+    begins, update payments"]
+
+    style A fill:#e1f5fe
+    style K fill:#e8f5e9
+    style I fill:#ffebee
+    style D fill:#fff3e0
+```
+
 ## UC-RN-001: Process Annual Policy Renewal
 
 Handles the end-to-end renewal flow from pre-renewal premium recalculation through automatic renewal or customer cancellation.

--- a/docs/phase-1-motor/use-cases/trafikforsakring.md
+++ b/docs/phase-1-motor/use-cases/trafikforsakring.md
@@ -35,6 +35,38 @@ via the Green Card system.
 | [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)                           | Membership reporting compliance; uninsured vehicle claims cooperation    |
 | FSA                                                                                              | Regulatory oversight of mandatory insurance obligations                  |
 
+## Compliance Lifecycle Flow
+
+```mermaid
+flowchart TD
+    A[Policy issued - any tier] --> B[Validate trafikforsakring included]
+    B --> C[Register with Transportstyrelsen]
+    C --> D[Ongoing: Monitor coverage continuity]
+    D --> E{Event type}
+    E -->|Coverage change| F[Vehicle or coverage change]
+    F --> G[Re-register with Transportstyrelsen]
+    G --> D
+    E -->|Personal injury claim| H[Apply Trafikskadelagen strict liability]
+    H --> I[Process compensation]
+    I --> J[Report claims data to TFF]
+    J --> D
+    E -->|Cancellation| K{Replacement coverage?}
+    K -->|Yes| L[Process cancellation]
+    K -->|No - vehicle registered| M[Block: warn about TFF penalty]
+    K -->|Vehicle deregistered| L
+    L --> N[Notify Transportstyrelsen]
+    E -->|TFF reporting deadline| O[Generate statutory reports]
+    O --> P[Compliance officer reviews and submits]
+    P --> D
+    E -->|Cross-border travel| Q[Issue Green Card for EU travel]
+    Q --> D
+
+    style A fill:#e1f5fe
+    style D fill:#e8f5e9
+    style M fill:#ffebee
+    style H fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Issuance — Mandatory Coverage Check and Registration

--- a/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -35,6 +35,64 @@ This use case describes the end-to-end policy cancellation process — from the 
 - The cancellation is blocked due to an outstanding claim under investigation (customer informed)
 - The system is unable to complete the request (customer directed to contact customer service)
 
+## Process Flow: Customer-Initiated Cancellation
+
+```mermaid
+flowchart TD
+    A[Customer requests cancellation] --> B{Cancellation type}
+    B -->|"Cooling-off (Angerratt)"| C{Within 14 days?}
+    C -->|Yes| D[Full refund]
+    C -->|No| E[Reject: cooling-off expired]
+    B -->|Huvudforfallodag| F{At renewal date?}
+    F -->|Yes| G[No penalty - cancel at renewal]
+    F -->|No| H[Wait for huvudforfallodag]
+    B -->|Mid-term| I{Valid reason?}
+    I -->|Vehicle sold/scrapped| J[Pro-rata refund]
+    I -->|Emigration| J
+    I -->|Death| J
+    I -->|No valid reason| K[Reject or wait for renewal]
+    D --> L{Trafikforsakring?}
+    G --> L
+    J --> L
+    L -->|Yes| M[Verify replacement coverage]
+    M --> N{Replacement confirmed?}
+    N -->|Yes| O[Process cancellation]
+    N -->|No| P[Block: coverage required]
+    L -->|No| O
+    O --> Q[Notify Transportstyrelsen]
+    Q --> R[Process refund if applicable]
+    R --> S[Send confirmation to customer]
+
+    style A fill:#e1f5fe
+    style S fill:#e8f5e9
+    style E fill:#ffebee
+    style K fill:#ffebee
+    style P fill:#ffebee
+```
+
+## Process Flow: Insurer-Initiated Cancellation
+
+```mermaid
+flowchart TD
+    A[Non-payment detected] --> B[Send payment reminder]
+    B --> C["Grace period (14 days)"]
+    C --> D{Payment received?}
+    D -->|Yes| E[Resume normal - policy active]
+    D -->|No| F[Send cancellation warning]
+    F --> G["Statutory notice period"]
+    G --> H{Payment received?}
+    H -->|Yes| E
+    H -->|No| I[Cancel policy]
+    I --> J{Trafikforsakring?}
+    J -->|Yes| K[Notify TFF]
+    J -->|No| L[Notify Transportstyrelsen]
+    K --> L
+
+    style A fill:#e1f5fe
+    style E fill:#e8f5e9
+    style I fill:#ffebee
+```
+
 ## Main Flow (Customer-Initiated Online Cancellation)
 
 | Step | Actor    | Action                                                                          | System Response                                                                                |

--- a/docs/phase-1-motor/use-cases/uc-claims-closure.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-closure.md
@@ -48,6 +48,41 @@ This use case describes the claims closure process, from the final review checkl
 - One or more closure checklist items fail validation
 - The claims handler is informed of the blocking item and the claim remains open
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Initiate claim closure] --> B{All payments confirmed?}
+    B -->|No| C[Resolve pending payments]
+    C --> B
+    B -->|Yes| D{Subrogation resolved?}
+    D -->|No| E[Resolve subrogation cases]
+    E --> D
+    D -->|Yes| F{Bonus class updated?}
+    F -->|No| G[Process bonus recalculation]
+    G --> F
+    F -->|Yes| H{All documents attached?}
+    H -->|No| I[Attach missing documents]
+    I --> H
+    H -->|Yes| J{Pending disputes?}
+    J -->|Yes| K[Resolve complaints first]
+    K --> J
+    J -->|No| L[Handler reviews closure summary]
+    L --> M[Confirm closure]
+    M --> N[Release outstanding reserves]
+    N --> O[Update actuarial reporting]
+    O --> P[Notify customer of closure]
+    P --> Q[Claim status: Closed]
+    Q --> R[Archive - retain 10 years]
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style C fill:#fff3e0
+    style E fill:#fff3e0
+    style I fill:#fff3e0
+    style K fill:#fff3e0
+```
+
 ## Main Success Scenario: Standard Closure
 
 | Step | Actor          | Action                                           | System Response                                                     |

--- a/docs/phase-1-motor/use-cases/uc-damage-assessment.md
+++ b/docs/phase-1-motor/use-cases/uc-damage-assessment.md
@@ -45,6 +45,41 @@ This use case describes the damage assessment process for motor insurance claims
 - The vehicle cannot be inspected (e.g., vehicle is inaccessible, customer unresponsive)
 - The assessment is placed on hold and the claims handler is notified
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim registered] --> B[Assign claims adjuster]
+    B --> C[Schedule inspection]
+    C --> D{Assessment type}
+    D -->|On-site| E[Inspect vehicle at location]
+    D -->|Remote| F[Request photos from customer]
+    D -->|Repair shop| G[Shop inspects and estimates]
+    E --> H[Document damage with photos]
+    F --> I{Photos sufficient?}
+    I -->|Yes| H
+    I -->|No| E
+    G --> J[Review shop estimate vs market rates]
+    H --> K[Prepare repair estimate]
+    J --> K
+    K --> L{Repair cost > 75% market value?}
+    L -->|Yes| M[Total loss evaluation]
+    M --> N[Assess market value and salvage]
+    L -->|No| O[Approve repair estimate]
+    N --> P[Submit total loss report]
+    O --> Q[Consistency check]
+    Q --> R{Damage consistent with incident?}
+    R -->|Yes| S[Submit assessment to claims handler]
+    R -->|No| T[Flag for fraud review]
+    P --> S
+    S --> U[Handler reviews and accepts]
+
+    style A fill:#e1f5fe
+    style U fill:#e8f5e9
+    style M fill:#fff3e0
+    style T fill:#ffebee
+```
+
 ## Main Success Scenario: On-Site Inspection
 
 | Step | Actor           | Action                                                                   | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -34,6 +34,35 @@ This use case details the First Notification of Loss (FNOL) process — from the
 - The customer is unable to complete the FNOL (e.g., no active policy found, system error)
 - The customer is informed of the issue and directed to contact customer service
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer reports claim] --> B{Channel}
+    B -->|Web/App| C[Authenticate via BankID]
+    B -->|Phone| D[Claims handler verifies identity]
+    B -->|Third party| E[Handler verifies policy exists]
+    C --> F[Select policy and vehicle]
+    D --> F
+    E --> G[Create third-party claim record]
+    F --> H[Select claim type]
+    H --> I[Capture incident details]
+    I --> J{Duplicate claim detected?}
+    J -->|Yes| K[Alert: possible duplicate]
+    J -->|No| L[Upload photos and documents]
+    K --> L
+    L --> M[Review FNOL summary]
+    M --> N[Submit claim report]
+    N --> O[Generate claim number]
+    O --> P[Auto-assign claims handler]
+    P --> Q[Send confirmation to customer]
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style G fill:#fff3e0
+    style K fill:#fff3e0
+```
+
 ## Main Flow (Online Self-Service)
 
 | Step | Actor    | Action                                                          | System Response                                                                                   |

--- a/docs/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/docs/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -33,6 +33,38 @@ This use case describes the fraud screening and investigation process for motor 
 - Fraud indicators are recorded for future pattern detection
 - Customer is notified of the denial (without disclosing investigation details)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[New claim registered] --> B[Run automated fraud indicators]
+    B --> C[Calculate fraud risk score]
+    C --> D{Risk level}
+    D -->|Low| E[Auto-clear]
+    E --> F[Normal claims processing]
+    D -->|Medium| G[Flag for handler review]
+    G --> H[Manual investigation]
+    H --> I{Finding}
+    I -->|Cleared| F
+    I -->|Suspicious| J[Escalate to senior handler]
+    D -->|High| K[Hold claim - pause settlement]
+    K --> L[Full investigation]
+    L --> M{Fraud confirmed?}
+    M -->|No| F
+    M -->|Yes| N[Deny claim]
+    N --> O{Criminal referral?}
+    O -->|Yes| P[Refer to police]
+    O -->|No| Q[Record fraud determination]
+    P --> Q
+    J --> L
+
+    style A fill:#e1f5fe
+    style F fill:#e8f5e9
+    style N fill:#ffebee
+    style P fill:#ffebee
+    style K fill:#fff3e0
+```
+
 ## Main Flow: Automated Screening
 
 | Step | Actor  | Action                     | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-liability-determination.md
+++ b/docs/phase-1-motor/use-cases/uc-liability-determination.md
@@ -46,6 +46,40 @@ This use case describes the liability determination process for motor insurance 
 - Liability cannot be determined due to insufficient evidence
 - The claim is placed on hold pending additional evidence (police report, witness statements)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim registered and coverage verified] --> B{Incident type}
+    B -->|Single vehicle| C[Driver at fault - 100%]
+    C --> D[Check coverage tier]
+    B -->|Multi-vehicle| E[Review evidence]
+    E --> F[Police report + witness statements + photos]
+    F --> G{Clear fault?}
+    G -->|Yes| H[Assign liability percentages]
+    G -->|No| I[Split 50/50 or escalate]
+    B -->|Animal collision| J[No-fault determination]
+    J --> K[Bonus-neutral]
+    B -->|Hit-and-run| L[Police report mandatory]
+    L --> M[TFF eligibility check]
+    H --> N[Record rationale and evidence]
+    I --> N
+    M --> N
+    D --> N
+    K --> N
+    N --> O{Subrogation eligible?}
+    O -->|Yes| P[Identify recovery target]
+    O -->|No| Q[Proceed to damage assessment]
+    P --> Q
+    B -->|Trafikforsakring PI| R[Strict liability applies]
+    R --> N
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style J fill:#fff3e0
+    style L fill:#fff3e0
+```
+
 ## Main Success Scenario: Multi-Party Collision
 
 | Step | Actor          | Action                                          | System Response                                                                 |

--- a/docs/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -33,6 +33,35 @@ This use case details the premium refund calculation and payment process followi
 - The refund calculation cannot be completed (e.g., missing premium data)
 - The Payment Provider rejects the refund (operations staff alerted for manual processing)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Cancellation confirmed] --> B{Cancellation type}
+    B -->|"Cooling-off (Angerratt)"| C[Full refund of premium paid]
+    C --> D{Early coverage start?}
+    D -->|Yes| E[Deduct days of coverage used]
+    D -->|No| F[Full amount refunded]
+    B -->|Huvudforfallodag| G[No refund - coverage runs to end]
+    B -->|Mid-term with reason| H[Calculate pro-rata refund]
+    H --> I["(Remaining days / 365) x Annual premium"]
+    I --> J{Outstanding balance?}
+    E --> J
+    F --> J
+    J -->|Yes| K[Offset: net refund = gross - outstanding]
+    J -->|No| L[Net refund = gross refund]
+    K --> M{Net refund positive?}
+    M -->|Yes| N[Process refund to customer]
+    M -->|No| O[No refund - inform customer]
+    L --> N
+    N --> P[Send refund confirmation]
+
+    style A fill:#e1f5fe
+    style P fill:#e8f5e9
+    style G fill:#fff3e0
+    style O fill:#fff3e0
+```
+
 ## Main Flow (Pro-Rata Refund Calculation)
 
 | Step | Actor    | Action                                                                                                | System Response                                                   |

--- a/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -33,6 +33,36 @@ This use case describes the settlement calculation and payment process for appro
 - Payment fails (e.g., invalid bank details, payment provider error)
 - Claims handler is notified and payment is retried or alternative payment method is used
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim approved] --> B[Verify coverage and assessment]
+    B --> C[Determine liability %]
+    C --> D{Total loss?}
+    D -->|Yes| E[Calculate market value]
+    E --> F[Subtract salvage value]
+    F --> G[Market value - salvage - deductible]
+    D -->|No| H[Use approved repair cost]
+    H --> I[Apply liability % adjustment]
+    I --> J[Subtract deductible]
+    G --> K[Net settlement amount]
+    J --> K
+    K --> L{Amount > handler authority?}
+    L -->|Yes| M[Senior approval required]
+    M --> N[Approve settlement]
+    L -->|No| N
+    N --> O{Payment method}
+    O -->|Direct to customer| P[Bank transfer to customer]
+    O -->|Direct billing| Q[Repair authorization to shop]
+    P --> R[Claim status: Settled]
+    Q --> R
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style M fill:#fff3e0
+```
+
 ## Main Flow: Vehicle Repair Settlement
 
 | Step | Actor          | Action                                              | System Response                                                                      |

--- a/docs/phase-1-motor/use-cases/underwriting-bonus.md
+++ b/docs/phase-1-motor/use-cases/underwriting-bonus.md
@@ -32,6 +32,35 @@ and referral handling.
 | Compliance Officer | Non-discriminatory rating; transparent premium calculation            |
 | TryggFörsäkring    | Profitable portfolio; competitive pricing; regulatory compliance      |
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[New quote or renewal request] --> B[Collect rating factors]
+    B --> C[Lookup bonus class]
+    C --> D[Apply rating model]
+    D --> E["Base premium x vehicle factor
+    x age factor x location factor x ..."]
+    E --> F[Apply bonus class discount]
+    F --> G{Within acceptance criteria?}
+    G -->|Yes - auto-accept| H[Present quote to customer]
+    G -->|Referral triggered| I[Underwriter review queue]
+    I --> J{Underwriter decision}
+    J -->|Approve| H
+    J -->|Approve with conditions| K[Modify terms or premium loading]
+    K --> H
+    J -->|Decline| L[Notify customer with reason]
+    G -->|Decline rule triggered| L
+    L --> M{Trafikforsakring only?}
+    M -->|Yes| N[Offer mandatory minimum coverage]
+    M -->|No| O[Application rejected]
+
+    style A fill:#e1f5fe
+    style H fill:#e8f5e9
+    style L fill:#ffebee
+    style I fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Bonus Class Determination

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
     hooks: {
       onBrokenMarkdownLinks: "throw",
     },
+    mermaid: true,
   },
 
   i18n: {

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/policy-administration.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/policy-administration.md
@@ -66,6 +66,35 @@ record entity provides a complete audit trail of every policy change.
 1. The customer has the registreringsnummer of the new vehicle
 1. The customer is authenticated via BankID
 
+### Vehicle Change Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer requests vehicle change] --> B[Enter new registreringsnummer]
+    B --> C[Transportstyrelsen vehicle lookup]
+    C --> D{Vehicle found?}
+    D -->|No| E[Manual entry required]
+    D -->|Yes| F[Display vehicle details for confirmation]
+    F --> G[Assess risk of new vehicle]
+    G --> H{High-risk vehicle?}
+    H -->|Yes| I[Underwriter review]
+    I --> J{Approved?}
+    J -->|No| K[Decline - notify customer]
+    J -->|Yes| L[Recalculate premium]
+    H -->|No| L
+    L --> M[Show premium change and pro-rata adjustment]
+    M --> N[Customer confirms]
+    N --> O[Update policy record]
+    O --> P[Notify Transportstyrelsen - old and new vehicle]
+    P --> Q[Trigger payment adjustment]
+    Q --> R[Reissue policy documents]
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style I fill:#fff3e0
+    style K fill:#ffebee
+```
+
 ### Main Success Scenario
 
 1. **Initiate** — Customer selects "Change vehicle" from their policy
@@ -784,6 +813,32 @@ stateDiagram-v2
 
 1. A policy amendment has been submitted that changes one or more rating factors
 1. The current premium and rating factors are known
+
+### Premium Recalculation Process Flow
+
+```mermaid
+flowchart TD
+    A["Amendment submitted
+    (trigger: rating factor changed)"] --> B[Identify changed factors]
+    B --> C[Retrieve current tariff and rating tables]
+    C --> D[Calculate new annual premium]
+    D --> E["Apply: base rate x vehicle x bonus
+    x postcode x driver x mileage factors"]
+    E --> F[Calculate pro-rata adjustment]
+    F --> G["(Remaining days / 365) x
+    (new premium - old premium)"]
+    G --> H{Net adjustment}
+    H -->|Charge| I[Collect additional premium]
+    H -->|Refund| J[Process refund to customer]
+    H -->|No change| K[No payment action]
+    I --> L[Update payment schedule]
+    J --> L
+    K --> L
+    L --> M[Store calculation with factor breakdown]
+
+    style A fill:#e1f5fe
+    style L fill:#e8f5e9
+```
 
 ### Main Success Scenario
 

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/quote-and-bind.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/quote-and-bind.md
@@ -32,6 +32,35 @@ policy issuance and Transportstyrelsen notification.
 | TryggFörsäkring        | New policy sale; regulatory compliance; accurate data                |
 | Transportstyrelsen     | Timely notification of insurance status changes                      |
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer enters reg.nr + personnummer] --> B[Transportstyrelsen vehicle lookup]
+    B --> C{Vehicle found?}
+    C -->|No| D[Manual vehicle entry]
+    D --> E[Underwriter review required]
+    C -->|Yes| F[Retrieve bonus class]
+    F --> G[Demands-and-needs assessment]
+    G --> H[Coverage tier selection]
+    H --> I[Premium calculation]
+    I --> J[Quote presentation with tier comparison]
+    J --> K[Customer selects coverage and accepts]
+    K --> L[Pre-contractual review]
+    L --> M[BankID signing]
+    M --> N{BankID verified?}
+    N -->|No| O[Retry or save quote for later]
+    N -->|Yes| P[Policy issuance + payment setup]
+    P --> Q[Transportstyrelsen notification]
+    Q --> R[Confirmation sent to customer]
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style D fill:#fff3e0
+    style O fill:#fff3e0
+    style E fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Customer Identification

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/renewals.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/renewals.md
@@ -6,6 +6,37 @@ sidebar_position: 3
 
 Detailed interaction flows for the motor insurance renewal lifecycle. Each use case describes the step-by-step process for pre-renewal processing, automatic renewal, customer-initiated cancellation at huvudförfallodag, and insurer switching via flyttanmälan.
 
+## Renewal Timeline
+
+```mermaid
+flowchart LR
+    A["T-60: Flag upcoming
+    renewals"] --> B["T-45: Recalculate premium
+    (bonus + rating factors)"]
+    B --> C{"Significant
+    premium change?"}
+    C -->|Yes| D["IDD reassessment
+    triggered"]
+    C -->|No| E["T-30: Send renewal
+    notice to customer"]
+    D --> E
+    E --> F["T-30 to T-0:
+    Customer response window"]
+    F --> G{Customer action}
+    G -->|No action| H["T-0: Auto-renew policy"]
+    G -->|Cancel| I["Process cancellation"]
+    G -->|Modify| J["Adjust coverage
+    and recalculate"]
+    J --> H
+    H --> K["T+1: New policy period
+    begins, update payments"]
+
+    style A fill:#e1f5fe
+    style K fill:#e8f5e9
+    style I fill:#ffebee
+    style D fill:#fff3e0
+```
+
 ## UC-RN-001: Process Annual Policy Renewal
 
 Handles the end-to-end renewal flow from pre-renewal premium recalculation through automatic renewal or customer cancellation.

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/trafikforsakring.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/trafikforsakring.md
@@ -35,6 +35,38 @@ via the Green Card system.
 | [TFF](../../actors/external-actors.md#trafikförsäkringsföreningen-tff)                           | Membership reporting compliance; uninsured vehicle claims cooperation    |
 | FSA                                                                                              | Regulatory oversight of mandatory insurance obligations                  |
 
+## Compliance Lifecycle Flow
+
+```mermaid
+flowchart TD
+    A[Policy issued - any tier] --> B[Validate trafikforsakring included]
+    B --> C[Register with Transportstyrelsen]
+    C --> D[Ongoing: Monitor coverage continuity]
+    D --> E{Event type}
+    E -->|Coverage change| F[Vehicle or coverage change]
+    F --> G[Re-register with Transportstyrelsen]
+    G --> D
+    E -->|Personal injury claim| H[Apply Trafikskadelagen strict liability]
+    H --> I[Process compensation]
+    I --> J[Report claims data to TFF]
+    J --> D
+    E -->|Cancellation| K{Replacement coverage?}
+    K -->|Yes| L[Process cancellation]
+    K -->|No - vehicle registered| M[Block: warn about TFF penalty]
+    K -->|Vehicle deregistered| L
+    L --> N[Notify Transportstyrelsen]
+    E -->|TFF reporting deadline| O[Generate statutory reports]
+    O --> P[Compliance officer reviews and submits]
+    P --> D
+    E -->|Cross-border travel| Q[Issue Green Card for EU travel]
+    Q --> D
+
+    style A fill:#e1f5fe
+    style D fill:#e8f5e9
+    style M fill:#ffebee
+    style H fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Issuance — Mandatory Coverage Check and Registration

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -35,6 +35,64 @@ This use case describes the end-to-end policy cancellation process — from the 
 - The cancellation is blocked due to an outstanding claim under investigation (customer informed)
 - The system is unable to complete the request (customer directed to contact customer service)
 
+## Process Flow: Customer-Initiated Cancellation
+
+```mermaid
+flowchart TD
+    A[Customer requests cancellation] --> B{Cancellation type}
+    B -->|"Cooling-off (Angerratt)"| C{Within 14 days?}
+    C -->|Yes| D[Full refund]
+    C -->|No| E[Reject: cooling-off expired]
+    B -->|Huvudforfallodag| F{At renewal date?}
+    F -->|Yes| G[No penalty - cancel at renewal]
+    F -->|No| H[Wait for huvudforfallodag]
+    B -->|Mid-term| I{Valid reason?}
+    I -->|Vehicle sold/scrapped| J[Pro-rata refund]
+    I -->|Emigration| J
+    I -->|Death| J
+    I -->|No valid reason| K[Reject or wait for renewal]
+    D --> L{Trafikforsakring?}
+    G --> L
+    J --> L
+    L -->|Yes| M[Verify replacement coverage]
+    M --> N{Replacement confirmed?}
+    N -->|Yes| O[Process cancellation]
+    N -->|No| P[Block: coverage required]
+    L -->|No| O
+    O --> Q[Notify Transportstyrelsen]
+    Q --> R[Process refund if applicable]
+    R --> S[Send confirmation to customer]
+
+    style A fill:#e1f5fe
+    style S fill:#e8f5e9
+    style E fill:#ffebee
+    style K fill:#ffebee
+    style P fill:#ffebee
+```
+
+## Process Flow: Insurer-Initiated Cancellation
+
+```mermaid
+flowchart TD
+    A[Non-payment detected] --> B[Send payment reminder]
+    B --> C["Grace period (14 days)"]
+    C --> D{Payment received?}
+    D -->|Yes| E[Resume normal - policy active]
+    D -->|No| F[Send cancellation warning]
+    F --> G["Statutory notice period"]
+    G --> H{Payment received?}
+    H -->|Yes| E
+    H -->|No| I[Cancel policy]
+    I --> J{Trafikforsakring?}
+    J -->|Yes| K[Notify TFF]
+    J -->|No| L[Notify Transportstyrelsen]
+    K --> L
+
+    style A fill:#e1f5fe
+    style E fill:#e8f5e9
+    style I fill:#ffebee
+```
+
 ## Main Flow (Customer-Initiated Online Cancellation)
 
 | Step | Actor    | Action                                                                          | System Response                                                                                |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-claims-closure.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-claims-closure.md
@@ -48,6 +48,41 @@ This use case describes the claims closure process, from the final review checkl
 - One or more closure checklist items fail validation
 - The claims handler is informed of the blocking item and the claim remains open
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Initiate claim closure] --> B{All payments confirmed?}
+    B -->|No| C[Resolve pending payments]
+    C --> B
+    B -->|Yes| D{Subrogation resolved?}
+    D -->|No| E[Resolve subrogation cases]
+    E --> D
+    D -->|Yes| F{Bonus class updated?}
+    F -->|No| G[Process bonus recalculation]
+    G --> F
+    F -->|Yes| H{All documents attached?}
+    H -->|No| I[Attach missing documents]
+    I --> H
+    H -->|Yes| J{Pending disputes?}
+    J -->|Yes| K[Resolve complaints first]
+    K --> J
+    J -->|No| L[Handler reviews closure summary]
+    L --> M[Confirm closure]
+    M --> N[Release outstanding reserves]
+    N --> O[Update actuarial reporting]
+    O --> P[Notify customer of closure]
+    P --> Q[Claim status: Closed]
+    Q --> R[Archive - retain 10 years]
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style C fill:#fff3e0
+    style E fill:#fff3e0
+    style I fill:#fff3e0
+    style K fill:#fff3e0
+```
+
 ## Main Success Scenario: Standard Closure
 
 | Step | Actor          | Action                                           | System Response                                                     |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-damage-assessment.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-damage-assessment.md
@@ -45,6 +45,41 @@ This use case describes the damage assessment process for motor insurance claims
 - The vehicle cannot be inspected (e.g., vehicle is inaccessible, customer unresponsive)
 - The assessment is placed on hold and the claims handler is notified
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim registered] --> B[Assign claims adjuster]
+    B --> C[Schedule inspection]
+    C --> D{Assessment type}
+    D -->|On-site| E[Inspect vehicle at location]
+    D -->|Remote| F[Request photos from customer]
+    D -->|Repair shop| G[Shop inspects and estimates]
+    E --> H[Document damage with photos]
+    F --> I{Photos sufficient?}
+    I -->|Yes| H
+    I -->|No| E
+    G --> J[Review shop estimate vs market rates]
+    H --> K[Prepare repair estimate]
+    J --> K
+    K --> L{Repair cost > 75% market value?}
+    L -->|Yes| M[Total loss evaluation]
+    M --> N[Assess market value and salvage]
+    L -->|No| O[Approve repair estimate]
+    N --> P[Submit total loss report]
+    O --> Q[Consistency check]
+    Q --> R{Damage consistent with incident?}
+    R -->|Yes| S[Submit assessment to claims handler]
+    R -->|No| T[Flag for fraud review]
+    P --> S
+    S --> U[Handler reviews and accepts]
+
+    style A fill:#e1f5fe
+    style U fill:#e8f5e9
+    style M fill:#fff3e0
+    style T fill:#ffebee
+```
+
 ## Main Success Scenario: On-Site Inspection
 
 | Step | Actor           | Action                                                                   | System Response                                                          |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -34,6 +34,35 @@ This use case details the First Notification of Loss (FNOL) process — from the
 - The customer is unable to complete the FNOL (e.g., no active policy found, system error)
 - The customer is informed of the issue and directed to contact customer service
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Customer reports claim] --> B{Channel}
+    B -->|Web/App| C[Authenticate via BankID]
+    B -->|Phone| D[Claims handler verifies identity]
+    B -->|Third party| E[Handler verifies policy exists]
+    C --> F[Select policy and vehicle]
+    D --> F
+    E --> G[Create third-party claim record]
+    F --> H[Select claim type]
+    H --> I[Capture incident details]
+    I --> J{Duplicate claim detected?}
+    J -->|Yes| K[Alert: possible duplicate]
+    J -->|No| L[Upload photos and documents]
+    K --> L
+    L --> M[Review FNOL summary]
+    M --> N[Submit claim report]
+    N --> O[Generate claim number]
+    O --> P[Auto-assign claims handler]
+    P --> Q[Send confirmation to customer]
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style G fill:#fff3e0
+    style K fill:#fff3e0
+```
+
 ## Main Flow (Online Self-Service)
 
 | Step | Actor    | Action                                                          | System Response                                                                                   |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -33,6 +33,38 @@ This use case describes the fraud screening and investigation process for motor 
 - Fraud indicators are recorded for future pattern detection
 - Customer is notified of the denial (without disclosing investigation details)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[New claim registered] --> B[Run automated fraud indicators]
+    B --> C[Calculate fraud risk score]
+    C --> D{Risk level}
+    D -->|Low| E[Auto-clear]
+    E --> F[Normal claims processing]
+    D -->|Medium| G[Flag for handler review]
+    G --> H[Manual investigation]
+    H --> I{Finding}
+    I -->|Cleared| F
+    I -->|Suspicious| J[Escalate to senior handler]
+    D -->|High| K[Hold claim - pause settlement]
+    K --> L[Full investigation]
+    L --> M{Fraud confirmed?}
+    M -->|No| F
+    M -->|Yes| N[Deny claim]
+    N --> O{Criminal referral?}
+    O -->|Yes| P[Refer to police]
+    O -->|No| Q[Record fraud determination]
+    P --> Q
+    J --> L
+
+    style A fill:#e1f5fe
+    style F fill:#e8f5e9
+    style N fill:#ffebee
+    style P fill:#ffebee
+    style K fill:#fff3e0
+```
+
 ## Main Flow: Automated Screening
 
 | Step | Actor  | Action                     | System Response                                                          |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-liability-determination.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-liability-determination.md
@@ -46,6 +46,40 @@ This use case describes the liability determination process for motor insurance 
 - Liability cannot be determined due to insufficient evidence
 - The claim is placed on hold pending additional evidence (police report, witness statements)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim registered and coverage verified] --> B{Incident type}
+    B -->|Single vehicle| C[Driver at fault - 100%]
+    C --> D[Check coverage tier]
+    B -->|Multi-vehicle| E[Review evidence]
+    E --> F[Police report + witness statements + photos]
+    F --> G{Clear fault?}
+    G -->|Yes| H[Assign liability percentages]
+    G -->|No| I[Split 50/50 or escalate]
+    B -->|Animal collision| J[No-fault determination]
+    J --> K[Bonus-neutral]
+    B -->|Hit-and-run| L[Police report mandatory]
+    L --> M[TFF eligibility check]
+    H --> N[Record rationale and evidence]
+    I --> N
+    M --> N
+    D --> N
+    K --> N
+    N --> O{Subrogation eligible?}
+    O -->|Yes| P[Identify recovery target]
+    O -->|No| Q[Proceed to damage assessment]
+    P --> Q
+    B -->|Trafikforsakring PI| R[Strict liability applies]
+    R --> N
+
+    style A fill:#e1f5fe
+    style Q fill:#e8f5e9
+    style J fill:#fff3e0
+    style L fill:#fff3e0
+```
+
 ## Main Success Scenario: Multi-Party Collision
 
 | Step | Actor          | Action                                          | System Response                                                                 |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -33,6 +33,35 @@ This use case details the premium refund calculation and payment process followi
 - The refund calculation cannot be completed (e.g., missing premium data)
 - The Payment Provider rejects the refund (operations staff alerted for manual processing)
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Cancellation confirmed] --> B{Cancellation type}
+    B -->|"Cooling-off (Angerratt)"| C[Full refund of premium paid]
+    C --> D{Early coverage start?}
+    D -->|Yes| E[Deduct days of coverage used]
+    D -->|No| F[Full amount refunded]
+    B -->|Huvudforfallodag| G[No refund - coverage runs to end]
+    B -->|Mid-term with reason| H[Calculate pro-rata refund]
+    H --> I["(Remaining days / 365) x Annual premium"]
+    I --> J{Outstanding balance?}
+    E --> J
+    F --> J
+    J -->|Yes| K[Offset: net refund = gross - outstanding]
+    J -->|No| L[Net refund = gross refund]
+    K --> M{Net refund positive?}
+    M -->|Yes| N[Process refund to customer]
+    M -->|No| O[No refund - inform customer]
+    L --> N
+    N --> P[Send refund confirmation]
+
+    style A fill:#e1f5fe
+    style P fill:#e8f5e9
+    style G fill:#fff3e0
+    style O fill:#fff3e0
+```
+
 ## Main Flow (Pro-Rata Refund Calculation)
 
 | Step | Actor    | Action                                                                                                | System Response                                                   |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -33,6 +33,36 @@ This use case describes the settlement calculation and payment process for appro
 - Payment fails (e.g., invalid bank details, payment provider error)
 - Claims handler is notified and payment is retried or alternative payment method is used
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[Claim approved] --> B[Verify coverage and assessment]
+    B --> C[Determine liability %]
+    C --> D{Total loss?}
+    D -->|Yes| E[Calculate market value]
+    E --> F[Subtract salvage value]
+    F --> G[Market value - salvage - deductible]
+    D -->|No| H[Use approved repair cost]
+    H --> I[Apply liability % adjustment]
+    I --> J[Subtract deductible]
+    G --> K[Net settlement amount]
+    J --> K
+    K --> L{Amount > handler authority?}
+    L -->|Yes| M[Senior approval required]
+    M --> N[Approve settlement]
+    L -->|No| N
+    N --> O{Payment method}
+    O -->|Direct to customer| P[Bank transfer to customer]
+    O -->|Direct billing| Q[Repair authorization to shop]
+    P --> R[Claim status: Settled]
+    Q --> R
+
+    style A fill:#e1f5fe
+    style R fill:#e8f5e9
+    style M fill:#fff3e0
+```
+
 ## Main Flow: Vehicle Repair Settlement
 
 | Step | Actor          | Action                                              | System Response                                                                      |

--- a/versioned_docs/version-phase-1/phase-1-motor/use-cases/underwriting-bonus.md
+++ b/versioned_docs/version-phase-1/phase-1-motor/use-cases/underwriting-bonus.md
@@ -32,6 +32,35 @@ and referral handling.
 | Compliance Officer | Non-discriminatory rating; transparent premium calculation            |
 | TryggFörsäkring    | Profitable portfolio; competitive pricing; regulatory compliance      |
 
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[New quote or renewal request] --> B[Collect rating factors]
+    B --> C[Lookup bonus class]
+    C --> D[Apply rating model]
+    D --> E["Base premium x vehicle factor
+    x age factor x location factor x ..."]
+    E --> F[Apply bonus class discount]
+    F --> G{Within acceptance criteria?}
+    G -->|Yes - auto-accept| H[Present quote to customer]
+    G -->|Referral triggered| I[Underwriter review queue]
+    I --> J{Underwriter decision}
+    J -->|Approve| H
+    J -->|Approve with conditions| K[Modify terms or premium loading]
+    K --> H
+    J -->|Decline| L[Notify customer with reason]
+    G -->|Decline rule triggered| L
+    L --> M{Trafikforsakring only?}
+    M -->|Yes| N[Offer mandatory minimum coverage]
+    M -->|No| O[Application rejected]
+
+    style A fill:#e1f5fe
+    style H fill:#e8f5e9
+    style L fill:#ffebee
+    style I fill:#fff3e0
+```
+
 ## Main Success Scenario
 
 ### 1. Bonus Class Determination


### PR DESCRIPTION
## Summary
- Enable Mermaid diagram support via `@docusaurus/theme-mermaid` in Docusaurus config
- Add visual flowcharts and activity diagrams to all 14 use case files (both `versioned_docs/` and `docs/`)
- Verify existing diagrams in UC-CLM-001 (claims lifecycle) and UC-PA-004 (policy status state machine) render correctly

## Changes
- `docusaurus.config.ts` — Added `markdown.mermaid: true` and `@docusaurus/theme-mermaid` theme
- `package.json` / `package-lock.json` — Added `@docusaurus/theme-mermaid` dependency
- 13 use case files updated with new Mermaid flowcharts (×2 for versioned_docs + docs):
  - **Quote and Bind** (UC-QNB-001) — End-to-end quote flow with decision points
  - **Policy Administration** (UC-PA-001) — Vehicle change flow; (UC-PA-005) — Premium recalculation flow
  - **FNOL Processing** (UC-CLM-002) — Multi-channel FNOL activity diagram
  - **Settlement Calculation** (UC-CLM-003) — Settlement logic with total loss decision
  - **Fraud Screening** (UC-CLM-004) — Risk-level decision tree
  - **Liability Determination** (UC-CLM-005) — Incident type routing diagram
  - **Damage Assessment** (UC-CLM-006) — Assessment workflow with total loss path
  - **Claims Closure** (UC-CLM-007) — Closure checklist validation flow
  - **Renewals** (UC-RN-001 to UC-RN-003) — Timeline flowchart (LR)
  - **Cancellation Processing** (UC-CAN-001) — Customer-initiated + insurer-initiated flows
  - **Refund Calculation** (UC-CAN-002) — Refund type routing diagram
  - **Trafikforsakring** (UC-TRF-001) — Compliance lifecycle flow
  - **Underwriting & Bonus** (UC-UWB-001) — Rating and acceptance flow

## Testing
- [x] markdownlint passes with zero warnings
- [x] prettier passes with zero warnings
- [x] `npm run build` succeeds with zero errors

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)