### PR TITLE
docs(#66): Add Phase 2 home & property actors

### DIFF
--- a/docs/actors/external/brf-board.md
+++ b/docs/actors/external/brf-board.md
@@ -1,0 +1,36 @@
+---
+sidebar_label: BRF Board (BRF-styrelse)
+sidebar_position: 8
+---
+
+# BRF Board (BRF-styrelse)
+
+- **Swedish term:** BRF-styrelse
+- **English name:** Tenant-Owner Association Board
+- **Description:** The board of a bostadsrättsförening (tenant-owner association)
+  responsible for managing building insurance, approving renovations, and
+  coordinating shared claims for multi-unit residential properties. BRF boards
+  are key stakeholders in home & property insurance as they hold the building
+  insurance policy on behalf of all members while individual members insure
+  their own apartments through separate bostadsrättstillägg coverage.
+- **Responsibilities:**
+  - Hold and manage the building insurance policy (fastighetsförsäkring) for
+    the association
+  - Report building-level claims (e.g., roof damage, pipe bursts in shared
+    areas)
+  - Approve and coordinate renovations that may affect insurance coverage
+  - Provide building documentation for underwriting and claims assessment
+  - Coordinate with individual member claims when damage spans shared and
+    private areas
+  - Maintain building safety and maintenance records
+- **Key interactions:** Claims handling (building-level claims, shared/private
+  damage coordination), underwriting (building risk assessment, renovation
+  approvals), policy administration (building policy management)
+- **Regulatory relevance:**
+  - FSA — building insurance must meet consumer protection standards; BRF
+    members are protected as policyholders (FSA-004)
+  - GDPR — BRF board shares member data (names, apartment numbers) with
+    insurer for claims coordination; requires legal basis and data processing
+    agreement (GDPR-001)
+  - IDD — BRF boards purchasing building insurance are entitled to
+    demands-and-needs assessment and product information (IDD-001, IDD-002)

--- a/docs/actors/external/building-committee.md
+++ b/docs/actors/external/building-committee.md
@@ -1,0 +1,30 @@
+---
+sidebar_label: Building Committee (Byggnadsnämnd)
+sidebar_position: 14
+---
+
+# Building Committee (Byggnadsnämnd)
+
+- **Swedish term:** Byggnadsnämnd
+- **English name:** Municipal Building Committee
+- **Description:** The municipal authority responsible for building permits,
+  building code compliance, and oversight of construction activities. The
+  building committee enforces Boverkets Byggregler (BBR) and Plan- och
+  Bygglagen (PBL). In the insurance context, building committee records are
+  relevant for verifying that insured properties comply with building codes,
+  assessing renovation permits, and investigating claims where non-compliant
+  construction may be a contributing factor.
+- **Responsibilities:**
+  - Issue building permits (bygglov) for renovations and new construction
+  - Enforce building code compliance (BBR)
+  - Provide building permit records for underwriting and claims assessment
+  - Issue completion certificates (slutbesked) confirming code compliance
+  - Investigate unauthorized construction that may affect claims
+- **Key interactions:** Underwriting (building permit verification, code
+  compliance assessment), claims handling (investigation of non-compliant
+  construction as a contributing factor to damage)
+- **Regulatory relevance:**
+  - FSA — building code compliance data supports accurate risk assessment and
+    fair claims settlement (FSA-005, FSA-010)
+  - GDPR — building permit records may include property owner personal data;
+    access must follow purpose limitation (GDPR-001)

--- a/docs/actors/external/fire-department.md
+++ b/docs/actors/external/fire-department.md
@@ -1,0 +1,29 @@
+---
+sidebar_label: Fire Department (Räddningstjänsten)
+sidebar_position: 12
+---
+
+# Fire Department (Räddningstjänsten)
+
+- **Swedish term:** Räddningstjänsten
+- **English name:** Municipal Rescue Service / Fire Department
+- **Description:** The municipal rescue service responsible for emergency
+  response to fires, floods, and other hazardous events affecting insured
+  properties. Fire department incident reports (insatsrapporter) are critical
+  evidence in home & property claims, providing details on cause of fire, extent
+  of damage, and actions taken. The fire department also performs fire cause
+  investigations that inform liability determination.
+- **Responsibilities:**
+  - Respond to fire, flood, and other property emergencies
+  - Produce incident reports documenting cause, extent, and response actions
+  - Perform fire cause investigations
+  - Provide incident reports to insurers upon request for claims processing
+  - Issue fire safety compliance reports
+- **Key interactions:** Claims handling (incident reports for fire and flood
+  claims, cause of loss determination), fraud detection (fire cause
+  investigation supporting arson detection)
+- **Regulatory relevance:**
+  - FSA — incident reports support evidence-based and fair claims settlement
+    (FSA-010)
+  - GDPR — exchange of personal data between rescue services and insurer must
+    have a legal basis; data minimization applies (GDPR-001)

--- a/docs/actors/external/lantmateriet.md
+++ b/docs/actors/external/lantmateriet.md
@@ -1,0 +1,31 @@
+---
+sidebar_label: Lantmäteriet
+sidebar_position: 13
+---
+
+# Lantmäteriet
+
+- **Swedish term:** Lantmäteriet
+- **English name:** Swedish Cadastral Authority
+- **Description:** The Swedish government agency responsible for cadastral
+  surveying, property registration, and geographic information. Lantmäteriet
+  maintains the property register (fastighetsregistret) containing property
+  boundaries, ownership records, easements, and encumbrances. This data is
+  essential for home & property underwriting (verifying ownership, property
+  boundaries, and building data) and claims handling (confirming insurable
+  interest and property details).
+- **Responsibilities:**
+  - Provide property ownership records for underwriting verification
+  - Supply property boundary and land area data
+  - Provide building data (construction year, area, building type)
+  - Issue property extracts (fastighetsutdrag) used in insurance applications
+  - Maintain geographic and mapping data used for risk assessment (flood zones,
+    landslide risk areas)
+- **Key interactions:** Underwriting (property ownership verification, building
+  data for risk assessment, geographic risk data), claims handling (verifying
+  insurable interest, property details)
+- **Regulatory relevance:**
+  - FSA — property data supports accurate risk assessment and product oversight
+    (FSA-005)
+  - GDPR — property register data includes personal data (owner names);
+    access must have a legal basis and follow purpose limitation (GDPR-001)

--- a/docs/actors/external/locksmith.md
+++ b/docs/actors/external/locksmith.md
@@ -1,0 +1,29 @@
+---
+sidebar_label: Locksmith (Låssmed)
+sidebar_position: 11
+---
+
+# Locksmith (Låssmed)
+
+- **Swedish term:** Låssmed
+- **English name:** Locksmith
+- **Description:** Professional locksmith services engaged for emergency lock
+  replacement following burglary or break-in, as well as security upgrades
+  recommended after security incidents. Locksmiths are dispatched as part of the
+  claims process and may be covered under the home insurance policy's burglary
+  coverage. TryggFörsäkring may maintain a network of approved locksmiths for
+  direct settlement.
+- **Responsibilities:**
+  - Provide emergency lock replacement after burglary or break-in
+  - Perform security upgrades (lock upgrades, security door installation)
+  - Provide cost estimates for insurance claims
+  - Submit invoices directly to TryggFörsäkring when under framework agreement
+  - Document the scope of work for claims records
+- **Key interactions:** Claims handling (emergency dispatch after burglary,
+  cost estimation, invoicing)
+- **Regulatory relevance:**
+  - FSA — locksmith costs as part of burglary claims must follow fair
+    settlement practices (FSA-010)
+  - GDPR — receives limited personal data (policyholder name, address)
+    necessary for service delivery; subject to data processing agreements
+    (GDPR-001)

--- a/docs/actors/external/property-inspector.md
+++ b/docs/actors/external/property-inspector.md
@@ -1,0 +1,32 @@
+---
+sidebar_label: Property Inspector (Besiktningsman)
+sidebar_position: 10
+---
+
+# Property Inspector (Besiktningsman)
+
+- **Swedish term:** Besiktningsman
+- **English name:** Certified Property Inspector
+- **Description:** A certified inspector who performs pre-purchase inspections
+  (överlåtelsebesiktning) and condition assessments of residential properties.
+  Property inspectors assess building condition, identify visible defects and
+  potential latent defects, and produce inspection reports that are used in
+  underwriting risk assessment and claims investigation. Inspectors are
+  certified according to SBR (Svenska Byggingenjörers Riksförbund) standards.
+- **Responsibilities:**
+  - Perform pre-purchase property inspections
+  - Assess building condition including structure, roof, plumbing, and
+    electrical systems
+  - Identify visible defects and flag risk areas for latent defects
+  - Produce structured inspection reports with findings and risk ratings
+  - Provide expert opinions for claims investigations involving building
+    defects
+  - Testify or provide statements in disputed claims
+- **Key interactions:** Underwriting (risk assessment input, property condition
+  data), claims handling (expert opinion on building defects, damage cause
+  assessment)
+- **Regulatory relevance:**
+  - FSA — inspection reports support evidence-based risk assessment and fair
+    claims settlement (FSA-005, FSA-010)
+  - GDPR — inspection reports may contain property owner personal data;
+    processing requires legal basis (GDPR-001)

--- a/docs/actors/external/restoration-company.md
+++ b/docs/actors/external/restoration-company.md
@@ -1,0 +1,32 @@
+---
+sidebar_label: Restoration Company (Saneringsfirma)
+sidebar_position: 9
+---
+
+# Restoration Company (Saneringsfirma)
+
+- **Swedish term:** Saneringsfirma
+- **English name:** Professional Restoration Company
+- **Description:** Specialized companies (e.g., Polygon, Anticimex, BELFOR) that
+  perform professional restoration and remediation work following insured events
+  in residential properties. Services include water damage drying, fire cleanup,
+  mold remediation, and structural restoration. Restoration companies are
+  typically dispatched by TryggFörsäkring and work under framework agreements
+  with established quality standards and pricing.
+- **Responsibilities:**
+  - Respond to emergency call-outs for water damage, fire damage, and mold
+  - Perform moisture measurement and drying of affected structures
+  - Execute fire cleanup and decontamination
+  - Conduct mold remediation and prevention
+  - Provide damage assessments and cost estimates to claims handlers
+  - Submit progress reports and completion documentation
+  - Invoice TryggFörsäkring directly under framework agreements
+- **Key interactions:** Claims handling (emergency dispatch, damage assessment,
+  restoration coordination), claims adjustment (damage scope verification, cost
+  validation)
+- **Regulatory relevance:**
+  - FSA — restoration quality and cost management support fair claims
+    settlement obligations (FSA-010)
+  - GDPR — receives limited personal data (property owner, address, contact
+    details) necessary for restoration work; subject to data processing
+    agreements (GDPR-001)

--- a/docs/actors/index.md
+++ b/docs/actors/index.md
@@ -11,25 +11,32 @@ term, responsibilities, key interactions, and regulatory relevance.
 
 ## Actor Summary
 
-| Actor                                                                 | Type     | Primary Role                                          |
-| --------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
-| [Customer (Privatkund)](internal/customer.md)                         | Internal | Private individual seeking or holding motor insurance |
-| [Corporate Customer (Företagskund)](internal/corporate-customer.md)   | Internal | Business entity with fleet or commercial vehicles     |
-| [Insurance Agent (Försäkringsagent)](internal/insurance-agent.md)     | Internal | Represents insurers and sells policies                |
-| [Insurance Broker (Försäkringsmäklare)](internal/insurance-broker.md) | Internal | Independent advisor representing customer interests   |
-| [Claims Handler (Skadereglerare)](internal/claims-handler.md)         | Internal | Assesses, investigates, and settles claims            |
-| [Claims Adjuster (Värderare)](internal/claims-adjuster.md)            | Internal | Specialized vehicle damage assessor                   |
-| [Underwriter (Riskbedömare)](internal/underwriter.md)                 | Internal | Assesses risk, sets premiums and terms                |
-| [Actuary](internal/actuary.md)                                        | Internal | Develops pricing models and analyzes claims data      |
-| [Compliance Officer](internal/compliance-officer.md)                  | Internal | Ensures regulatory adherence                          |
-| [System Administrator](internal/system-administrator.md)              | Internal | Manages platform configuration and access             |
-| [Transportstyrelsen](external/transportstyrelsen.md)                  | External | Swedish Transport Agency — vehicle registry           |
-| [TFF](external/tff.md)                                                | External | Swedish Motor Insurers — uninsured claims             |
-| [BankID](external/bankid.md)                                          | External | Electronic identification and signing                 |
-| [Repair Shop (Verkstad)](external/repair-shop.md)                     | External | Authorized vehicle repair network                     |
-| [Police (Polis)](external/police.md)                                  | External | Accident reports and fraud investigation              |
-| [Medical Provider (Vårdgivare)](external/medical-provider.md)         | External | Injury treatment and medical reports                  |
-| [Payment Provider](external/payment-provider.md)                      | External | Payment processing for premiums and claims            |
+| Actor                                                                   | Type     | Phase       | Primary Role                                        |
+| ----------------------------------------------------------------------- | -------- | ----------- | --------------------------------------------------- |
+| [Customer (Privatkund)](internal/customer.md)                           | Internal | Motor, Home | Private individual seeking or holding insurance     |
+| [Corporate Customer (Företagskund)](internal/corporate-customer.md)     | Internal | Motor       | Business entity with fleet or commercial vehicles   |
+| [Insurance Agent (Försäkringsagent)](internal/insurance-agent.md)       | Internal | Motor, Home | Represents insurers and sells policies              |
+| [Insurance Broker (Försäkringsmäklare)](internal/insurance-broker.md)   | Internal | Motor       | Independent advisor representing customer interests |
+| [Claims Handler (Skadereglerare)](internal/claims-handler.md)           | Internal | Motor, Home | Assesses, investigates, and settles claims          |
+| [Claims Adjuster (Värderare)](internal/claims-adjuster.md)              | Internal | Motor       | Specialized vehicle damage assessor                 |
+| [Underwriter (Riskbedömare)](internal/underwriter.md)                   | Internal | Motor, Home | Assesses risk, sets premiums and terms              |
+| [Actuary](internal/actuary.md)                                          | Internal | Motor       | Develops pricing models and analyzes claims data    |
+| [Compliance Officer](internal/compliance-officer.md)                    | Internal | Motor       | Ensures regulatory adherence                        |
+| [System Administrator](internal/system-administrator.md)                | Internal | Motor       | Manages platform configuration and access           |
+| [Transportstyrelsen](external/transportstyrelsen.md)                    | External | Motor       | Swedish Transport Agency — vehicle registry         |
+| [TFF](external/tff.md)                                                  | External | Motor       | Swedish Motor Insurers — uninsured claims           |
+| [BankID](external/bankid.md)                                            | External | Motor       | Electronic identification and signing               |
+| [Repair Shop (Verkstad)](external/repair-shop.md)                       | External | Motor       | Authorized vehicle repair network                   |
+| [Police (Polis)](external/police.md)                                    | External | Motor       | Accident reports and fraud investigation            |
+| [Medical Provider (Vårdgivare)](external/medical-provider.md)           | External | Motor       | Injury treatment and medical reports                |
+| [Payment Provider](external/payment-provider.md)                        | External | Motor       | Payment processing for premiums and claims          |
+| [BRF Board (BRF-styrelse)](external/brf-board.md)                       | External | Home        | Tenant-owner association — building insurance       |
+| [Restoration Company (Saneringsfirma)](external/restoration-company.md) | External | Home        | Professional restoration — water, fire, mold        |
+| [Property Inspector (Besiktningsman)](external/property-inspector.md)   | External | Home        | Certified property condition inspector              |
+| [Locksmith (Låssmed)](external/locksmith.md)                            | External | Home        | Emergency lock replacement after burglary           |
+| [Fire Department (Räddningstjänsten)](external/fire-department.md)      | External | Home        | First responder — incident reports for claims       |
+| [Lantmäteriet](external/lantmateriet.md)                                | External | Home        | Swedish cadastral authority — property records      |
+| [Building Committee (Byggnadsnämnd)](external/building-committee.md)    | External | Home        | Municipal authority — building permits and codes    |
 
 ## Internal vs External Actors
 

--- a/docs/actors/internal/claims-handler.md
+++ b/docs/actors/internal/claims-handler.md
@@ -9,7 +9,9 @@ sidebar_position: 5
 - **Description:** An employee of TryggFörsäkring responsible for the end-to-end
   handling of insurance claims. Claims handlers receive first notifications of
   loss (FNOL), investigate claim circumstances, determine coverage and
-  liability, and authorize settlements.
+  liability, and authorize settlements. In the home & property domain, claims
+  handlers manage complex multi-party claims involving water damage, fire,
+  burglary, and natural events.
 - **Responsibilities:**
   - Receive and register claims (skadeanmälan)
   - Investigate claim circumstances and verify coverage
@@ -18,7 +20,16 @@ sidebar_position: 5
   - Authorize claim payments and settlements
   - Handle disputes and escalate to complaints procedures when needed
   - Detect and flag potential fraud
-- **Key interactions:** Claims handling, fraud detection, settlement processing
+  - _Home & property:_ Dispatch and coordinate restoration companies for water
+    damage drying, fire cleanup, and mold remediation
+  - _Home & property:_ Manage multi-party claims involving BRF shared areas
+    and individual member apartments
+  - _Home & property:_ Coordinate with fire department for incident reports
+    and cause-of-loss determination
+  - _Home & property:_ Arrange property inspections for building defect claims
+  - _Home & property:_ Coordinate locksmith dispatch for burglary claims
+- **Key interactions:** Claims handling, fraud detection, settlement processing,
+  restoration company coordination, fire department liaison
 - **Regulatory relevance:**
   - FSA — must ensure fair and timely claims settlement (FSA-010); adhere to
     complaints handling procedures (FSA-011)

--- a/docs/actors/internal/customer.md
+++ b/docs/actors/internal/customer.md
@@ -6,19 +6,30 @@ sidebar_position: 1
 # Customer (Privatkund)
 
 - **Swedish term:** Privatkund
-- **Description:** A private individual who seeks, purchases, or holds a motor
-  insurance policy with TryggFörsäkring. Customers interact with the platform
-  through self-service channels (web, mobile) and through agents or brokers.
+- **Description:** A private individual who seeks, purchases, or holds insurance
+  policies with TryggFörsäkring. Customers interact with the platform through
+  self-service channels (web, mobile) and through agents or brokers. In the home
+  & property domain, customers may be homeowners (villaägare), apartment owners
+  (bostadsrättsinnehavare), or renters (hyresgäster), each with distinct
+  coverage needs.
 - **Responsibilities:**
-  - Request and compare motor insurance quotes
+  - Request and compare insurance quotes (motor, home & property)
   - Purchase and sign insurance policies (via BankID)
   - Report claims (skadeanmälan) and track claim status
   - Manage policy details (vehicle changes, address updates, coverage
-    adjustments)
+    adjustments, property details)
   - Pay premiums and manage payment methods
   - Exercise cooling-off rights (ångerrätt) and request cancellations
+  - _Home & property:_ Provide property details for underwriting (property
+    type, construction year, area, security features)
+  - _Home & property:_ Report home claims (water damage, fire, burglary,
+    liability)
+  - _Home & property:_ Coordinate with BRF board when damage spans shared and
+    private areas
+  - _Home & property:_ Arrange access for restoration companies and property
+    inspectors
 - **Key interactions:** Quote and bind, policy administration, claims reporting,
-  renewals, cancellations
+  renewals, cancellations, home claims coordination
 - **Regulatory relevance:**
   - GDPR — data subject with rights to access, rectification, erasure, and
     portability (GDPR-001 to GDPR-006)

--- a/docs/actors/internal/insurance-agent.md
+++ b/docs/actors/internal/insurance-agent.md
@@ -9,7 +9,9 @@ sidebar_position: 3
 - **Description:** A licensed intermediary who represents one or more insurance
   companies and sells their products. Agents act on behalf of the insurer and
   are registered with Finansinspektionen. In the Swedish market, agents are
-  tied to the insurers they represent.
+  tied to the insurers they represent. In the home & property domain, agents
+  advise on home insurance products, bostadsrättstillägg, and villa coverage
+  options.
 - **Responsibilities:**
   - Conduct demands-and-needs assessments for customers
   - Present quotes and recommend appropriate coverage tiers
@@ -17,8 +19,14 @@ sidebar_position: 3
   - Provide pre-contractual information (IPID, disclosure documents)
   - Maintain competence through ongoing training
   - Record all advisory interactions
+  - _Home & property:_ Advise on home insurance coverage options
+    (hemförsäkring, villaförsäkring, bostadsrättstillägg)
+  - _Home & property:_ Assist customers with property-specific
+    demands-and-needs assessments
+  - _Home & property:_ Handle home policy inquiries and first-line claims
+    support
 - **Key interactions:** Quote and bind, demands-and-needs assessment, policy
-  administration
+  administration, home policy advisory
 - **Regulatory relevance:**
   - IDD — must perform demands-and-needs assessment (IDD-001), provide IPID
     (IDD-002), disclose distribution status and remuneration (IDD-005), and

--- a/docs/actors/internal/underwriter.md
+++ b/docs/actors/internal/underwriter.md
@@ -9,7 +9,9 @@ sidebar_position: 7
 - **Description:** An insurance professional responsible for evaluating risk and
   determining the terms, conditions, and pricing of insurance policies.
   Underwriters apply risk models, bonus class rules, and company guidelines
-  to decide whether to accept, modify, or decline insurance applications.
+  to decide whether to accept, modify, or decline insurance applications. In
+  the home & property domain, underwriters assess property-specific risk factors
+  including construction type, location, flood exposure, and security features.
 - **Responsibilities:**
   - Evaluate insurance applications against risk criteria
   - Set premium levels based on risk factors (vehicle type, driver history,
@@ -18,8 +20,18 @@ sidebar_position: 7
   - Apply bonus class rules and no-claims discount schedules
   - Approve or decline high-risk or non-standard applications
   - Maintain and update underwriting guidelines
+  - _Home & property:_ Assess property risk factors (property type,
+    construction year, building materials, roof type, area)
+  - _Home & property:_ Evaluate location-based risks (flood zones, landslide
+    areas, crime statistics) using Lantmäteriet geographic data
+  - _Home & property:_ Verify building permit compliance via building
+    committee records
+  - _Home & property:_ Assess BRF building insurance applications including
+    shared infrastructure risk
+  - _Home & property:_ Review property inspection reports for pre-existing
+    conditions
 - **Key interactions:** Quote and bind, underwriting and bonus management,
-  renewals, policy administration
+  renewals, policy administration, property risk assessment
 - **Regulatory relevance:**
   - FSA — pricing must comply with consumer protection and fair treatment rules
     (FSA-004); products must be governed by product oversight processes


### PR DESCRIPTION
## Summary
- Create 7 new external actor definitions for the home & property domain: BRF Board, Restoration Company, Property Inspector, Locksmith, Fire Department, Lantmäteriet, and Building Committee
- Update 4 existing actors (Customer, Claims Handler, Underwriter, Insurance Agent) with home & property responsibilities
- Add Phase column to actors index table for multi-phase visibility

## Changes
- **New files:** 7 external actor markdown files in `docs/actors/external/`
- **Updated files:** 4 internal actor files with Phase 2 home & property additions
- **Updated:** `docs/actors/index.md` — added new actors and Phase column

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] Docusaurus build succeeds
- [x] All regulatory cross-references verified (FSA, GDPR, IDD)
- [x] Swedish terms included for all actors

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)