### PR TITLE
docs(#68): Add Phase 2 home & property regulatory requirements

### DIFF
--- a/docs/regulatory/fsa-requirements.md
+++ b/docs/regulatory/fsa-requirements.md
@@ -10,31 +10,37 @@ Regulatory requirements from **Finansinspektionen** (Swedish Financial Superviso
 
 The following Swedish laws and EU directives form the legal basis for FSA regulatory obligations relevant to this platform:
 
-| Law / Directive          | Swedish Name                        | Scope                                                       |
-| ------------------------ | ----------------------------------- | ----------------------------------------------------------- |
-| Insurance Business Act   | Försäkringsrörelselagen (2010:2043) | Authorization, governance, capital requirements, solvency   |
-| Motor Traffic Damage Act | Trafikskadelagen (1975:1410)        | Mandatory trafikförsäkring, liability rules, TFF membership |
-| Insurance Contracts Act  | Försäkringsavtalslagen (2005:104)   | Consumer insurance contract rules, disclosure, cancellation |
-| EU Solvency II Directive | Direktiv 2009/138/EG                | Capital adequacy, risk management, supervisory reporting    |
+| Law / Directive           | Swedish Name                        | Scope                                                                |
+| ------------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| Insurance Business Act    | Försäkringsrörelselagen (2010:2043) | Authorization, governance, capital requirements, solvency            |
+| Motor Traffic Damage Act  | Trafikskadelagen (1975:1410)        | Mandatory trafikförsäkring, liability rules, TFF membership          |
+| Insurance Contracts Act   | Försäkringsavtalslagen (2005:104)   | Consumer insurance contract rules, disclosure, cancellation          |
+| EU Solvency II Directive  | Direktiv 2009/138/EG                | Capital adequacy, risk management, supervisory reporting             |
+| Housing Cooperative Act   | Bostadsrättslagen (1991:614)        | BRF governance, building insurance obligations (Phase 2)             |
+| Planning and Building Act | Plan- och bygglagen (2010:900)      | Building standards, property valuation, construction rules (Phase 2) |
 
 ## Requirement Summary
 
-| ID                                                      | Area                | Short Description                                   |
-| ------------------------------------------------------- | ------------------- | --------------------------------------------------- |
-| [FSA-001](#fsa-001-insurance-company-authorization)     | Authorization       | Insurance company must be authorized by FSA         |
-| [FSA-002](#fsa-002-minimum-start-up-capital)            | Capital             | EUR 4M minimum start-up capital for motor insurance |
-| [FSA-003](#fsa-003-solvency-ii-compliance)              | Solvency            | Solvency II capital adequacy and risk management    |
-| [FSA-004](#fsa-004-consumer-protection--fair-treatment) | Consumer Protection | Fair treatment and clear policy terms               |
-| [FSA-005](#fsa-005-product-governance)                  | Product Governance  | Target market identification and product monitoring |
-| [FSA-006](#fsa-006-supervisory-reporting)               | Reporting           | Regular financial and supervisory reporting to FSA  |
-| [FSA-007](#fsa-007-mandatory-trafikförsäkring)          | Trafikförsäkring    | Mandatory insurance for all registered vehicles     |
-| [FSA-008](#fsa-008-tff-membership)                      | TFF Membership      | Membership in Trafikförsäkringsföreningen           |
-| [FSA-009](#fsa-009-transportstyrelsen-notification)     | Transportstyrelsen  | Policy changes reported to Transport Agency         |
-| [FSA-010](#fsa-010-fair-and-timely-claims-settlement)   | Claims Handling     | Fair and timely claims settlement                   |
-| [FSA-011](#fsa-011-complaints-handling-procedure)       | Complaints          | Complaints handling procedure                       |
-| [FSA-012](#fsa-012-insurance-contract-disclosure)       | Disclosure          | Pre-contractual and contractual information duties  |
-| [FSA-013](#fsa-013-cancellation-and-cooling-off-rights) | Cancellation        | Consumer cancellation and ångerrätt (cooling-off)   |
-| [FSA-014](#fsa-014-record-keeping)                      | Record Keeping      | Retention of policy and claims records              |
+| ID                                                      | Area                           | Short Description                                                            |
+| ------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------- |
+| [FSA-001](#fsa-001-insurance-company-authorization)     | Authorization                  | Insurance company must be authorized by FSA                                  |
+| [FSA-002](#fsa-002-minimum-start-up-capital)            | Capital                        | EUR 4M minimum start-up capital for motor insurance                          |
+| [FSA-003](#fsa-003-solvency-ii-compliance)              | Solvency                       | Solvency II capital adequacy and risk management                             |
+| [FSA-004](#fsa-004-consumer-protection--fair-treatment) | Consumer Protection            | Fair treatment and clear policy terms                                        |
+| [FSA-005](#fsa-005-product-governance)                  | Product Governance             | Target market identification and product monitoring                          |
+| [FSA-006](#fsa-006-supervisory-reporting)               | Reporting                      | Regular financial and supervisory reporting to FSA                           |
+| [FSA-007](#fsa-007-mandatory-trafikförsäkring)          | Trafikförsäkring               | Mandatory insurance for all registered vehicles                              |
+| [FSA-008](#fsa-008-tff-membership)                      | TFF Membership                 | Membership in Trafikförsäkringsföreningen                                    |
+| [FSA-009](#fsa-009-transportstyrelsen-notification)     | Transportstyrelsen             | Policy changes reported to Transport Agency                                  |
+| [FSA-010](#fsa-010-fair-and-timely-claims-settlement)   | Claims Handling                | Fair and timely claims settlement                                            |
+| [FSA-011](#fsa-011-complaints-handling-procedure)       | Complaints                     | Complaints handling procedure                                                |
+| [FSA-012](#fsa-012-insurance-contract-disclosure)       | Disclosure                     | Pre-contractual and contractual information duties                           |
+| [FSA-013](#fsa-013-cancellation-and-cooling-off-rights) | Cancellation                   | Consumer cancellation and ångerrätt (cooling-off)                            |
+| [FSA-014](#fsa-014-record-keeping)                      | Record Keeping                 | Retention of policy and claims records                                       |
+| [FSA-015](#fsa-015-consumer-protection--home)           | Consumer Protection — Home     | Product suitability for hemförsäkring; mandatory coverage levels _(Phase 2)_ |
+| [FSA-016](#fsa-016-building-valuation)                  | Building Valuation             | Adequate building sum insured; underinsurance rules _(Phase 2)_              |
+| [FSA-017](#fsa-017-claims-handling--water-damage)       | Claims Handling — Water Damage | Obligations for coordinating restoration (saneringsfirma) _(Phase 2)_        |
+| [FSA-018](#fsa-018-natural-disaster-reserves)           | Natural Disaster Reserves      | Reserve requirements for storm/flood/climate events _(Phase 2)_              |
 
 ## Detailed Requirements
 
@@ -135,6 +141,38 @@ The following Swedish laws and EU directives form the legal basis for FSA regula
 - **Legal basis:** Försäkringsrörelselagen (2010:2043), Chapter 10; Bokföringslagen (1999:1078)
 - **Impact on platform:** The platform must implement data retention policies. Policy records, claims files, and customer correspondence must be retained for a minimum of 10 years after the contract ends. Archival and retrieval mechanisms must be built into the system.
 - **Compliance verification:** Data retention policies are configured in the platform. Automated archival processes are operational. Retrieval from archive is tested and documented. No records are deleted before the retention period expires.
+
+### FSA-015: Consumer Protection — Home
+
+- **Description:** Insurance companies offering hemförsäkring (home insurance) must ensure product suitability for the customer's housing situation. Mandatory coverage levels for hemförsäkring include personal property (lösöre), liability protection (ansvarsförsäkring), legal expenses (rättsskydd), and assault coverage (överfallsskydd). The insurer must clearly communicate what is and is not covered, particularly the distinction between bostadsrättstillägg (housing cooperative supplement), villaförsäkring (detached house insurance), and hyresrättsförsäkring (rental apartment insurance).
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapters 2 and 3; FSA General Guidelines (FFFS 2015:9); Bostadsrättslagen (1991:614) for BRF-related obligations
+- **Impact on platform:** The platform must enforce product configuration rules that ensure all hemförsäkring products include mandatory coverage components. The quote workflow must determine the customer's housing type (villa, bostadsrätt, hyresrätt) and present appropriate product variants. Coverage limits must be validated against minimum statutory levels.
+- **Compliance verification:** Product configuration includes all mandatory coverage components. Quote workflow captures housing type and applies the correct product variant. Coverage limit validation rules are enforced. Customer-facing documents clearly distinguish between housing types and their respective coverage.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-016: Building Valuation
+
+- **Description:** For villaförsäkring (detached house insurance) and BRF building insurance, the insurer must ensure adequate building sum insured (fullvärdesförsäkring or förstadagsbelopp) to prevent underinsurance (underförsäkring). The insurer must provide tools or guidance for the customer to determine the correct rebuilding cost (återuppbyggnadskostnad). Where the building sum insured is inadequate, the insurer must inform the customer of the risk of proportional claims settlement.
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapter 6, Section 2 (proportional settlement); FSA General Guidelines on property insurance; Plan- och bygglagen (2010:900) for building standards affecting valuation
+- **Impact on platform:** The platform must include a building valuation tool or integration (e.g., Lantmäteriet property data, byggkostnadskalkyl) that helps determine the appropriate sum insured. The quote workflow must flag potential underinsurance when the customer-specified sum insured falls below the estimated rebuilding cost. Renewal workflows must prompt the customer to review the sum insured, accounting for building cost inflation (byggkostnadsindex).
+- **Compliance verification:** Building valuation tool produces estimates consistent with market rebuilding costs. Underinsurance warnings are triggered and documented when sum insured is below threshold. Renewal notices include building cost inflation adjustments. Proportional settlement calculations are correctly applied when underinsurance exists.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-017: Claims Handling — Water Damage
+
+- **Description:** Water damage (vattenskada) is the most common and costly home insurance claim category in Sweden. The insurer has specific obligations to coordinate with restoration companies (saneringsfirmor), plumbers (rörmokare), and building inspectors to ensure timely and adequate remediation. The insurer must ensure that policyholders are informed of their right to choose their own contractor while also maintaining quality standards through approved supplier networks.
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapter 7; FSA General Guidelines on claims handling; Branschregler for vattenskadesanering (industry guidelines)
+- **Impact on platform:** The claims module must support water damage-specific workflows including: initial damage assessment, moisture measurement scheduling, restoration company assignment (from approved supplier network or customer-chosen contractor), progress tracking through drying and restoration phases, and final inspection sign-off. The system must track response times from first notification of loss (FNOL) through restoration completion.
+- **Compliance verification:** Water damage claims workflows include all required phases (assessment, sanering, restoration, inspection). Response time SLAs are configured and monitored. Policyholder contractor choice is documented. Approved supplier network is maintained and accessible. Restoration quality standards are tracked.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-018: Natural Disaster Reserves
+
+- **Description:** Insurance companies offering property insurance must maintain adequate technical reserves for natural disaster events (naturkatastrofreserv), including storm (storm), flooding (översvämning), and climate-related events. FSA requires insurers to model catastrophe risk exposure and hold sufficient capital buffers. This is particularly relevant given increasing climate-related claims frequency in Sweden, including cloudbursts (skyfall), rising sea levels, and extreme weather events.
+- **Legal basis:** Försäkringsrörelselagen (2010:2043), Chapter 4 (technical provisions); EU Solvency II Directive, Article 101 (SCR for natural catastrophe risk); FSA regulations (FFFS 2019:23) for reporting natural catastrophe exposure
+- **Impact on platform:** The platform must capture and categorize property claims by peril type (storm, flood, fire, water damage, etc.) to support catastrophe risk modeling. Geospatial data (property location, flood zone, proximity to water bodies) must be stored for risk assessment. The platform must support aggregate exposure reporting by geographic area and peril type for actuarial and regulatory purposes.
+- **Compliance verification:** Claims categorization includes peril type taxonomy. Property records include geospatial risk data. Aggregate exposure reports can be generated by region and peril type. Catastrophe reserve calculations are supported by accurate platform data. Reporting to FSA on natural catastrophe exposure is facilitated.
+- **Phase:** Phase 2 — Home & Property
 
 ## Cross-reference Guide
 

--- a/docs/regulatory/gdpr-mapping.md
+++ b/docs/regulatory/gdpr-mapping.md
@@ -4,20 +4,22 @@ sidebar_position: 2
 
 # GDPR Data Mapping
 
-GDPR compliance mapping for personal data handling within the TryggFörsäkring motor insurance platform. Each data processing activity has a unique ID (GDPR-001, GDPR-002, etc.) used for cross-referencing from user stories and use cases.
+GDPR compliance mapping for personal data handling within the TryggFörsäkring insurance platform. Each data processing activity has a unique ID (GDPR-001, GDPR-002, etc.) used for cross-referencing from user stories and use cases. GDPR-001 through GDPR-006 cover motor insurance; GDPR-007 through GDPR-009 cover home & property insurance (Phase 2).
 
 ## Key Legislation
 
 The following EU regulations and Swedish laws govern personal data processing in the insurance context:
 
-| Regulation / Law                   | Swedish Name                      | Scope                                                         |
-| ---------------------------------- | --------------------------------- | ------------------------------------------------------------- |
-| General Data Protection Regulation | EU Förordning 2016/679 (GDPR)     | Personal data processing, data subject rights, accountability |
-| Swedish Data Protection Act        | Dataskyddslagen (2018:218)        | Supplements GDPR with Swedish-specific provisions             |
-| Swedish Data Protection Ordinance  | Dataskyddsförordningen (2018:219) | Implementing provisions for Dataskyddslagen                   |
-| Motor Traffic Damage Act           | Trafikskadelagen (1975:1410)      | Legal obligation basis for claims data processing             |
-| Accounting Act                     | Bokföringslagen (1999:1078)       | Retention periods for financial records                       |
-| Insurance Contracts Act            | Försäkringsavtalslagen (2005:104) | Contract performance basis for policy data                    |
+| Regulation / Law                   | Swedish Name                       | Scope                                                         |
+| ---------------------------------- | ---------------------------------- | ------------------------------------------------------------- |
+| General Data Protection Regulation | EU Förordning 2016/679 (GDPR)      | Personal data processing, data subject rights, accountability |
+| Swedish Data Protection Act        | Dataskyddslagen (2018:218)         | Supplements GDPR with Swedish-specific provisions             |
+| Swedish Data Protection Ordinance  | Dataskyddsförordningen (2018:219)  | Implementing provisions for Dataskyddslagen                   |
+| Motor Traffic Damage Act           | Trafikskadelagen (1975:1410)       | Legal obligation basis for claims data processing             |
+| Accounting Act                     | Bokföringslagen (1999:1078)        | Retention periods for financial records                       |
+| Insurance Contracts Act            | Försäkringsavtalslagen (2005:104)  | Contract performance basis for policy data                    |
+| Housing Cooperative Act            | Bostadsrättslagen (1991:614)       | BRF governance, building insurance obligations (Phase 2)      |
+| Real Property Register Act         | Fastighetsregisterlagen (2000:224) | Property data from Lantmäteriet (Phase 2)                     |
 
 **Supervisory Authority:** Integritetsskyddsmyndigheten (IMY) is the Swedish supervisory authority for data protection.
 
@@ -33,6 +35,17 @@ The following EU regulations and Swedish laws govern personal data processing in
 | Payment         | Bank account, payment history                                | (b) Contract performance                        | 7 years (Bokföringslagen)     |
 | Location        | Parking address, accident location                           | (b) Contract performance                        | Duration of policy            |
 | Communication   | Emails, call recordings, chat logs                           | (f) Legitimate interest                         | 3 years                       |
+
+### Personal Data Categories in Home & Property Insurance (Phase 2)
+
+| Category       | Data Elements                                                      | Legal Basis (Article 6(1)) | Retention Period              |
+| -------------- | ------------------------------------------------------------------ | -------------------------- | ----------------------------- |
+| Property       | Address, property type (villa/BRF/hyresrätt), building specs, area | (b) Contract performance   | Duration of policy + 10 years |
+| BRF membership | BRF name, org. number, board member names, membership status       | (b) Contract performance   | Duration of policy + 10 years |
+| Building       | Construction year, materials, rebuilding cost, renovations         | (b) Contract performance   | Duration of policy + 10 years |
+| Contents       | Sum insured, high-value items registry, home inventory             | (b) Contract performance   | Duration of policy + 10 years |
+| Restoration    | Damage reports, contractor details, restoration progress           | (b) Contract performance   | 10 years (limitation period)  |
+| Geospatial     | Flood zone, proximity to water, terrain data, climate risk zone    | (f) Legitimate interest    | Duration of policy            |
 
 ### Swedish-Specific Data Considerations
 
@@ -101,6 +114,39 @@ The following EU regulations and Swedish laws govern personal data processing in
 - **Data minimization:** Access full claims details only for flagged cases. Automated screening should use anonymized or pseudonymized data where possible. Limit access to fraud investigation staff.
 - **Retention:** Fraud investigation records retained for 10 years from investigation closure. Cleared cases: flag removed but investigation log retained.
 - **Recipients:** Internal fraud investigation team, GSR (industry fraud register), police (when criminal referral is made), reinsurers (for material fraud cases).
+
+### GDPR-007: Property Data Processing
+
+- **Purpose:** Collect and process property-related personal data for home & property insurance underwriting, policy administration, and claims handling. This includes address, property details, BRF membership, building specifications, and rebuilding cost estimates.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract; Article 6(1)(f) — legitimate interest for property risk assessment using publicly available data.
+- **Data categories:** Identity, property, building, BRF membership, geospatial.
+- **Data sources:** Customer input, Lantmäteriet (fastighetsregister — property registry), BRF board (building information), municipality (building permits and zoning), building valuation tools.
+- **Data minimization:** Collect only property data required for underwriting and risk assessment. Do not collect interior details beyond what is relevant to coverage (e.g., kitchen renovation status is relevant for rebuilding cost but room-by-room photographs are not). Geospatial risk data should be aggregated at zone level rather than exact-coordinate level where possible.
+- **Retention:** Policy-related property data retained for duration of policy + 10 years (FSA-014). Unconverted quotes with property data retained for 12 months, then deleted. Geospatial risk assessments retained for duration of policy.
+- **Recipients:** Internal underwriting systems, Lantmäteriet (property verification), building valuation providers (data processor agreements required), reinsurers (for catastrophe exposure assessment).
+- **Phase:** Phase 2 — Home & Property
+
+### GDPR-008: Restoration Company Data Sharing
+
+- **Purpose:** Share policyholder personal data with restoration companies (saneringsfirmor), contractors, and building inspectors during the claims handling process for home & property insurance. This is necessary to coordinate damage assessment, drying, restoration, and repair work.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract (claims settlement); Article 6(1)(f) — legitimate interest in efficient claims resolution.
+- **Data categories:** Identity (policyholder name, contact details, address), property (damage location, building access details), claims (damage description, assessment reports, restoration scope).
+- **Data sources:** Internal claims systems, policyholder (damage notification), property inspector reports.
+- **Data minimization:** Share only the data necessary for the specific restoration task. Restoration companies receive: policyholder name and contact details (for site access coordination), property address and access instructions, damage description and scope of work. They do not receive: personnummer, policy financial details, claims history, or unrelated personal data. Each contractor receives only the information relevant to their specific role.
+- **Retention:** Data sharing logs retained for 10 years from claim closure. Contractor copies of personal data must be returned or deleted after the restoration engagement ends, as specified in the data processing agreement.
+- **Recipients:** Approved restoration companies (saneringsfirmor), plumbers, electricians, building inspectors, moisture measurement specialists. All recipients must have valid data processing agreements (Article 28).
+- **Phase:** Phase 2 — Home & Property
+
+### GDPR-009: BRF Board Data
+
+- **Purpose:** Process personal data of BRF (bostadsrättsförening) board members in connection with building insurance policies for housing cooperatives. BRF board members act as representatives of the cooperative for insurance matters including policy administration, building maintenance coordination, and claims reporting.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract (BRF is the policyholder); Article 6(1)(f) — legitimate interest for verifying authority to act on behalf of the BRF.
+- **Data categories:** Identity (board member names, roles, contact details), BRF membership (organization number, board composition, mandate periods).
+- **Data sources:** BRF board (direct input), Bolagsverket (organization register for BRF registration verification), Lantmäteriet (property ownership records).
+- **Data minimization:** Collect only board member data necessary for insurance administration: name, role (ordförande, ledamot, suppleant), contact details, and mandate period. Do not collect personnummer of board members unless required for specific verification. Limit processing to board members who are authorized signatories or designated insurance contacts.
+- **Retention:** Board member data retained for duration of the BRF policy + 10 years (FSA-014). When board composition changes, historical board data is archived but retained for the full retention period to support claims traceability.
+- **Recipients:** Internal policy administration systems, building inspectors (for coordinating property inspections), Bolagsverket (for organization verification).
+- **Phase:** Phase 2 — Home & Property
 
 ## Data Subject Rights
 
@@ -186,11 +232,14 @@ Multiple requirements may apply to a single user story. Always list all applicab
 
 ### GDPR to FSA Cross-references
 
-| GDPR ID  | Related FSA IDs           | Relationship                                                                                        |
-| -------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
-| GDPR-001 | FSA-012                   | Quote generation requires both data collection consent and pre-contractual disclosure               |
-| GDPR-002 | FSA-014                   | Policy data retention aligns with FSA record-keeping requirements                                   |
-| GDPR-003 | FSA-010                   | Claims processing must satisfy both GDPR and fair settlement requirements                           |
-| GDPR-004 | FSA-007, FSA-008, FSA-009 | Transportstyrelsen and TFF reporting is both a GDPR legal obligation and FSA regulatory requirement |
-| GDPR-005 | FSA-004                   | Marketing must respect both GDPR consent rules and FSA fair treatment principles                    |
-| GDPR-006 | FSA-010                   | Fraud detection must balance data protection with fair claims handling                              |
+| GDPR ID  | Related FSA IDs           | Relationship                                                                                                 |
+| -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| GDPR-001 | FSA-012                   | Quote generation requires both data collection consent and pre-contractual disclosure                        |
+| GDPR-002 | FSA-014                   | Policy data retention aligns with FSA record-keeping requirements                                            |
+| GDPR-003 | FSA-010                   | Claims processing must satisfy both GDPR and fair settlement requirements                                    |
+| GDPR-004 | FSA-007, FSA-008, FSA-009 | Transportstyrelsen and TFF reporting is both a GDPR legal obligation and FSA regulatory requirement          |
+| GDPR-005 | FSA-004                   | Marketing must respect both GDPR consent rules and FSA fair treatment principles                             |
+| GDPR-006 | FSA-010                   | Fraud detection must balance data protection with fair claims handling                                       |
+| GDPR-007 | FSA-015, FSA-016          | Property data processing supports product suitability and building valuation requirements _(Phase 2)_        |
+| GDPR-008 | FSA-017                   | Restoration data sharing must comply with both GDPR and water damage claims handling obligations _(Phase 2)_ |
+| GDPR-009 | FSA-015                   | BRF board data processing supports home insurance policy administration _(Phase 2)_                          |

--- a/docs/regulatory/idd-compliance.md
+++ b/docs/regulatory/idd-compliance.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # IDD Compliance
 
-Insurance Distribution Directive (IDD) compliance requirements for the TryggFörsäkring motor insurance platform. The IDD governs how insurance products are sold and distributed, mandating demands-and-needs assessments, pre-contractual information, and product governance. Each requirement has a unique ID (IDD-001, IDD-002, etc.) used for cross-referencing from user stories and use cases.
+Insurance Distribution Directive (IDD) compliance requirements for the TryggFörsäkring insurance platform. The IDD governs how insurance products are sold and distributed, mandating demands-and-needs assessments, pre-contractual information, and product governance. Each requirement has a unique ID (IDD-001, IDD-002, etc.) used for cross-referencing from user stories and use cases. IDD-001 through IDD-010 cover motor insurance; IDD-011 through IDD-013 cover home & property insurance (Phase 2).
 
 ## Key Legislation
 
@@ -24,18 +24,21 @@ The following EU directives and Swedish laws form the legal basis for IDD compli
 
 ## Requirement Summary
 
-| ID                                                              | Area                        | Short Description                                      |
-| --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------ |
-| [IDD-001](#idd-001-demands-and-needs-assessment)                | Demands and Needs           | Assess customer needs before recommending a product    |
-| [IDD-002](#idd-002-insurance-product-information-document-ipid) | IPID                        | Standardized product information document              |
-| [IDD-003](#idd-003-pre-contractual-information)                 | Pre-contractual Information | Identity, complaints, and conflict of interest details |
-| [IDD-004](#idd-004-product-oversight-and-governance)            | Product Governance          | Target market, monitoring, and distribution strategy   |
-| [IDD-005](#idd-005-disclosure-of-distribution-status)           | Disclosure                  | Registration status and remuneration transparency      |
-| [IDD-006](#idd-006-advice-and-recommendation-requirements)      | Advice                      | Personalized recommendation obligations                |
-| [IDD-007](#idd-007-cross-selling-requirements)                  | Cross-selling               | Rules for bundled and optional add-on products         |
-| [IDD-008](#idd-008-record-keeping-for-distribution)             | Record Keeping              | Retention of distribution and advisory records         |
-| [IDD-009](#idd-009-professional-competence-and-training)        | Competence                  | Staff knowledge and ongoing training requirements      |
-| [IDD-010](#idd-010-complaints-handling-for-distribution)        | Complaints                  | Distribution-specific complaints procedures            |
+| ID                                                              | Area                            | Short Description                                                      |
+| --------------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------- |
+| [IDD-001](#idd-001-demands-and-needs-assessment)                | Demands and Needs               | Assess customer needs before recommending a product                    |
+| [IDD-002](#idd-002-insurance-product-information-document-ipid) | IPID                            | Standardized product information document                              |
+| [IDD-003](#idd-003-pre-contractual-information)                 | Pre-contractual Information     | Identity, complaints, and conflict of interest details                 |
+| [IDD-004](#idd-004-product-oversight-and-governance)            | Product Governance              | Target market, monitoring, and distribution strategy                   |
+| [IDD-005](#idd-005-disclosure-of-distribution-status)           | Disclosure                      | Registration status and remuneration transparency                      |
+| [IDD-006](#idd-006-advice-and-recommendation-requirements)      | Advice                          | Personalized recommendation obligations                                |
+| [IDD-007](#idd-007-cross-selling-requirements)                  | Cross-selling                   | Rules for bundled and optional add-on products                         |
+| [IDD-008](#idd-008-record-keeping-for-distribution)             | Record Keeping                  | Retention of distribution and advisory records                         |
+| [IDD-009](#idd-009-professional-competence-and-training)        | Competence                      | Staff knowledge and ongoing training requirements                      |
+| [IDD-010](#idd-010-complaints-handling-for-distribution)        | Complaints                      | Distribution-specific complaints procedures                            |
+| [IDD-011](#idd-011-demands-and-needs--home)                     | Demands and Needs — Home        | Needs assessment for home products: BRF vs villa vs rental _(Phase 2)_ |
+| [IDD-012](#idd-012-product-complexity-disclosure)               | Product Complexity Disclosure   | Explaining coverage gaps (allrisk, flood exclusions) _(Phase 2)_       |
+| [IDD-013](#idd-013-cross-selling-governance--home)              | Cross-selling Governance — Home | Rules for bundling home + travel + ID-skydd _(Phase 2)_                |
 
 ## Detailed Requirements
 
@@ -172,6 +175,52 @@ The following EU directives and Swedish laws form the legal basis for IDD compli
 - **Platform impact:** The complaints module must support categorization of complaints as distribution-related. The system must track complaint source (distribution channel), link complaints to the relevant distribution record, and generate reports on distribution complaint volumes and outcomes.
 - **Evidence requirements:** Retain complaint records including the nature of the complaint, the distribution channel involved, investigation findings, resolution outcome, and time to resolution. Aggregate complaint data must be available for POG product reviews (IDD-004) and FSA reporting (FSA-011).
 
+### IDD-011: Demands and Needs — Home
+
+- **Description:** Before recommending or concluding a home & property insurance contract, the distributor must perform a demands-and-needs assessment (krav- och behovsanalys) specific to the customer's housing situation. The assessment must determine the customer's housing type (villa, bostadsrätt, or hyresrätt), identify the appropriate product variant, and evaluate the need for supplementary coverage. Home insurance presents distinct assessment challenges compared to motor insurance because the product structure varies significantly by housing type.
+- **Legal basis:** IDD Article 20; Lag om försäkringsdistribution (2018:1219), Chapter 4, Section 3; FFFS 2018:10, Chapter 4
+- **Home insurance application:**
+  - Determine housing type: villa (detached house), bostadsrätt (housing cooperative apartment), or hyresrätt (rental apartment)
+  - For villa: assess building insurance needs (rebuilding cost, building age, construction materials), contents coverage level, and liability coverage
+  - For bostadsrätt: assess need for bostadsrättstillägg (BRF supplement covering interior fittings and improvements), contents coverage level, and whether the BRF's collective building insurance is adequate
+  - For hyresrätt: assess contents and liability coverage needs (no building component)
+  - Evaluate need for supplementary coverage: allriskförsäkring (accidental damage), ID-skydd (identity theft protection), bostadsrättstillägg, trädgårdsförsäkring (garden insurance for villa)
+  - Assess appropriate deductible level based on the customer's financial situation
+  - Document the assessment and the rationale for the recommendation
+- **Platform impact:** The quote workflow must include a structured demands-and-needs assessment that branches based on housing type. The assessment must capture the customer's housing situation, ownership status, property details, and coverage preferences before presenting product options. The platform must store the assessment responses, the recommended product configuration, and the rationale linking the recommendation to the customer's stated needs.
+- **Evidence requirements:** Retain the completed assessment form, the housing type determination, the recommended product variant, the rationale for the recommendation, and the customer's acceptance or deviation from the recommendation. Records must be retained for the duration of the customer relationship plus 10 years.
+- **Phase:** Phase 2 — Home & Property
+
+### IDD-012: Product Complexity Disclosure
+
+- **Description:** Home & property insurance products contain significant complexity that must be disclosed to the customer before contract conclusion. Coverage gaps between standard hemförsäkring and allriskförsäkring must be clearly explained. Common exclusions (flood from natural watercourses, subsidence, gradual damage) must be highlighted because customers frequently misunderstand what their home insurance covers. The distributor must ensure the customer understands the distinction between covered perils and excluded events.
+- **Legal basis:** IDD Article 20; Lag om försäkringsdistribution (2018:1219), Chapter 4, Sections 3-4; FFFS 2018:10, Chapters 4-5; Försäkringsavtalslagen (2005:104), Chapter 2 (disclosure)
+- **Home insurance application:**
+  - Clearly distinguish between standard hemförsäkring (named-perils coverage) and allriskförsäkring (accidental damage coverage)
+  - Disclose common exclusions that apply even under allriskförsäkring: gradual damage (smygande skador), wear and tear (slitage), damage from insects/pests, damage from poor maintenance
+  - Explain flood coverage limitations: distinguish between water damage from internal plumbing (typically covered) and flooding from natural watercourses or rising groundwater (often excluded or requiring separate coverage)
+  - For bostadsrätt: explain the boundary between the BRF's building insurance and the individual member's bostadsrättstillägg (the "ytskikt" principle — who covers what)
+  - Disclose natural disaster coverage limitations: storm damage thresholds, earthquake exclusions, and any sub-limits for specific perils
+  - Explain underinsurance consequences: if contents sum insured is inadequate, proportional settlement may apply
+- **Platform impact:** The platform must present coverage complexity disclosures as part of the quote-to-bind workflow. Product comparison views must clearly show what is covered and excluded for each product variant. The system must log that the customer was presented with coverage gap information and acknowledge understanding before binding. IPID documents for home products must address the key coverage distinctions described above.
+- **Evidence requirements:** Retain proof that coverage complexity disclosures were presented to the customer, including the specific product comparison shown, exclusion summaries presented, and the customer's acknowledgement timestamp.
+- **Phase:** Phase 2 — Home & Property
+
+### IDD-013: Cross-selling Governance — Home
+
+- **Description:** Home insurance is frequently bundled with complementary products including reseförsäkring (travel insurance), ID-skydd (identity theft protection), and tilläggsförsäkringar (supplementary coverage). The distributor must comply with cross-selling rules by presenting each product as separately available, providing individual pricing, and assessing whether the bundled package meets the customer's demands and needs. Cross-selling governance must prevent mis-selling of unnecessary add-on products.
+- **Legal basis:** IDD Article 24; Lag om försäkringsdistribution (2018:1219), Chapter 4, Section 7; FFFS 2018:10, Chapter 7; EU Commission Delegated Regulation 2017/2359, Article 13
+- **Home insurance application:**
+  - Common home insurance bundles include: hemförsäkring + reseförsäkring, hemförsäkring + ID-skydd, hemförsäkring + allriskförsäkring + ID-skydd
+  - Each component must be offered as separately purchasable where technically feasible (travel insurance and ID-skydd can be purchased independently; allriskförsäkring requires base hemförsäkring)
+  - Individual pricing must be disclosed for each component in the bundle, including any discount applied for purchasing the bundle
+  - The demands-and-needs assessment (IDD-011) must inform the bundle recommendation — do not recommend travel insurance to a customer who states they do not travel, or ID-skydd without explaining its relevance
+  - For BRF policyholders: cross-selling of bostadsrättstillägg alongside base hemförsäkring must clearly explain that the supplement covers interior fittings not covered by the BRF's building insurance
+  - Product governance (IDD-004) must include monitoring of bundle attachment rates and customer complaints related to bundled products
+- **Platform impact:** The quote workflow must present bundle components with individual pricing and clear descriptions. The system must allow customers to select or deselect individual add-on products within a bundle. Bundle recommendations must be linked to the demands-and-needs assessment. The platform must track bundle attachment rates and unbundling requests for product governance reviews. Cross-selling disclosures must be logged.
+- **Evidence requirements:** Retain the bundle composition presented to each customer, individual component pricing, the customer's selection/deselection of components, and the link between the recommendation and the demands-and-needs assessment. Bundle attachment rate reports must be available for product governance reviews.
+- **Phase:** Phase 2 — Home & Property
+
 ## Swedish Implementation Notes
 
 ### Transposition into Swedish Law
@@ -210,25 +259,30 @@ Multiple requirements may apply to a single user story. Always list all applicab
 
 ### IDD to FSA Cross-references
 
-| IDD ID  | Related FSA IDs  | Relationship                                                                         |
-| ------- | ---------------- | ------------------------------------------------------------------------------------ |
-| IDD-001 | FSA-004, FSA-012 | Demands-and-needs assessment supports fair treatment and pre-contractual disclosure  |
-| IDD-002 | FSA-012          | IPID provision is part of the broader pre-contractual disclosure obligation          |
-| IDD-003 | FSA-012          | Pre-contractual information duties overlap with FSA disclosure requirements          |
-| IDD-004 | FSA-005          | POG requirements align with FSA product governance obligations                       |
-| IDD-005 | FSA-004          | Distribution status disclosure supports fair treatment principles                    |
-| IDD-006 | FSA-004, FSA-012 | Advice requirements ensure fair treatment and adequate disclosure                    |
-| IDD-007 | FSA-004          | Cross-selling transparency supports fair treatment of customers                      |
-| IDD-008 | FSA-014          | Distribution record keeping aligns with FSA record retention requirements            |
-| IDD-009 | —                | Professional competence is an IDD-specific requirement with no direct FSA equivalent |
-| IDD-010 | FSA-011          | Distribution complaints handling complements the general FSA complaints procedure    |
+| IDD ID  | Related FSA IDs  | Relationship                                                                                      |
+| ------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| IDD-001 | FSA-004, FSA-012 | Demands-and-needs assessment supports fair treatment and pre-contractual disclosure               |
+| IDD-002 | FSA-012          | IPID provision is part of the broader pre-contractual disclosure obligation                       |
+| IDD-003 | FSA-012          | Pre-contractual information duties overlap with FSA disclosure requirements                       |
+| IDD-004 | FSA-005          | POG requirements align with FSA product governance obligations                                    |
+| IDD-005 | FSA-004          | Distribution status disclosure supports fair treatment principles                                 |
+| IDD-006 | FSA-004, FSA-012 | Advice requirements ensure fair treatment and adequate disclosure                                 |
+| IDD-007 | FSA-004          | Cross-selling transparency supports fair treatment of customers                                   |
+| IDD-008 | FSA-014          | Distribution record keeping aligns with FSA record retention requirements                         |
+| IDD-009 | —                | Professional competence is an IDD-specific requirement with no direct FSA equivalent              |
+| IDD-010 | FSA-011          | Distribution complaints handling complements the general FSA complaints procedure                 |
+| IDD-011 | FSA-004, FSA-015 | Home demands-and-needs assessment supports fair treatment and product suitability _(Phase 2)_     |
+| IDD-012 | FSA-004, FSA-012 | Product complexity disclosure supports fair treatment and pre-contractual information _(Phase 2)_ |
+| IDD-013 | FSA-004, FSA-015 | Cross-selling governance ensures fair treatment in bundled home products _(Phase 2)_              |
 
 ### IDD to GDPR Cross-references
 
-| IDD ID  | Related GDPR IDs | Relationship                                                                                  |
-| ------- | ---------------- | --------------------------------------------------------------------------------------------- |
-| IDD-001 | GDPR-001         | Demands-and-needs data collection must comply with data minimization and consent requirements |
-| IDD-002 | —                | IPID is a standardized document with no personal data processing implications                 |
-| IDD-003 | —                | Pre-contractual information is about the distributor, not personal data                       |
-| IDD-004 | GDPR-005         | Product review data (complaints, cancellations) may involve aggregated personal data          |
-| IDD-008 | GDPR-002         | Distribution record retention must comply with GDPR retention principles                      |
+| IDD ID  | Related GDPR IDs | Relationship                                                                                       |
+| ------- | ---------------- | -------------------------------------------------------------------------------------------------- |
+| IDD-001 | GDPR-001         | Demands-and-needs data collection must comply with data minimization and consent requirements      |
+| IDD-002 | —                | IPID is a standardized document with no personal data processing implications                      |
+| IDD-003 | —                | Pre-contractual information is about the distributor, not personal data                            |
+| IDD-004 | GDPR-005         | Product review data (complaints, cancellations) may involve aggregated personal data               |
+| IDD-008 | GDPR-002         | Distribution record retention must comply with GDPR retention principles                           |
+| IDD-011 | GDPR-007         | Home demands-and-needs data collection must comply with property data processing rules _(Phase 2)_ |
+| IDD-013 | GDPR-007         | Cross-selling involves property data collection subject to GDPR-007 processing rules _(Phase 2)_   |

--- a/versioned_docs/version-phase-1/regulatory/fsa-requirements.md
+++ b/versioned_docs/version-phase-1/regulatory/fsa-requirements.md
@@ -10,31 +10,37 @@ Regulatory requirements from **Finansinspektionen** (Swedish Financial Superviso
 
 The following Swedish laws and EU directives form the legal basis for FSA regulatory obligations relevant to this platform:
 
-| Law / Directive          | Swedish Name                        | Scope                                                       |
-| ------------------------ | ----------------------------------- | ----------------------------------------------------------- |
-| Insurance Business Act   | Försäkringsrörelselagen (2010:2043) | Authorization, governance, capital requirements, solvency   |
-| Motor Traffic Damage Act | Trafikskadelagen (1975:1410)        | Mandatory trafikförsäkring, liability rules, TFF membership |
-| Insurance Contracts Act  | Försäkringsavtalslagen (2005:104)   | Consumer insurance contract rules, disclosure, cancellation |
-| EU Solvency II Directive | Direktiv 2009/138/EG                | Capital adequacy, risk management, supervisory reporting    |
+| Law / Directive           | Swedish Name                        | Scope                                                                |
+| ------------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| Insurance Business Act    | Försäkringsrörelselagen (2010:2043) | Authorization, governance, capital requirements, solvency            |
+| Motor Traffic Damage Act  | Trafikskadelagen (1975:1410)        | Mandatory trafikförsäkring, liability rules, TFF membership          |
+| Insurance Contracts Act   | Försäkringsavtalslagen (2005:104)   | Consumer insurance contract rules, disclosure, cancellation          |
+| EU Solvency II Directive  | Direktiv 2009/138/EG                | Capital adequacy, risk management, supervisory reporting             |
+| Housing Cooperative Act   | Bostadsrättslagen (1991:614)        | BRF governance, building insurance obligations (Phase 2)             |
+| Planning and Building Act | Plan- och bygglagen (2010:900)      | Building standards, property valuation, construction rules (Phase 2) |
 
 ## Requirement Summary
 
-| ID                                                      | Area                | Short Description                                   |
-| ------------------------------------------------------- | ------------------- | --------------------------------------------------- |
-| [FSA-001](#fsa-001-insurance-company-authorization)     | Authorization       | Insurance company must be authorized by FSA         |
-| [FSA-002](#fsa-002-minimum-start-up-capital)            | Capital             | EUR 4M minimum start-up capital for motor insurance |
-| [FSA-003](#fsa-003-solvency-ii-compliance)              | Solvency            | Solvency II capital adequacy and risk management    |
-| [FSA-004](#fsa-004-consumer-protection--fair-treatment) | Consumer Protection | Fair treatment and clear policy terms               |
-| [FSA-005](#fsa-005-product-governance)                  | Product Governance  | Target market identification and product monitoring |
-| [FSA-006](#fsa-006-supervisory-reporting)               | Reporting           | Regular financial and supervisory reporting to FSA  |
-| [FSA-007](#fsa-007-mandatory-trafikförsäkring)          | Trafikförsäkring    | Mandatory insurance for all registered vehicles     |
-| [FSA-008](#fsa-008-tff-membership)                      | TFF Membership      | Membership in Trafikförsäkringsföreningen           |
-| [FSA-009](#fsa-009-transportstyrelsen-notification)     | Transportstyrelsen  | Policy changes reported to Transport Agency         |
-| [FSA-010](#fsa-010-fair-and-timely-claims-settlement)   | Claims Handling     | Fair and timely claims settlement                   |
-| [FSA-011](#fsa-011-complaints-handling-procedure)       | Complaints          | Complaints handling procedure                       |
-| [FSA-012](#fsa-012-insurance-contract-disclosure)       | Disclosure          | Pre-contractual and contractual information duties  |
-| [FSA-013](#fsa-013-cancellation-and-cooling-off-rights) | Cancellation        | Consumer cancellation and ångerrätt (cooling-off)   |
-| [FSA-014](#fsa-014-record-keeping)                      | Record Keeping      | Retention of policy and claims records              |
+| ID                                                      | Area                           | Short Description                                                            |
+| ------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------- |
+| [FSA-001](#fsa-001-insurance-company-authorization)     | Authorization                  | Insurance company must be authorized by FSA                                  |
+| [FSA-002](#fsa-002-minimum-start-up-capital)            | Capital                        | EUR 4M minimum start-up capital for motor insurance                          |
+| [FSA-003](#fsa-003-solvency-ii-compliance)              | Solvency                       | Solvency II capital adequacy and risk management                             |
+| [FSA-004](#fsa-004-consumer-protection--fair-treatment) | Consumer Protection            | Fair treatment and clear policy terms                                        |
+| [FSA-005](#fsa-005-product-governance)                  | Product Governance             | Target market identification and product monitoring                          |
+| [FSA-006](#fsa-006-supervisory-reporting)               | Reporting                      | Regular financial and supervisory reporting to FSA                           |
+| [FSA-007](#fsa-007-mandatory-trafikförsäkring)          | Trafikförsäkring               | Mandatory insurance for all registered vehicles                              |
+| [FSA-008](#fsa-008-tff-membership)                      | TFF Membership                 | Membership in Trafikförsäkringsföreningen                                    |
+| [FSA-009](#fsa-009-transportstyrelsen-notification)     | Transportstyrelsen             | Policy changes reported to Transport Agency                                  |
+| [FSA-010](#fsa-010-fair-and-timely-claims-settlement)   | Claims Handling                | Fair and timely claims settlement                                            |
+| [FSA-011](#fsa-011-complaints-handling-procedure)       | Complaints                     | Complaints handling procedure                                                |
+| [FSA-012](#fsa-012-insurance-contract-disclosure)       | Disclosure                     | Pre-contractual and contractual information duties                           |
+| [FSA-013](#fsa-013-cancellation-and-cooling-off-rights) | Cancellation                   | Consumer cancellation and ångerrätt (cooling-off)                            |
+| [FSA-014](#fsa-014-record-keeping)                      | Record Keeping                 | Retention of policy and claims records                                       |
+| [FSA-015](#fsa-015-consumer-protection--home)           | Consumer Protection — Home     | Product suitability for hemförsäkring; mandatory coverage levels _(Phase 2)_ |
+| [FSA-016](#fsa-016-building-valuation)                  | Building Valuation             | Adequate building sum insured; underinsurance rules _(Phase 2)_              |
+| [FSA-017](#fsa-017-claims-handling--water-damage)       | Claims Handling — Water Damage | Obligations for coordinating restoration (saneringsfirma) _(Phase 2)_        |
+| [FSA-018](#fsa-018-natural-disaster-reserves)           | Natural Disaster Reserves      | Reserve requirements for storm/flood/climate events _(Phase 2)_              |
 
 ## Detailed Requirements
 
@@ -135,6 +141,38 @@ The following Swedish laws and EU directives form the legal basis for FSA regula
 - **Legal basis:** Försäkringsrörelselagen (2010:2043), Chapter 10; Bokföringslagen (1999:1078)
 - **Impact on platform:** The platform must implement data retention policies. Policy records, claims files, and customer correspondence must be retained for a minimum of 10 years after the contract ends. Archival and retrieval mechanisms must be built into the system.
 - **Compliance verification:** Data retention policies are configured in the platform. Automated archival processes are operational. Retrieval from archive is tested and documented. No records are deleted before the retention period expires.
+
+### FSA-015: Consumer Protection — Home
+
+- **Description:** Insurance companies offering hemförsäkring (home insurance) must ensure product suitability for the customer's housing situation. Mandatory coverage levels for hemförsäkring include personal property (lösöre), liability protection (ansvarsförsäkring), legal expenses (rättsskydd), and assault coverage (överfallsskydd). The insurer must clearly communicate what is and is not covered, particularly the distinction between bostadsrättstillägg (housing cooperative supplement), villaförsäkring (detached house insurance), and hyresrättsförsäkring (rental apartment insurance).
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapters 2 and 3; FSA General Guidelines (FFFS 2015:9); Bostadsrättslagen (1991:614) for BRF-related obligations
+- **Impact on platform:** The platform must enforce product configuration rules that ensure all hemförsäkring products include mandatory coverage components. The quote workflow must determine the customer's housing type (villa, bostadsrätt, hyresrätt) and present appropriate product variants. Coverage limits must be validated against minimum statutory levels.
+- **Compliance verification:** Product configuration includes all mandatory coverage components. Quote workflow captures housing type and applies the correct product variant. Coverage limit validation rules are enforced. Customer-facing documents clearly distinguish between housing types and their respective coverage.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-016: Building Valuation
+
+- **Description:** For villaförsäkring (detached house insurance) and BRF building insurance, the insurer must ensure adequate building sum insured (fullvärdesförsäkring or förstadagsbelopp) to prevent underinsurance (underförsäkring). The insurer must provide tools or guidance for the customer to determine the correct rebuilding cost (återuppbyggnadskostnad). Where the building sum insured is inadequate, the insurer must inform the customer of the risk of proportional claims settlement.
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapter 6, Section 2 (proportional settlement); FSA General Guidelines on property insurance; Plan- och bygglagen (2010:900) for building standards affecting valuation
+- **Impact on platform:** The platform must include a building valuation tool or integration (e.g., Lantmäteriet property data, byggkostnadskalkyl) that helps determine the appropriate sum insured. The quote workflow must flag potential underinsurance when the customer-specified sum insured falls below the estimated rebuilding cost. Renewal workflows must prompt the customer to review the sum insured, accounting for building cost inflation (byggkostnadsindex).
+- **Compliance verification:** Building valuation tool produces estimates consistent with market rebuilding costs. Underinsurance warnings are triggered and documented when sum insured is below threshold. Renewal notices include building cost inflation adjustments. Proportional settlement calculations are correctly applied when underinsurance exists.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-017: Claims Handling — Water Damage
+
+- **Description:** Water damage (vattenskada) is the most common and costly home insurance claim category in Sweden. The insurer has specific obligations to coordinate with restoration companies (saneringsfirmor), plumbers (rörmokare), and building inspectors to ensure timely and adequate remediation. The insurer must ensure that policyholders are informed of their right to choose their own contractor while also maintaining quality standards through approved supplier networks.
+- **Legal basis:** Försäkringsavtalslagen (2005:104), Chapter 7; FSA General Guidelines on claims handling; Branschregler for vattenskadesanering (industry guidelines)
+- **Impact on platform:** The claims module must support water damage-specific workflows including: initial damage assessment, moisture measurement scheduling, restoration company assignment (from approved supplier network or customer-chosen contractor), progress tracking through drying and restoration phases, and final inspection sign-off. The system must track response times from first notification of loss (FNOL) through restoration completion.
+- **Compliance verification:** Water damage claims workflows include all required phases (assessment, sanering, restoration, inspection). Response time SLAs are configured and monitored. Policyholder contractor choice is documented. Approved supplier network is maintained and accessible. Restoration quality standards are tracked.
+- **Phase:** Phase 2 — Home & Property
+
+### FSA-018: Natural Disaster Reserves
+
+- **Description:** Insurance companies offering property insurance must maintain adequate technical reserves for natural disaster events (naturkatastrofreserv), including storm (storm), flooding (översvämning), and climate-related events. FSA requires insurers to model catastrophe risk exposure and hold sufficient capital buffers. This is particularly relevant given increasing climate-related claims frequency in Sweden, including cloudbursts (skyfall), rising sea levels, and extreme weather events.
+- **Legal basis:** Försäkringsrörelselagen (2010:2043), Chapter 4 (technical provisions); EU Solvency II Directive, Article 101 (SCR for natural catastrophe risk); FSA regulations (FFFS 2019:23) for reporting natural catastrophe exposure
+- **Impact on platform:** The platform must capture and categorize property claims by peril type (storm, flood, fire, water damage, etc.) to support catastrophe risk modeling. Geospatial data (property location, flood zone, proximity to water bodies) must be stored for risk assessment. The platform must support aggregate exposure reporting by geographic area and peril type for actuarial and regulatory purposes.
+- **Compliance verification:** Claims categorization includes peril type taxonomy. Property records include geospatial risk data. Aggregate exposure reports can be generated by region and peril type. Catastrophe reserve calculations are supported by accurate platform data. Reporting to FSA on natural catastrophe exposure is facilitated.
+- **Phase:** Phase 2 — Home & Property
 
 ## Cross-reference Guide
 

--- a/versioned_docs/version-phase-1/regulatory/gdpr-mapping.md
+++ b/versioned_docs/version-phase-1/regulatory/gdpr-mapping.md
@@ -4,20 +4,22 @@ sidebar_position: 2
 
 # GDPR Data Mapping
 
-GDPR compliance mapping for personal data handling within the TryggFörsäkring motor insurance platform. Each data processing activity has a unique ID (GDPR-001, GDPR-002, etc.) used for cross-referencing from user stories and use cases.
+GDPR compliance mapping for personal data handling within the TryggFörsäkring insurance platform. Each data processing activity has a unique ID (GDPR-001, GDPR-002, etc.) used for cross-referencing from user stories and use cases. GDPR-001 through GDPR-006 cover motor insurance; GDPR-007 through GDPR-009 cover home & property insurance (Phase 2).
 
 ## Key Legislation
 
 The following EU regulations and Swedish laws govern personal data processing in the insurance context:
 
-| Regulation / Law                   | Swedish Name                      | Scope                                                         |
-| ---------------------------------- | --------------------------------- | ------------------------------------------------------------- |
-| General Data Protection Regulation | EU Förordning 2016/679 (GDPR)     | Personal data processing, data subject rights, accountability |
-| Swedish Data Protection Act        | Dataskyddslagen (2018:218)        | Supplements GDPR with Swedish-specific provisions             |
-| Swedish Data Protection Ordinance  | Dataskyddsförordningen (2018:219) | Implementing provisions for Dataskyddslagen                   |
-| Motor Traffic Damage Act           | Trafikskadelagen (1975:1410)      | Legal obligation basis for claims data processing             |
-| Accounting Act                     | Bokföringslagen (1999:1078)       | Retention periods for financial records                       |
-| Insurance Contracts Act            | Försäkringsavtalslagen (2005:104) | Contract performance basis for policy data                    |
+| Regulation / Law                   | Swedish Name                       | Scope                                                         |
+| ---------------------------------- | ---------------------------------- | ------------------------------------------------------------- |
+| General Data Protection Regulation | EU Förordning 2016/679 (GDPR)      | Personal data processing, data subject rights, accountability |
+| Swedish Data Protection Act        | Dataskyddslagen (2018:218)         | Supplements GDPR with Swedish-specific provisions             |
+| Swedish Data Protection Ordinance  | Dataskyddsförordningen (2018:219)  | Implementing provisions for Dataskyddslagen                   |
+| Motor Traffic Damage Act           | Trafikskadelagen (1975:1410)       | Legal obligation basis for claims data processing             |
+| Accounting Act                     | Bokföringslagen (1999:1078)        | Retention periods for financial records                       |
+| Insurance Contracts Act            | Försäkringsavtalslagen (2005:104)  | Contract performance basis for policy data                    |
+| Housing Cooperative Act            | Bostadsrättslagen (1991:614)       | BRF governance, building insurance obligations (Phase 2)      |
+| Real Property Register Act         | Fastighetsregisterlagen (2000:224) | Property data from Lantmäteriet (Phase 2)                     |
 
 **Supervisory Authority:** Integritetsskyddsmyndigheten (IMY) is the Swedish supervisory authority for data protection.
 
@@ -33,6 +35,17 @@ The following EU regulations and Swedish laws govern personal data processing in
 | Payment         | Bank account, payment history                                | (b) Contract performance                        | 7 years (Bokföringslagen)     |
 | Location        | Parking address, accident location                           | (b) Contract performance                        | Duration of policy            |
 | Communication   | Emails, call recordings, chat logs                           | (f) Legitimate interest                         | 3 years                       |
+
+### Personal Data Categories in Home & Property Insurance (Phase 2)
+
+| Category       | Data Elements                                                      | Legal Basis (Article 6(1)) | Retention Period              |
+| -------------- | ------------------------------------------------------------------ | -------------------------- | ----------------------------- |
+| Property       | Address, property type (villa/BRF/hyresrätt), building specs, area | (b) Contract performance   | Duration of policy + 10 years |
+| BRF membership | BRF name, org. number, board member names, membership status       | (b) Contract performance   | Duration of policy + 10 years |
+| Building       | Construction year, materials, rebuilding cost, renovations         | (b) Contract performance   | Duration of policy + 10 years |
+| Contents       | Sum insured, high-value items registry, home inventory             | (b) Contract performance   | Duration of policy + 10 years |
+| Restoration    | Damage reports, contractor details, restoration progress           | (b) Contract performance   | 10 years (limitation period)  |
+| Geospatial     | Flood zone, proximity to water, terrain data, climate risk zone    | (f) Legitimate interest    | Duration of policy            |
 
 ### Swedish-Specific Data Considerations
 
@@ -101,6 +114,39 @@ The following EU regulations and Swedish laws govern personal data processing in
 - **Data minimization:** Access full claims details only for flagged cases. Automated screening should use anonymized or pseudonymized data where possible. Limit access to fraud investigation staff.
 - **Retention:** Fraud investigation records retained for 10 years from investigation closure. Cleared cases: flag removed but investigation log retained.
 - **Recipients:** Internal fraud investigation team, GSR (industry fraud register), police (when criminal referral is made), reinsurers (for material fraud cases).
+
+### GDPR-007: Property Data Processing
+
+- **Purpose:** Collect and process property-related personal data for home & property insurance underwriting, policy administration, and claims handling. This includes address, property details, BRF membership, building specifications, and rebuilding cost estimates.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract; Article 6(1)(f) — legitimate interest for property risk assessment using publicly available data.
+- **Data categories:** Identity, property, building, BRF membership, geospatial.
+- **Data sources:** Customer input, Lantmäteriet (fastighetsregister — property registry), BRF board (building information), municipality (building permits and zoning), building valuation tools.
+- **Data minimization:** Collect only property data required for underwriting and risk assessment. Do not collect interior details beyond what is relevant to coverage (e.g., kitchen renovation status is relevant for rebuilding cost but room-by-room photographs are not). Geospatial risk data should be aggregated at zone level rather than exact-coordinate level where possible.
+- **Retention:** Policy-related property data retained for duration of policy + 10 years (FSA-014). Unconverted quotes with property data retained for 12 months, then deleted. Geospatial risk assessments retained for duration of policy.
+- **Recipients:** Internal underwriting systems, Lantmäteriet (property verification), building valuation providers (data processor agreements required), reinsurers (for catastrophe exposure assessment).
+- **Phase:** Phase 2 — Home & Property
+
+### GDPR-008: Restoration Company Data Sharing
+
+- **Purpose:** Share policyholder personal data with restoration companies (saneringsfirmor), contractors, and building inspectors during the claims handling process for home & property insurance. This is necessary to coordinate damage assessment, drying, restoration, and repair work.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract (claims settlement); Article 6(1)(f) — legitimate interest in efficient claims resolution.
+- **Data categories:** Identity (policyholder name, contact details, address), property (damage location, building access details), claims (damage description, assessment reports, restoration scope).
+- **Data sources:** Internal claims systems, policyholder (damage notification), property inspector reports.
+- **Data minimization:** Share only the data necessary for the specific restoration task. Restoration companies receive: policyholder name and contact details (for site access coordination), property address and access instructions, damage description and scope of work. They do not receive: personnummer, policy financial details, claims history, or unrelated personal data. Each contractor receives only the information relevant to their specific role.
+- **Retention:** Data sharing logs retained for 10 years from claim closure. Contractor copies of personal data must be returned or deleted after the restoration engagement ends, as specified in the data processing agreement.
+- **Recipients:** Approved restoration companies (saneringsfirmor), plumbers, electricians, building inspectors, moisture measurement specialists. All recipients must have valid data processing agreements (Article 28).
+- **Phase:** Phase 2 — Home & Property
+
+### GDPR-009: BRF Board Data
+
+- **Purpose:** Process personal data of BRF (bostadsrättsförening) board members in connection with building insurance policies for housing cooperatives. BRF board members act as representatives of the cooperative for insurance matters including policy administration, building maintenance coordination, and claims reporting.
+- **Legal basis:** Article 6(1)(b) — necessary for performance of the insurance contract (BRF is the policyholder); Article 6(1)(f) — legitimate interest for verifying authority to act on behalf of the BRF.
+- **Data categories:** Identity (board member names, roles, contact details), BRF membership (organization number, board composition, mandate periods).
+- **Data sources:** BRF board (direct input), Bolagsverket (organization register for BRF registration verification), Lantmäteriet (property ownership records).
+- **Data minimization:** Collect only board member data necessary for insurance administration: name, role (ordförande, ledamot, suppleant), contact details, and mandate period. Do not collect personnummer of board members unless required for specific verification. Limit processing to board members who are authorized signatories or designated insurance contacts.
+- **Retention:** Board member data retained for duration of the BRF policy + 10 years (FSA-014). When board composition changes, historical board data is archived but retained for the full retention period to support claims traceability.
+- **Recipients:** Internal policy administration systems, building inspectors (for coordinating property inspections), Bolagsverket (for organization verification).
+- **Phase:** Phase 2 — Home & Property
 
 ## Data Subject Rights
 
@@ -186,11 +232,14 @@ Multiple requirements may apply to a single user story. Always list all applicab
 
 ### GDPR to FSA Cross-references
 
-| GDPR ID  | Related FSA IDs           | Relationship                                                                                        |
-| -------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
-| GDPR-001 | FSA-012                   | Quote generation requires both data collection consent and pre-contractual disclosure               |
-| GDPR-002 | FSA-014                   | Policy data retention aligns with FSA record-keeping requirements                                   |
-| GDPR-003 | FSA-010                   | Claims processing must satisfy both GDPR and fair settlement requirements                           |
-| GDPR-004 | FSA-007, FSA-008, FSA-009 | Transportstyrelsen and TFF reporting is both a GDPR legal obligation and FSA regulatory requirement |
-| GDPR-005 | FSA-004                   | Marketing must respect both GDPR consent rules and FSA fair treatment principles                    |
-| GDPR-006 | FSA-010                   | Fraud detection must balance data protection with fair claims handling                              |
+| GDPR ID  | Related FSA IDs           | Relationship                                                                                                 |
+| -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| GDPR-001 | FSA-012                   | Quote generation requires both data collection consent and pre-contractual disclosure                        |
+| GDPR-002 | FSA-014                   | Policy data retention aligns with FSA record-keeping requirements                                            |
+| GDPR-003 | FSA-010                   | Claims processing must satisfy both GDPR and fair settlement requirements                                    |
+| GDPR-004 | FSA-007, FSA-008, FSA-009 | Transportstyrelsen and TFF reporting is both a GDPR legal obligation and FSA regulatory requirement          |
+| GDPR-005 | FSA-004                   | Marketing must respect both GDPR consent rules and FSA fair treatment principles                             |
+| GDPR-006 | FSA-010                   | Fraud detection must balance data protection with fair claims handling                                       |
+| GDPR-007 | FSA-015, FSA-016          | Property data processing supports product suitability and building valuation requirements _(Phase 2)_        |
+| GDPR-008 | FSA-017                   | Restoration data sharing must comply with both GDPR and water damage claims handling obligations _(Phase 2)_ |
+| GDPR-009 | FSA-015                   | BRF board data processing supports home insurance policy administration _(Phase 2)_                          |

--- a/versioned_docs/version-phase-1/regulatory/idd-compliance.md
+++ b/versioned_docs/version-phase-1/regulatory/idd-compliance.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # IDD Compliance
 
-Insurance Distribution Directive (IDD) compliance requirements for the TryggFörsäkring motor insurance platform. The IDD governs how insurance products are sold and distributed, mandating demands-and-needs assessments, pre-contractual information, and product governance. Each requirement has a unique ID (IDD-001, IDD-002, etc.) used for cross-referencing from user stories and use cases.
+Insurance Distribution Directive (IDD) compliance requirements for the TryggFörsäkring insurance platform. The IDD governs how insurance products are sold and distributed, mandating demands-and-needs assessments, pre-contractual information, and product governance. Each requirement has a unique ID (IDD-001, IDD-002, etc.) used for cross-referencing from user stories and use cases. IDD-001 through IDD-010 cover motor insurance; IDD-011 through IDD-013 cover home & property insurance (Phase 2).
 
 ## Key Legislation
 
@@ -24,18 +24,21 @@ The following EU directives and Swedish laws form the legal basis for IDD compli
 
 ## Requirement Summary
 
-| ID                                                              | Area                        | Short Description                                      |
-| --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------ |
-| [IDD-001](#idd-001-demands-and-needs-assessment)                | Demands and Needs           | Assess customer needs before recommending a product    |
-| [IDD-002](#idd-002-insurance-product-information-document-ipid) | IPID                        | Standardized product information document              |
-| [IDD-003](#idd-003-pre-contractual-information)                 | Pre-contractual Information | Identity, complaints, and conflict of interest details |
-| [IDD-004](#idd-004-product-oversight-and-governance)            | Product Governance          | Target market, monitoring, and distribution strategy   |
-| [IDD-005](#idd-005-disclosure-of-distribution-status)           | Disclosure                  | Registration status and remuneration transparency      |
-| [IDD-006](#idd-006-advice-and-recommendation-requirements)      | Advice                      | Personalized recommendation obligations                |
-| [IDD-007](#idd-007-cross-selling-requirements)                  | Cross-selling               | Rules for bundled and optional add-on products         |
-| [IDD-008](#idd-008-record-keeping-for-distribution)             | Record Keeping              | Retention of distribution and advisory records         |
-| [IDD-009](#idd-009-professional-competence-and-training)        | Competence                  | Staff knowledge and ongoing training requirements      |
-| [IDD-010](#idd-010-complaints-handling-for-distribution)        | Complaints                  | Distribution-specific complaints procedures            |
+| ID                                                              | Area                            | Short Description                                                      |
+| --------------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------- |
+| [IDD-001](#idd-001-demands-and-needs-assessment)                | Demands and Needs               | Assess customer needs before recommending a product                    |
+| [IDD-002](#idd-002-insurance-product-information-document-ipid) | IPID                            | Standardized product information document                              |
+| [IDD-003](#idd-003-pre-contractual-information)                 | Pre-contractual Information     | Identity, complaints, and conflict of interest details                 |
+| [IDD-004](#idd-004-product-oversight-and-governance)            | Product Governance              | Target market, monitoring, and distribution strategy                   |
+| [IDD-005](#idd-005-disclosure-of-distribution-status)           | Disclosure                      | Registration status and remuneration transparency                      |
+| [IDD-006](#idd-006-advice-and-recommendation-requirements)      | Advice                          | Personalized recommendation obligations                                |
+| [IDD-007](#idd-007-cross-selling-requirements)                  | Cross-selling                   | Rules for bundled and optional add-on products                         |
+| [IDD-008](#idd-008-record-keeping-for-distribution)             | Record Keeping                  | Retention of distribution and advisory records                         |
+| [IDD-009](#idd-009-professional-competence-and-training)        | Competence                      | Staff knowledge and ongoing training requirements                      |
+| [IDD-010](#idd-010-complaints-handling-for-distribution)        | Complaints                      | Distribution-specific complaints procedures                            |
+| [IDD-011](#idd-011-demands-and-needs--home)                     | Demands and Needs — Home        | Needs assessment for home products: BRF vs villa vs rental _(Phase 2)_ |
+| [IDD-012](#idd-012-product-complexity-disclosure)               | Product Complexity Disclosure   | Explaining coverage gaps (allrisk, flood exclusions) _(Phase 2)_       |
+| [IDD-013](#idd-013-cross-selling-governance--home)              | Cross-selling Governance — Home | Rules for bundling home + travel + ID-skydd _(Phase 2)_                |
 
 ## Detailed Requirements
 
@@ -172,6 +175,52 @@ The following EU directives and Swedish laws form the legal basis for IDD compli
 - **Platform impact:** The complaints module must support categorization of complaints as distribution-related. The system must track complaint source (distribution channel), link complaints to the relevant distribution record, and generate reports on distribution complaint volumes and outcomes.
 - **Evidence requirements:** Retain complaint records including the nature of the complaint, the distribution channel involved, investigation findings, resolution outcome, and time to resolution. Aggregate complaint data must be available for POG product reviews (IDD-004) and FSA reporting (FSA-011).
 
+### IDD-011: Demands and Needs — Home
+
+- **Description:** Before recommending or concluding a home & property insurance contract, the distributor must perform a demands-and-needs assessment (krav- och behovsanalys) specific to the customer's housing situation. The assessment must determine the customer's housing type (villa, bostadsrätt, or hyresrätt), identify the appropriate product variant, and evaluate the need for supplementary coverage. Home insurance presents distinct assessment challenges compared to motor insurance because the product structure varies significantly by housing type.
+- **Legal basis:** IDD Article 20; Lag om försäkringsdistribution (2018:1219), Chapter 4, Section 3; FFFS 2018:10, Chapter 4
+- **Home insurance application:**
+  - Determine housing type: villa (detached house), bostadsrätt (housing cooperative apartment), or hyresrätt (rental apartment)
+  - For villa: assess building insurance needs (rebuilding cost, building age, construction materials), contents coverage level, and liability coverage
+  - For bostadsrätt: assess need for bostadsrättstillägg (BRF supplement covering interior fittings and improvements), contents coverage level, and whether the BRF's collective building insurance is adequate
+  - For hyresrätt: assess contents and liability coverage needs (no building component)
+  - Evaluate need for supplementary coverage: allriskförsäkring (accidental damage), ID-skydd (identity theft protection), bostadsrättstillägg, trädgårdsförsäkring (garden insurance for villa)
+  - Assess appropriate deductible level based on the customer's financial situation
+  - Document the assessment and the rationale for the recommendation
+- **Platform impact:** The quote workflow must include a structured demands-and-needs assessment that branches based on housing type. The assessment must capture the customer's housing situation, ownership status, property details, and coverage preferences before presenting product options. The platform must store the assessment responses, the recommended product configuration, and the rationale linking the recommendation to the customer's stated needs.
+- **Evidence requirements:** Retain the completed assessment form, the housing type determination, the recommended product variant, the rationale for the recommendation, and the customer's acceptance or deviation from the recommendation. Records must be retained for the duration of the customer relationship plus 10 years.
+- **Phase:** Phase 2 — Home & Property
+
+### IDD-012: Product Complexity Disclosure
+
+- **Description:** Home & property insurance products contain significant complexity that must be disclosed to the customer before contract conclusion. Coverage gaps between standard hemförsäkring and allriskförsäkring must be clearly explained. Common exclusions (flood from natural watercourses, subsidence, gradual damage) must be highlighted because customers frequently misunderstand what their home insurance covers. The distributor must ensure the customer understands the distinction between covered perils and excluded events.
+- **Legal basis:** IDD Article 20; Lag om försäkringsdistribution (2018:1219), Chapter 4, Sections 3-4; FFFS 2018:10, Chapters 4-5; Försäkringsavtalslagen (2005:104), Chapter 2 (disclosure)
+- **Home insurance application:**
+  - Clearly distinguish between standard hemförsäkring (named-perils coverage) and allriskförsäkring (accidental damage coverage)
+  - Disclose common exclusions that apply even under allriskförsäkring: gradual damage (smygande skador), wear and tear (slitage), damage from insects/pests, damage from poor maintenance
+  - Explain flood coverage limitations: distinguish between water damage from internal plumbing (typically covered) and flooding from natural watercourses or rising groundwater (often excluded or requiring separate coverage)
+  - For bostadsrätt: explain the boundary between the BRF's building insurance and the individual member's bostadsrättstillägg (the "ytskikt" principle — who covers what)
+  - Disclose natural disaster coverage limitations: storm damage thresholds, earthquake exclusions, and any sub-limits for specific perils
+  - Explain underinsurance consequences: if contents sum insured is inadequate, proportional settlement may apply
+- **Platform impact:** The platform must present coverage complexity disclosures as part of the quote-to-bind workflow. Product comparison views must clearly show what is covered and excluded for each product variant. The system must log that the customer was presented with coverage gap information and acknowledge understanding before binding. IPID documents for home products must address the key coverage distinctions described above.
+- **Evidence requirements:** Retain proof that coverage complexity disclosures were presented to the customer, including the specific product comparison shown, exclusion summaries presented, and the customer's acknowledgement timestamp.
+- **Phase:** Phase 2 — Home & Property
+
+### IDD-013: Cross-selling Governance — Home
+
+- **Description:** Home insurance is frequently bundled with complementary products including reseförsäkring (travel insurance), ID-skydd (identity theft protection), and tilläggsförsäkringar (supplementary coverage). The distributor must comply with cross-selling rules by presenting each product as separately available, providing individual pricing, and assessing whether the bundled package meets the customer's demands and needs. Cross-selling governance must prevent mis-selling of unnecessary add-on products.
+- **Legal basis:** IDD Article 24; Lag om försäkringsdistribution (2018:1219), Chapter 4, Section 7; FFFS 2018:10, Chapter 7; EU Commission Delegated Regulation 2017/2359, Article 13
+- **Home insurance application:**
+  - Common home insurance bundles include: hemförsäkring + reseförsäkring, hemförsäkring + ID-skydd, hemförsäkring + allriskförsäkring + ID-skydd
+  - Each component must be offered as separately purchasable where technically feasible (travel insurance and ID-skydd can be purchased independently; allriskförsäkring requires base hemförsäkring)
+  - Individual pricing must be disclosed for each component in the bundle, including any discount applied for purchasing the bundle
+  - The demands-and-needs assessment (IDD-011) must inform the bundle recommendation — do not recommend travel insurance to a customer who states they do not travel, or ID-skydd without explaining its relevance
+  - For BRF policyholders: cross-selling of bostadsrättstillägg alongside base hemförsäkring must clearly explain that the supplement covers interior fittings not covered by the BRF's building insurance
+  - Product governance (IDD-004) must include monitoring of bundle attachment rates and customer complaints related to bundled products
+- **Platform impact:** The quote workflow must present bundle components with individual pricing and clear descriptions. The system must allow customers to select or deselect individual add-on products within a bundle. Bundle recommendations must be linked to the demands-and-needs assessment. The platform must track bundle attachment rates and unbundling requests for product governance reviews. Cross-selling disclosures must be logged.
+- **Evidence requirements:** Retain the bundle composition presented to each customer, individual component pricing, the customer's selection/deselection of components, and the link between the recommendation and the demands-and-needs assessment. Bundle attachment rate reports must be available for product governance reviews.
+- **Phase:** Phase 2 — Home & Property
+
 ## Swedish Implementation Notes
 
 ### Transposition into Swedish Law
@@ -210,25 +259,30 @@ Multiple requirements may apply to a single user story. Always list all applicab
 
 ### IDD to FSA Cross-references
 
-| IDD ID  | Related FSA IDs  | Relationship                                                                         |
-| ------- | ---------------- | ------------------------------------------------------------------------------------ |
-| IDD-001 | FSA-004, FSA-012 | Demands-and-needs assessment supports fair treatment and pre-contractual disclosure  |
-| IDD-002 | FSA-012          | IPID provision is part of the broader pre-contractual disclosure obligation          |
-| IDD-003 | FSA-012          | Pre-contractual information duties overlap with FSA disclosure requirements          |
-| IDD-004 | FSA-005          | POG requirements align with FSA product governance obligations                       |
-| IDD-005 | FSA-004          | Distribution status disclosure supports fair treatment principles                    |
-| IDD-006 | FSA-004, FSA-012 | Advice requirements ensure fair treatment and adequate disclosure                    |
-| IDD-007 | FSA-004          | Cross-selling transparency supports fair treatment of customers                      |
-| IDD-008 | FSA-014          | Distribution record keeping aligns with FSA record retention requirements            |
-| IDD-009 | —                | Professional competence is an IDD-specific requirement with no direct FSA equivalent |
-| IDD-010 | FSA-011          | Distribution complaints handling complements the general FSA complaints procedure    |
+| IDD ID  | Related FSA IDs  | Relationship                                                                                      |
+| ------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| IDD-001 | FSA-004, FSA-012 | Demands-and-needs assessment supports fair treatment and pre-contractual disclosure               |
+| IDD-002 | FSA-012          | IPID provision is part of the broader pre-contractual disclosure obligation                       |
+| IDD-003 | FSA-012          | Pre-contractual information duties overlap with FSA disclosure requirements                       |
+| IDD-004 | FSA-005          | POG requirements align with FSA product governance obligations                                    |
+| IDD-005 | FSA-004          | Distribution status disclosure supports fair treatment principles                                 |
+| IDD-006 | FSA-004, FSA-012 | Advice requirements ensure fair treatment and adequate disclosure                                 |
+| IDD-007 | FSA-004          | Cross-selling transparency supports fair treatment of customers                                   |
+| IDD-008 | FSA-014          | Distribution record keeping aligns with FSA record retention requirements                         |
+| IDD-009 | —                | Professional competence is an IDD-specific requirement with no direct FSA equivalent              |
+| IDD-010 | FSA-011          | Distribution complaints handling complements the general FSA complaints procedure                 |
+| IDD-011 | FSA-004, FSA-015 | Home demands-and-needs assessment supports fair treatment and product suitability _(Phase 2)_     |
+| IDD-012 | FSA-004, FSA-012 | Product complexity disclosure supports fair treatment and pre-contractual information _(Phase 2)_ |
+| IDD-013 | FSA-004, FSA-015 | Cross-selling governance ensures fair treatment in bundled home products _(Phase 2)_              |
 
 ### IDD to GDPR Cross-references
 
-| IDD ID  | Related GDPR IDs | Relationship                                                                                  |
-| ------- | ---------------- | --------------------------------------------------------------------------------------------- |
-| IDD-001 | GDPR-001         | Demands-and-needs data collection must comply with data minimization and consent requirements |
-| IDD-002 | —                | IPID is a standardized document with no personal data processing implications                 |
-| IDD-003 | —                | Pre-contractual information is about the distributor, not personal data                       |
-| IDD-004 | GDPR-005         | Product review data (complaints, cancellations) may involve aggregated personal data          |
-| IDD-008 | GDPR-002         | Distribution record retention must comply with GDPR retention principles                      |
+| IDD ID  | Related GDPR IDs | Relationship                                                                                       |
+| ------- | ---------------- | -------------------------------------------------------------------------------------------------- |
+| IDD-001 | GDPR-001         | Demands-and-needs data collection must comply with data minimization and consent requirements      |
+| IDD-002 | —                | IPID is a standardized document with no personal data processing implications                      |
+| IDD-003 | —                | Pre-contractual information is about the distributor, not personal data                            |
+| IDD-004 | GDPR-005         | Product review data (complaints, cancellations) may involve aggregated personal data               |
+| IDD-008 | GDPR-002         | Distribution record retention must comply with GDPR retention principles                           |
+| IDD-011 | GDPR-007         | Home demands-and-needs data collection must comply with property data processing rules _(Phase 2)_ |
+| IDD-013 | GDPR-007         | Cross-selling involves property data collection subject to GDPR-007 processing rules _(Phase 2)_   |


### PR DESCRIPTION
## Summary
- Added FSA-015 to FSA-018: home & property-specific FSA requirements covering consumer protection, building valuation, water damage claims handling, and natural disaster reserves
- Added GDPR-007 to GDPR-009: property data processing, restoration company data sharing, and BRF board data handling
- Added IDD-011 to IDD-013: home-specific demands-and-needs assessment, product complexity disclosure, and cross-selling governance

## Changes
- `versioned_docs/version-phase-1/regulatory/fsa-requirements.md` — 4 new requirements (FSA-015–018), updated summary table, added home-related legislation
- `versioned_docs/version-phase-1/regulatory/gdpr-mapping.md` — 3 new processing activities (GDPR-007–009), added property data categories, updated cross-references
- `versioned_docs/version-phase-1/regulatory/idd-compliance.md` — 3 new requirements (IDD-011–013), updated summary table, updated FSA and GDPR cross-references
- `docs/regulatory/` — all three files synced with versioned_docs

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] Docusaurus build succeeds

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)