### PR TITLE
docs(#65): Add home & property insurance terms to Phase 2 glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,14 +9,29 @@ TryggFörsäkring requirements documentation. Terms are organized by category.
 
 ## Insurance Products
 
-| Swedish Term            | English Translation                       | Definition                                                                                                                                                                                                      |
-| ----------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Helförsäkring**       | Full comprehensive insurance              | The highest tier of motor insurance (tier 3). Includes trafikförsäkring, all halvförsäkring coverages, plus collision damage (vagnskadeförsäkring).                                                             |
-| **Halvförsäkring**      | Partial comprehensive insurance           | Mid-tier motor insurance (tier 2). Includes trafikförsäkring plus fire, theft, glass damage, rescue/roadside assistance, and legal expenses. Does not include collision damage.                                 |
-| **Kaskoförsäkring**     | Comprehensive/collision coverage          | General term for voluntary motor insurance that goes beyond mandatory trafikförsäkring. Covers damage to the policyholder's own vehicle.                                                                        |
-| **Trafikförsäkring**    | Mandatory third-party liability insurance | Legally required motor insurance under Trafikskadelagen (1975:1410). Covers personal injury to all parties and property damage to third parties. Every registered vehicle in Sweden must have trafikförsäkring. |
-| **Vagnskadeförsäkring** | Collision damage insurance                | Covers damage to the policyholder's own vehicle caused by collisions, regardless of fault. Included in helförsäkring but not halvförsäkring.                                                                    |
-| **Vagnskadegaranti**    | Collision damage warranty                 | Manufacturer or dealer warranty covering collision damage, typically for the first 3 years on new vehicles. Replaces vagnskadeförsäkring during the warranty period.                                            |
+| Swedish Term               | English Translation                       | Definition                                                                                                                                                                                                      |
+| -------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bostadsrättsförsäkring** | Tenant-owner (BRF) insurance              | Insurance for tenant-owners in a bostadsrättsförening (housing cooperative). Covers interior fixtures, personal property, and liability. Complements the BRF's building insurance.                              |
+| **Fritidshusförsäkring**   | Vacation/second home insurance            | Insurance for vacation or second homes (fritidshus). Covers building, contents, and liability with terms adapted for properties that may be unoccupied for extended periods.                                    |
+| **Helförsäkring**          | Full comprehensive insurance              | The highest tier of motor insurance (tier 3). Includes trafikförsäkring, all halvförsäkring coverages, plus collision damage (vagnskadeförsäkring).                                                             |
+| **Halvförsäkring**         | Partial comprehensive insurance           | Mid-tier motor insurance (tier 2). Includes trafikförsäkring plus fire, theft, glass damage, rescue/roadside assistance, and legal expenses. Does not include collision damage.                                 |
+| **Hemförsäkring**          | Home insurance                            | Standard home insurance covering personal property (contents), personal liability, legal expenses, travel insurance, and assault protection. Intended for renters and BRF tenant-owners.                        |
+| **Kaskoförsäkring**        | Comprehensive/collision coverage          | General term for voluntary motor insurance that goes beyond mandatory trafikförsäkring. Covers damage to the policyholder's own vehicle.                                                                        |
+| **Trafikförsäkring**       | Mandatory third-party liability insurance | Legally required motor insurance under Trafikskadelagen (1975:1410). Covers personal injury to all parties and property damage to third parties. Every registered vehicle in Sweden must have trafikförsäkring. |
+| **Vagnskadeförsäkring**    | Collision damage insurance                | Covers damage to the policyholder's own vehicle caused by collisions, regardless of fault. Included in helförsäkring but not halvförsäkring.                                                                    |
+| **Vagnskadegaranti**       | Collision damage warranty                 | Manufacturer or dealer warranty covering collision damage, typically for the first 3 years on new vehicles. Replaces vagnskadeförsäkring during the warranty period.                                            |
+| **Villahemförsäkring**     | Homeowner insurance                       | Comprehensive insurance for house owners. Covers the building structure, contents, personal liability, legal expenses, and travel insurance. Combines villaförsäkring (building) with hemförsäkring (contents). |
+
+## Coverage Types
+
+| Swedish Term             | English Translation          | Definition                                                                                                                                                                                  |
+| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Allrisk** / **Drulle** | Accidental damage (all-risk) | Optional add-on coverage for sudden and unforeseen damage to personal property, including accidents caused by the policyholder (e.g., dropping a phone). Common extension to hemförsäkring. |
+| **Ansvarsskydd**         | Personal liability coverage  | Covers the policyholder's legal liability for injury or property damage caused to others. Included as standard in hemförsäkring and villahemförsäkring.                                     |
+| **ID-skydd**             | Identity theft protection    | Coverage for expenses and assistance related to identity theft, including credit monitoring, fraud resolution support, and financial loss reimbursement.                                    |
+| **Reseskydd**            | Travel insurance             | Travel coverage included in Swedish home insurance policies. Covers medical expenses, trip cancellation, and baggage loss during travel, typically for trips up to 45 days.                 |
+| **Rättsskydd**           | Legal expenses coverage      | Covers legal costs (attorney fees, court costs) when the policyholder is involved in a legal dispute. Included as standard in hemförsäkring and villahemförsäkring.                         |
+| **Överfallsskydd**       | Assault coverage             | Provides compensation if the policyholder is a victim of assault or violent crime. Included as standard in Swedish home insurance policies. Supplements public crime victim compensation.   |
 
 ## Business Terms
 
@@ -33,11 +48,30 @@ TryggFörsäkring requirements documentation. Terms are organized by category.
 | **Skadeanmälan**               | First notification of loss (FNOL) / claims report | The formal report submitted by the policyholder or claimant to initiate the claims process after an insured event.                                                                      |
 | **Skadereglering**             | Claims settlement / claims adjustment             | The process of investigating, evaluating, and resolving an insurance claim, including determination of liability and payment of benefits.                                               |
 | **Ångerrätt**                  | Right of withdrawal / cooling-off period          | The policyholder's legal right to cancel a new insurance policy within 14 days of purchase without penalty, as required by the Insurance Distribution Directive (IDD).                  |
+| **Åldersavdrag**               | Age deduction / depreciation                      | A reduction applied to claims payouts based on the age and wear of damaged or stolen items. Standard practice in Swedish home insurance to reflect current value rather than new value. |
+
+## Claims and Damage
+
+| Swedish Term      | English Translation           | Definition                                                                                                                                                                                                      |
+| ----------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Brand**         | Fire                          | Fire damage to property. One of the standard perils covered by both hemförsäkring and villahemförsäkring. Claims require a fire investigation report (brandutredning) for significant losses.                   |
+| **Dolda fel**     | Latent defects                | Hidden defects in a property that were not discoverable during a standard inspection at the time of purchase. Sellers are liable for latent defects for 10 years under Swedish property law (Jordabalken 4:19). |
+| **Inbrott**       | Burglary                      | Unlawful entry and theft from a locked premises. Covered by hemförsäkring and villahemförsäkring. Claims require a police report (polisanmälan) and evidence of forced entry.                                   |
+| **Sanering**      | Decontamination / restoration | Professional cleanup and restoration work following damage events such as water damage, fire, or mold. Typically performed by specialized restoration companies (saneringsfirmor).                              |
+| **Torkprotokoll** | Drying protocol               | A documented record of the drying process following water damage. Tracks moisture levels, equipment used, and drying duration. Required for claims settlement to verify restoration is complete.                |
+| **Vattenskada**   | Water damage                  | Damage caused by water leakage, flooding, or burst pipes. The most common home insurance claim type in Sweden. Requires prompt reporting and professional drying (torkprotokoll) to prevent secondary damage.   |
+
+## Property Terms
+
+| Swedish Term  | English Translation         | Definition                                                                                                                                                                        |
+| ------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fastighet** | Real property / real estate | Immovable property including land and permanent structures. In insurance context, refers to the physical property being insured under villahemförsäkring or fritidshusförsäkring. |
 
 ## Regulatory and Legal
 
 | Swedish Term                          | English Translation                           | Definition                                                                                                                                                                                     |
 | ------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BBR** (**Boverkets byggregler**)    | Swedish building regulations                  | National building regulations issued by Boverket (National Board of Housing, Building and Planning). Relevant for property insurance when assessing building standards and compliance.         |
 | **Finansinspektionen** / **FI**       | Swedish Financial Supervisory Authority (FSA) | The government agency responsible for supervising and regulating financial markets and firms in Sweden, including insurance companies. See [FSA Requirements](regulatory/fsa-requirements.md). |
 | **Försäkringsavtalslagen** / **FAL**  | Insurance Contracts Act                       | Swedish law governing the contractual relationship between insurers and policyholders, including disclosure obligations, claims handling, and policyholder rights.                             |
 | **Försäkringsrörelselagen** / **FRL** | Insurance Business Act                        | Swedish law regulating the operations of insurance companies, including solvency requirements, governance, and reporting obligations.                                                          |
@@ -48,12 +82,23 @@ TryggFörsäkring requirements documentation. Terms are organized by category.
 
 ## Organizations
 
-| Swedish Term                               | English Translation                      | Definition                                                                                                                                                                               |
-| ------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Integritetsskyddsmyndigheten** / **IMY** | Swedish Authority for Privacy Protection | The national supervisory authority for data protection and privacy in Sweden. Enforces GDPR compliance.                                                                                  |
-| **Konsumentverket**                        | Swedish Consumer Agency                  | Government agency responsible for consumer rights and fair trade practices. Relevant for insurance consumer protection and marketing regulations.                                        |
-| **Trafikförsäkringsföreningen** / **TFF**  | Swedish Motor Insurers                   | Industry organization that all companies selling trafikförsäkring must be members of. TFF also provides trafikförsäkring for uninsured vehicles and manages the central claims database. |
-| **Transportstyrelsen**                     | Swedish Transport Agency                 | Government agency managing the vehicle registry (fordonsregistret). Insurance companies integrate with Transportstyrelsen to verify vehicle data and report insurance status.            |
+| Swedish Term                               | English Translation                      | Definition                                                                                                                                                                                  |
+| ------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BRF** (**Bostadsrättsförening**)         | Tenant-owner housing cooperative         | A Swedish housing cooperative where members own the right to occupy an apartment. The BRF owns the building and is responsible for building insurance; members insure their own interiors.  |
+| **Byggnadsnämnd**                          | Building committee (municipal)           | A municipal authority responsible for building permits, inspections, and enforcement of building regulations. Relevant for property insurance claims involving structural modifications.    |
+| **Integritetsskyddsmyndigheten** / **IMY** | Swedish Authority for Privacy Protection | The national supervisory authority for data protection and privacy in Sweden. Enforces GDPR compliance.                                                                                     |
+| **Konsumentverket**                        | Swedish Consumer Agency                  | Government agency responsible for consumer rights and fair trade practices. Relevant for insurance consumer protection and marketing regulations.                                           |
+| **Lantmäteriet**                           | Swedish mapping and cadastral authority  | Government agency responsible for land registration, property boundaries, and geographic data. Provides property information used in underwriting and claims assessment for home insurance. |
+| **Trafikförsäkringsföreningen** / **TFF**  | Swedish Motor Insurers                   | Industry organization that all companies selling trafikförsäkring must be members of. TFF also provides trafikförsäkring for uninsured vehicles and manages the central claims database.    |
+| **Transportstyrelsen**                     | Swedish Transport Agency                 | Government agency managing the vehicle registry (fordonsregistret). Insurance companies integrate with Transportstyrelsen to verify vehicle data and report insurance status.               |
+
+## Service Providers
+
+| Swedish Term       | English Translation | Definition                                                                                                                                                                                       |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Besiktningsman** | Property inspector  | A certified professional who performs property inspections (besiktningar) before real estate transactions. Inspection reports are relevant for identifying risks and assessing dolda fel claims. |
+| **Låssmed**        | Locksmith           | A locksmith service provider. Relevant in insurance for emergency lock replacement after burglary (inbrott) claims, typically covered under hemförsäkring.                                       |
+| **Saneringsfirma** | Restoration company | A company specializing in damage restoration (e.g., Polygon, Anticimex). Contracted by insurance companies to perform water damage drying, fire restoration, and decontamination work.           |
 
 ## Identity and Systems
 


### PR DESCRIPTION
## Summary
- Adds 24 home and property insurance terms to `docs/glossary.md` for Phase 2 (Home & Property)
- New sections: Coverage Types, Claims and Damage, Property Terms, Service Providers
- All terms maintain Swedish term + English explanation format, alphabetical within categories

## Changes
- `docs/glossary.md`: Added 4 product types, 6 coverage types, 6 claims/damage terms, 1 property term, 1 business term, 1 regulatory term, 3 organizations, 3 service providers

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting verified
- [x] Docusaurus build succeeds

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)