### PR TITLE
docs(#71): Add Phase 2 water damage (vattenskada) user stories and use case

### DIFF
--- a/docs/phase-2-home-property/use-cases/index.md
+++ b/docs/phase-2-home-property/use-cases/index.md
@@ -23,3 +23,9 @@ covers:
 - BankID digital signing
 - Policy issuance and confirmation delivery
 - Agent-assisted and high-risk alternative flows
+
+## Water Damage Claims (Vattenskada)
+
+| ID                                         | Title                        | Scope                                                                                         |
+| ------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------- |
+| [UC-HCW-001](uc-water-damage-lifecycle.md) | Water Damage Claim Lifecycle | End-to-end flow from FNOL through emergency response, drying, repair, settlement, and closure |

--- a/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
@@ -1,0 +1,267 @@
+---
+sidebar_position: 10
+---
+
+# UC-HCW-001: Water Damage Claim Lifecycle
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a water damage (vattenskada) claim — from FNOL through emergency response, drying, repair, settlement, and closure. Water damage is the most common home insurance claim in Sweden (~100,000 per year) with a unique lifecycle involving restoration companies, drying protocols, BRF/individual responsibility determination, and complex multi-party settlement coordination.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md), [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md), [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md), [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md)
+
+## Preconditions
+
+1. The customer holds an active home insurance policy (hemförsäkring, villahemförsäkring, or bostadsrättsförsäkring) with TryggFörsäkring
+2. A water damage event has occurred at the insured property
+3. The customer has access to the web portal, mobile app, or claims phone line
+
+## Postconditions
+
+**Success:**
+
+- Claim is settled and closed with full documentation
+- Property has been dried and restored to pre-damage condition
+- Customer has received the settlement amount (minus deductible and age deductions)
+- BRF/individual responsibility has been determined and cross-claim coordination completed (if applicable)
+- Drying protocols, inspection reports, and settlement calculations are archived
+- Claims data has been recorded for underwriting risk assessment
+
+**Failure:**
+
+- Claim is denied with documented reason (e.g., excluded cause, lapsed policy)
+- Customer has been informed of the denial reason and complaints procedure
+- Emergency response and drying may still proceed under reservation pending investigation
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[1. Customer reports water damage] --> B[2. FNOL registration and classification]
+    B --> C[3. Dispatch saneringsfirma]
+    C --> D[4. Emergency response and leak detection]
+    D --> E{Home uninhabitable?}
+    E -->|Yes| F[4a. Arrange temporary housing]
+    E -->|No| G[5. Install drying equipment]
+    F --> G
+    G --> H[6. Claims handler assesses damage scope]
+    H --> I{Besiktningsman needed?}
+    I -->|Yes| J[6a. Property inspection]
+    I -->|No| K{BRF property?}
+    J --> K
+    K -->|Yes| L[7. Determine BRF vs individual responsibility]
+    K -->|No| M[8. Saneringsfirma submits torkprotokoll]
+    L --> M
+    M --> N{Drying complete?}
+    N -->|No| M
+    N -->|Yes| O[9. Approve repair scope and contractor]
+    O --> P[10. Contractor performs repairs]
+    P --> Q[11. Final inspection]
+    Q --> R{Restoration satisfactory?}
+    R -->|No| P
+    R -->|Yes| S[12. Calculate settlement]
+    S --> T[13. Process payment]
+    T --> U[14. Close claim and record data]
+
+    style A fill:#e1f5fe
+    style U fill:#e8f5e9
+    style F fill:#fff3e0
+    style J fill:#fff3e0
+    style L fill:#fff3e0
+```
+
+## Main Flow (Water Damage Claim Lifecycle)
+
+| Step | Actor          | Action                                                                       | System Response                                                       | Reference                                                        |
+| ---- | -------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1    | Customer       | Reports water damage via web, app, or phone (available 24/7)                 | Creates FNOL record with claim number, sends confirmation to customer | [US-HCW-001](../user-stories/water-damage-fnol.md)               |
+| 2    | Claims Handler | Registers FNOL with damage type, location, and suspected cause               | Validates coverage, categorizes claim, assigns claims handler         | [US-HCW-003](../user-stories/water-damage-registration.md)       |
+| 3    | System         | Dispatches nearest available saneringsfirma under framework agreement        | Records dispatch time, notifies customer of expected arrival          | [US-HCW-002](../user-stories/water-damage-dispatch.md)           |
+| 4    | Saneringsfirma | Performs leak detection, stops water source, removes standing water          | Records arrival time, updates claim status to "Emergency Response"    | [US-HCW-002](../user-stories/water-damage-dispatch.md)           |
+| 5    | Saneringsfirma | Installs drying equipment and begins torkprotokoll (drying protocol)         | Records equipment placement, starts drying timeline                   | [US-HCW-008](../user-stories/water-damage-drying-protocol.md)    |
+| 6    | Claims Handler | Assesses damage scope using saneringsfirma's moisture measurement report     | Displays moisture readings, affected area, and cost estimate          | [US-HCW-004](../user-stories/water-damage-moisture-report.md)    |
+| 7    | Claims Handler | Determines coverage responsibility: individual vs BRF (for bostadsrätt)      | Presents responsibility boundary tool, records determination          | [US-HCW-005](../user-stories/water-damage-brf-responsibility.md) |
+| 8    | Saneringsfirma | Submits periodic torkprotokoll with moisture measurements                    | Updates drying progress, notifies handler and customer                | [US-HCW-008](../user-stories/water-damage-drying-protocol.md)    |
+| 9    | Claims Handler | Approves repair scope and selects contractor once drying is complete         | Records approved scope and budget, notifies customer                  | [US-HCW-009](../user-stories/water-damage-repair-approval.md)    |
+| 10   | Contractor     | Performs repairs per approved scope                                          | Tracks repair progress, updates claim timeline                        | [US-HCW-009](../user-stories/water-damage-repair-approval.md)    |
+| 11   | Claims Handler | Verifies restoration is complete via final inspection or customer sign-off   | Records inspection results and customer acceptance                    | [US-HCW-014](../user-stories/water-damage-final-inspection.md)   |
+| 12   | Claims Handler | Calculates settlement: replacement cost minus age deduction minus deductible | Generates settlement breakdown for customer review                    | [US-HCW-011](../user-stories/water-damage-settlement.md)         |
+| 13   | System         | Processes payment to customer, contractor, and/or saneringsfirma             | Records payment details, updates claim status to "Settled"            | [US-HCW-011](../user-stories/water-damage-settlement.md)         |
+| 14   | System         | Closes claim and records data for risk assessment                            | Archives claim file, updates property claims history                  | [US-HCW-015](../user-stories/water-damage-closure.md)            |
+
+## Alternative Flow: Emergency After Hours
+
+| Step | Actor             | Action                                                       | System Response                                                   |
+| ---- | ----------------- | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| 1a.1 | Customer          | Reports water damage outside business hours via phone or app | Routes to 24/7 emergency service                                  |
+| 1a.2 | Emergency Service | Takes FNOL details and dispatches saneringsfirma directly    | Creates preliminary claim record, dispatches with urgent priority |
+| 1a.3 | Claims Handler    | Reviews and completes FNOL registration next business day    | Validates and finalizes the claim record                          |
+
+## Alternative Flow: Severe Damage — Temporary Housing
+
+| Step | Actor                   | Action                                                | System Response                                               |
+| ---- | ----------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| 4a.1 | Customer/Saneringsfirma | Reports that the property is uninhabitable            | Claims handler is notified of housing need                    |
+| 4a.2 | Claims Handler          | Approves temporary housing and arranges accommodation | Creates housing order, books accommodation, notifies customer |
+| 4a.3 | System                  | Tracks temporary housing costs for settlement         | Accumulates daily costs against policy limits                 |
+| 4a.4 | Claims Handler          | Ends temporary housing when property is restored      | Records total housing cost, includes in settlement            |
+
+## Alternative Flow: Construction Defect (Dolda Fel)
+
+| Step | Actor          | Action                                                                  | System Response                                        |
+| ---- | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
+| 6a.1 | Besiktningsman | Identifies construction defect as damage cause                          | Records defect finding in inspection report            |
+| 6a.2 | Claims Handler | Determines that subrogation may apply against seller or builder         | Flags claim for subrogation assessment                 |
+| 6a.3 | Claims Handler | Processes customer claim normally while pursuing subrogation separately | Tracks subrogation separately from customer settlement |
+
+## Alternative Flow: BRF/Individual Boundary Dispute
+
+| Step | Actor                 | Action                                                      | System Response                                 |
+| ---- | --------------------- | ----------------------------------------------------------- | ----------------------------------------------- |
+| 7a.1 | Claims Handler        | Cannot determine responsibility due to ambiguous boundary   | Escalates to senior claims handler              |
+| 7a.2 | Senior Claims Handler | Reviews BRF stadgar and engages besiktningsman if needed    | Records determination with documented rationale |
+| 7a.3 | Claims Handler        | If dispute persists, informs customer of complaints process | Records dispute and FSA-compliant communication |
+
+## Alternative Flow: Multi-Apartment Damage
+
+| Step | Actor          | Action                                                      | System Response                                             |
+| ---- | -------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| 7b.1 | Claims Handler | Identifies that multiple apartments in the BRF are affected | Creates linked claims for each affected apartment           |
+| 7b.2 | Claims Handler | Assigns a lead handler for the coordinated claim group      | Links all sub-claims to a parent coordination record        |
+| 7b.3 | System         | Coordinates drying and repair across all affected units     | Tracks progress per unit while maintaining overall timeline |
+
+## Exception Flow: Repair Cost Exceeds Threshold
+
+| Step | Actor                 | Action                                               | System Response                                           |
+| ---- | --------------------- | ---------------------------------------------------- | --------------------------------------------------------- |
+| 9a.1 | Claims Handler        | Submits repair scope that exceeds approval threshold | Flags for senior approval, blocks contractor notification |
+| 9a.2 | Senior Claims Handler | Reviews and approves or adjusts the repair scope     | Records senior approval, releases repair to proceed       |
+
+## Exception Flow: Customer Disputes Settlement
+
+| Step  | Actor          | Action                                                      | System Response                                          |
+| ----- | -------------- | ----------------------------------------------------------- | -------------------------------------------------------- |
+| 12a.1 | Customer       | Disputes the settlement amount (e.g., age deduction, scope) | Records dispute, pauses payment                          |
+| 12a.2 | Claims Handler | Reviews dispute and recalculates or escalates               | Updates settlement if justified, or refers to complaints |
+| 12a.3 | System         | If unresolved, directs customer to FSA complaints process   | Records complaint referral                               |
+
+## Validation Rules
+
+| Rule       | Description                                                        |
+| ---------- | ------------------------------------------------------------------ |
+| VR-HCW-001 | Incident date must not be in the future                            |
+| VR-HCW-002 | Incident date must fall within the policy's active coverage period |
+| VR-HCW-003 | Property address must match the insured property on the policy     |
+| VR-HCW-004 | Damage cause must be a covered peril under the policy terms        |
+| VR-HCW-005 | Drying must be verified complete before repair phase can begin     |
+| VR-HCW-006 | Repair cost exceeding threshold requires senior approval           |
+| VR-HCW-007 | All required documentation must be complete before claim closure   |
+
+## Data Model
+
+### WaterDamageClaim
+
+| Field               | Type      | Required       | Description                                                                           |
+| ------------------- | --------- | -------------- | ------------------------------------------------------------------------------------- |
+| claimId             | String    | Auto-generated | Unique claim identifier (skadenummer)                                                 |
+| policyId            | Reference | Yes            | Link to the insured policy                                                            |
+| damageDate          | Date      | Yes            | Date water damage was discovered                                                      |
+| reportDate          | Timestamp | Auto-set       | Date and time of FNOL submission                                                      |
+| causeCategory       | Enum      | Yes            | Burst pipe, appliance leak, membrane failure, frozen pipes, roof leak, external water |
+| affectedRooms       | String[]  | Yes            | List of affected rooms                                                                |
+| propertyType        | Enum      | Yes            | Villa, bostadsrätt, hyresrätt                                                         |
+| brfInvolved         | Boolean   | Yes            | Whether BRF coordination is required                                                  |
+| brfPolicyId         | Reference | Conditional    | BRF building insurance policy (if applicable)                                         |
+| responsibilitySplit | Object    | Conditional    | BRF vs individual percentage or line-item split                                       |
+| estimatedCost       | Currency  | No             | Initial cost estimate                                                                 |
+| totalClaimCost      | Currency  | Calculated     | Final total cost (drying + repair + housing)                                          |
+| status              | Enum      | Auto-set       | Emergency Reported, Registered, Drying, Repair, Settled, Closed                       |
+| assignedHandler     | Reference | Auto-set       | Claims handler assigned to the claim                                                  |
+
+### RestorationOrder
+
+| Field           | Type      | Required       | Description                              |
+| --------------- | --------- | -------------- | ---------------------------------------- |
+| orderId         | String    | Auto-generated | Unique restoration order identifier      |
+| claimId         | Reference | Yes            | Link to the water damage claim           |
+| saneringsfirma  | String    | Yes            | Name of the assigned restoration company |
+| dispatchTime    | Timestamp | Yes            | When the company was dispatched          |
+| arrivalTime     | Timestamp | No             | When the company arrived on site         |
+| dryingStartDate | Date      | No             | When drying equipment was installed      |
+| dryingEndDate   | Date      | No             | When drying was completed                |
+| totalDryingCost | Currency  | Calculated     | Total cost for drying services           |
+
+### DryingProtocol (Torkprotokoll)
+
+| Field              | Type      | Required       | Description                                      |
+| ------------------ | --------- | -------------- | ------------------------------------------------ |
+| protocolId         | String    | Auto-generated | Unique protocol identifier                       |
+| restorationOrderId | Reference | Yes            | Link to the restoration order                    |
+| measurementDate    | Date      | Yes            | Date measurements were taken                     |
+| moistureLevels     | Object[]  | Yes            | Room-by-room moisture readings                   |
+| equipmentUsed      | Object[]  | Yes            | Drying equipment in use                          |
+| dryingAssessment   | Enum      | Yes            | On track, delayed, complete, reassessment needed |
+| technicianNotes    | Text      | No             | Observations and recommendations                 |
+
+### TemporaryHousing
+
+| Field             | Type      | Required       | Description                               |
+| ----------------- | --------- | -------------- | ----------------------------------------- |
+| housingId         | String    | Auto-generated | Unique housing record identifier          |
+| claimId           | Reference | Yes            | Link to the water damage claim            |
+| startDate         | Date      | Yes            | Temporary housing start date              |
+| endDate           | Date      | No             | End date (updated on completion)          |
+| accommodationType | Enum      | Yes            | Hotel, furnished apartment, extended-stay |
+| dailyCost         | Currency  | Yes            | Daily accommodation cost                  |
+| totalCost         | Currency  | Calculated     | Total accumulated housing cost            |
+
+## Business Rules
+
+| Rule       | Description                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------- |
+| BR-HCW-001 | Saneringsfirma must be dispatched within 2 hours for urgent cases (water still flowing)                        |
+| BR-HCW-002 | Drying must be verified complete (moisture within acceptable limits) before repair phase begins                |
+| BR-HCW-003 | Age deduction (åldersavdrag) is applied per the insurer's published tables based on material type and age      |
+| BR-HCW-004 | BRF responsibility follows bostadsrättslagen unless the BRF's stadgar specify otherwise                        |
+| BR-HCW-005 | Repair costs exceeding SEK 200,000 require senior claims handler approval                                      |
+| BR-HCW-006 | Temporary housing is covered for the duration of restoration, subject to policy coverage limits                |
+| BR-HCW-007 | The customer must not be left out of pocket for covered portions while cross-claim coordination is in progress |
+
+## External Integrations
+
+| System                              | Purpose                                                  | Data Exchanged                                                |
+| ----------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| Saneringsfirma API (Polygon/BELFOR) | Dispatch, status updates, torkprotokoll submission       | Dispatch orders, moisture reports, cost estimates             |
+| BRF building insurer                | Cross-claim coordination for split-responsibility claims | Claim details, responsibility determination, settlement split |
+| Temporary housing provider          | Accommodation booking for uninhabitable properties       | Booking requests, availability, cost confirmation             |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the entire claims lifecycle must proceed without undue delay; SLAs must be tracked
+- **FSA-004** — Consumer protection: the customer must receive clear communication at each stage of the process
+- **FSA-011** — Complaints handling: the customer must be informed of the complaints procedure if they dispute any aspect of the claim
+- **FSA-014** — Record keeping: the complete claims file (FNOL, moisture reports, torkprotokoll, inspection reports, settlement calculations, payments) must be retained for 10 years
+- **FSA-005** — Product governance: claims data must be available for product reviews
+- **GDPR-003** — Claims processing: personal data shared with saneringsfirma, besiktningsman, and housing providers must be limited to what is necessary and covered by data processing agreements
+- **GDPR-006** — Fraud detection: unusual claim patterns (frequency, cost, timing) may trigger fraud screening
+
+## Related User Stories
+
+- [US-HCW-001](../user-stories/water-damage-fnol.md) — Report Water Damage Emergency (24/7)
+- [US-HCW-002](../user-stories/water-damage-dispatch.md) — Dispatch Restoration Company
+- [US-HCW-003](../user-stories/water-damage-registration.md) — Register FNOL With Damage Classification
+- [US-HCW-004](../user-stories/water-damage-moisture-report.md) — Receive Moisture Measurement Report
+- [US-HCW-005](../user-stories/water-damage-brf-responsibility.md) — Determine BRF vs Individual Responsibility
+- [US-HCW-006](../user-stories/water-damage-inspection.md) — Document Damage With Inspection
+- [US-HCW-007](../user-stories/water-damage-drying-progress.md) — Track Drying Progress
+- [US-HCW-008](../user-stories/water-damage-drying-protocol.md) — Submit Drying Protocol (Torkprotokoll)
+- [US-HCW-009](../user-stories/water-damage-repair-approval.md) — Approve Repair Scope and Contractor
+- [US-HCW-010](../user-stories/water-damage-temporary-housing.md) — Arrange Temporary Housing
+- [US-HCW-011](../user-stories/water-damage-settlement.md) — Calculate Settlement With Age Deduction
+- [US-HCW-012](../user-stories/water-damage-deductible.md) — View Deductible for Claim
+- [US-HCW-013](../user-stories/water-damage-cross-claim.md) — Coordinate Cross-Claim Payment
+- [US-HCW-014](../user-stories/water-damage-final-inspection.md) — Verify Restoration via Final Inspection
+- [US-HCW-015](../user-stories/water-damage-closure.md) — Close Claim and Record for Risk Assessment

--- a/docs/phase-2-home-property/user-stories/index.md
+++ b/docs/phase-2-home-property/user-stories/index.md
@@ -26,3 +26,49 @@ flow from initial customer inquiry through policy issuance:
 | HQB-08 | Underwriter            | Review flagged high-risk quotes                                     |
 | HQB-09 | System                 | Verify property address via Lantmäteriet                            |
 | HQB-10 | System                 | Calculate premium based on rating factors                           |
+
+## Water Damage Claims (Vattenskada)
+
+Water damage is the most common home insurance claim in Sweden (~100,000 per
+year). These user stories cover the complete water damage claim lifecycle from
+emergency FNOL through restoration and settlement.
+
+### FNOL and Emergency
+
+| ID                                         | Title                                         | Priority  |
+| ------------------------------------------ | --------------------------------------------- | --------- |
+| [US-HCW-001](water-damage-fnol.md)         | Report Water Damage Emergency (24/7)          | Must Have |
+| [US-HCW-002](water-damage-dispatch.md)     | Dispatch Restoration Company (Saneringsfirma) | Must Have |
+| [US-HCW-003](water-damage-registration.md) | Register FNOL With Damage Classification      | Must Have |
+
+### Investigation and Assessment
+
+| ID                                               | Title                                      | Priority    |
+| ------------------------------------------------ | ------------------------------------------ | ----------- |
+| [US-HCW-004](water-damage-moisture-report.md)    | Receive Moisture Measurement Report        | Must Have   |
+| [US-HCW-005](water-damage-brf-responsibility.md) | Determine BRF vs Individual Responsibility | Must Have   |
+| [US-HCW-006](water-damage-inspection.md)         | Document Damage With Inspection            | Should Have |
+
+### Restoration Process
+
+| ID                                              | Title                                         | Priority    |
+| ----------------------------------------------- | --------------------------------------------- | ----------- |
+| [US-HCW-007](water-damage-drying-progress.md)   | Track Drying Progress                         | Should Have |
+| [US-HCW-008](water-damage-drying-protocol.md)   | Submit Drying Protocol (Torkprotokoll)        | Must Have   |
+| [US-HCW-009](water-damage-repair-approval.md)   | Approve Repair Scope and Contractor           | Must Have   |
+| [US-HCW-010](water-damage-temporary-housing.md) | Arrange Temporary Housing (Evakueringsboende) | Must Have   |
+
+### Settlement
+
+| ID                                        | Title                                           | Priority  |
+| ----------------------------------------- | ----------------------------------------------- | --------- |
+| [US-HCW-011](water-damage-settlement.md)  | Calculate Settlement With Age Deduction         | Must Have |
+| [US-HCW-012](water-damage-deductible.md)  | View Deductible (Självrisk) for Claim           | Must Have |
+| [US-HCW-013](water-damage-cross-claim.md) | Coordinate Cross-Claim Payment (BRF/Individual) | Must Have |
+
+### Closure
+
+| ID                                             | Title                                      | Priority    |
+| ---------------------------------------------- | ------------------------------------------ | ----------- |
+| [US-HCW-014](water-damage-final-inspection.md) | Verify Restoration via Final Inspection    | Should Have |
+| [US-HCW-015](water-damage-closure.md)          | Close Claim and Record for Risk Assessment | Must Have   |

--- a/docs/phase-2-home-property/user-stories/water-damage-brf-responsibility.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-brf-responsibility.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 14
+---
+
+# US-HCW-005: Determine BRF vs Individual Responsibility
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** determine whether the water damage is a building issue (BRF) or an individual issue,
+**so that** the correct insurance policy pays and the claim is settled fairly.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md), [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md)
+
+## Priority
+
+**Must Have** — BRF/individual boundary determination is one of the most complex and disputed aspects of water damage claims in Sweden.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim involves a bostadsrätt property
+  **WHEN** the claims handler assesses coverage responsibility
+  **THEN** the system presents a decision support tool that maps damage cause and location to the standard BRF/individual responsibility boundary based on bostadsrättslagen and the BRF's stadgar
+
+- **GIVEN** the claims handler is determining responsibility
+  **WHEN** the damage originates from a shared system (stamledning, gemensamt avlopp, yttertak)
+  **THEN** the system defaults to BRF building insurance responsibility and prompts the handler to contact the BRF's insurer for coordination
+
+- **GIVEN** the claims handler is determining responsibility
+  **WHEN** the damage originates from the individual apartment's interior (e.g., appliance leak, bathroom membrane installed by the member)
+  **THEN** the system defaults to individual bostadsrättsförsäkring responsibility
+
+- **GIVEN** the damage spans both shared and individual areas
+  **WHEN** the claims handler identifies a split-responsibility scenario
+  **THEN** the system supports recording the responsibility split (percentage or line-item) and creates linked claims against both the BRF building insurance and the individual's policy
+
+- **GIVEN** the BRF and individual parties dispute the responsibility boundary
+  **WHEN** the claims handler cannot resolve the dispute
+  **THEN** the system escalates the claim to a senior claims handler and optionally engages a besiktningsman for an independent determination
+
+## Responsibility Boundary Guidelines
+
+| Damage Source                           | Typical Responsibility | Notes                                  |
+| --------------------------------------- | ---------------------- | -------------------------------------- |
+| Stamledning (main pipes)                | BRF building insurance | Shared infrastructure                  |
+| Yttertak (roof)                         | BRF building insurance | Building envelope                      |
+| Bathroom membrane (original)            | BRF building insurance | Installed at construction              |
+| Bathroom membrane (renovated by member) | Individual             | Member responsible for own renovations |
+| Appliance in apartment                  | Individual             | Washing machine, dishwasher            |
+| Water heater (shared)                   | BRF building insurance | Building utility                       |
+| Balcony drainage                        | BRF building insurance | Building structure                     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the responsibility determination must be transparent and fair to both parties
+- **FSA-004** — Consumer protection: the customer must receive a clear explanation of the responsibility determination and their right to dispute it
+- **FSA-011** — Complaints handling: if the customer disputes the determination, the complaints process must be accessible
+
+## Dependencies
+
+- Depends on US-HCW-003 (Register FNOL With Damage Classification)
+- BRF building insurance policy lookup
+- Access to BRF stadgar (articles of association) for specific boundary rules
+
+## Notes
+
+- BRF responsibility boundaries vary between associations — the stadgar may deviate from the default rules in bostadsrättslagen
+- The 2003 amendment to bostadsrättslagen shifted some responsibility from BRF to individual members, but many older BRFs have not updated their stadgar
+- This is one of the most common sources of disputes and complaints in Swedish home insurance
+- When TryggFörsäkring insures both the BRF building and the individual member, coordination is simpler but the fair settlement obligation still applies

--- a/docs/phase-2-home-property/user-stories/water-damage-closure.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-closure.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 24
+---
+
+# US-HCW-015: Close Claim and Record for Risk Assessment
+
+## User Story
+
+**As the** system,
+**I want to** record the completed water damage claim for future risk assessment,
+**so that** underwriting can adjust premiums and risk models based on claims experience.
+
+## Actors
+
+- **Primary:** System
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Claims data feeds into underwriting risk models and pricing, which is essential for portfolio sustainability.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim has been fully settled and restoration verified
+  **WHEN** the claims handler initiates claim closure
+  **THEN** the system performs a final validation that all required documentation is complete: FNOL, moisture reports, torkprotokoll, settlement calculation, payment confirmation, and customer sign-off
+
+- **GIVEN** all closure validations pass
+  **WHEN** the system closes the claim
+  **THEN** the system sets the claim status to "Closed" (Avslutad), records the total claim cost (drying + repair + temporary housing), and updates the property's claims history
+
+- **GIVEN** a claim has been closed
+  **WHEN** the system updates risk assessment data
+  **THEN** the system records: claim cause category, total cost, property type, property age, BRF vs individual, restoration duration, and geographic location for use in underwriting risk models
+
+- **GIVEN** the claim data has been recorded
+  **WHEN** the renewal cycle approaches for the affected policy
+  **THEN** the underwriting system can access the claims history to assess whether a premium adjustment is warranted
+
+- **GIVEN** a closed claim is reopened due to recurrence or quality issue
+  **WHEN** the claims handler reopens the claim
+  **THEN** the system reverts the status, links the reopening to the original claim, and retains the original closure record
+
+## Claims Data for Risk Assessment
+
+| Data Point           | Description                                           | Use in Underwriting          |
+| -------------------- | ----------------------------------------------------- | ---------------------------- |
+| Cause category       | Burst pipe, appliance leak, membrane failure, etc.    | Risk factor by cause type    |
+| Total claim cost     | All costs including drying, repair, temporary housing | Loss ratio analysis          |
+| Property type        | Villa, bostadsrätt, hyresrätt                         | Risk segmentation            |
+| Property age         | Construction year                                     | Age-related risk curves      |
+| Geographic location  | Municipality and postal code                          | Regional risk mapping        |
+| Restoration duration | Days from FNOL to closure                             | Claims efficiency metrics    |
+| BRF involvement      | Whether the claim involved BRF coordination           | Multi-party claim complexity |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: claim closure must be communicated to the customer with a clear summary
+- **FSA-014** — Record keeping: the complete claims file must be retained for 10 years after closure
+- **FSA-005** — Product governance: claims data must be available for product reviews to ensure products continue to meet customer needs
+- **GDPR-003** — Claims processing: claims data used for risk assessment must follow data minimization; use aggregated or anonymized data where possible for statistical analysis
+
+## Dependencies
+
+- Depends on US-HCW-011 (Calculate Settlement With Age Deduction) — settlement must be processed
+- Depends on US-HCW-014 (Verify Restoration via Final Inspection) — restoration must be verified
+- Underwriting risk model integration
+
+## Notes
+
+- Water damage claims data is particularly valuable for underwriting because of the high frequency and significant variation in costs
+- Property age and type are strong predictors of water damage risk
+- Claims history affects the individual customer's premium at renewal but also feeds into portfolio-level risk assessment

--- a/docs/phase-2-home-property/user-stories/water-damage-cross-claim.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-cross-claim.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 22
+---
+
+# US-HCW-013: Coordinate Cross-Claim Payment (BRF/Individual)
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** coordinate payment between the BRF's building insurance and the individual's bostadsrättsförsäkring,
+**so that** each party pays their share and the customer receives full compensation.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md), [Customer (Privatkund)](../../actors/internal/customer.md)
+
+## Priority
+
+**Must Have** — Cross-claim coordination between BRF and individual insurance is essential for bostadsrätt water damage claims where both policies are involved.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim has been determined to involve both BRF building insurance and the individual's bostadsrättsförsäkring
+  **WHEN** the claims handler prepares the settlement
+  **THEN** the system supports splitting the settlement into a BRF portion (building structure, shared systems) and an individual portion (apartment interior, personal property, fixtures)
+
+- **GIVEN** the BRF building insurance is held by a different insurer
+  **WHEN** the claims handler needs to coordinate the BRF portion
+  **THEN** the system records the BRF insurer details and supports sending a cross-claim coordination request to the other insurer
+
+- **GIVEN** both the BRF building insurance and the individual policy are held by TryggFörsäkring
+  **WHEN** the claims handler processes the settlement
+  **THEN** the system allows coordinated settlement under both policies with a single claims handler, applying each policy's deductible independently
+
+- **GIVEN** the cross-claim coordination is complete
+  **WHEN** both insurers have agreed on their respective shares
+  **THEN** the system records the agreed split and processes payment from TryggFörsäkring's share without waiting for the other insurer's payment to the customer
+
+- **GIVEN** the customer's own policy covers a portion and the BRF's insurer covers the building portion
+  **WHEN** the customer receives the settlement
+  **THEN** the system ensures the customer is not left out of pocket for the covered portion while the BRF claim is being processed
+
+## Cross-Claim Split Examples
+
+| Damage Component            | Typical Payer          | Notes                                                         |
+| --------------------------- | ---------------------- | ------------------------------------------------------------- |
+| Building structure repair   | BRF building insurance | Walls, floors (under surface), pipes in wall                  |
+| Surface finishes (interior) | Individual policy      | Flooring, tiles, paint, wallpaper                             |
+| Kitchen/bathroom fixtures   | Depends on BRF stadgar | Often individual responsibility                               |
+| Personal property           | Individual policy      | Furniture, electronics, clothing                              |
+| Drying costs                | Split or BRF           | Often building insurance responsibility                       |
+| Temporary housing           | Individual policy      | Covered under individual hemförsäkring/bostadsrättsförsäkring |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the customer must not experience undue delay due to cross-claim coordination between insurers
+- **FSA-004** — Consumer protection: the customer must receive clear communication about which insurer is responsible for each portion
+- **FSA-014** — Record keeping: the cross-claim coordination details must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCW-005 (Determine BRF vs Individual Responsibility)
+- Depends on US-HCW-011 (Calculate Settlement With Age Deduction)
+- BRF building insurance policy lookup and cross-insurer communication
+
+## Notes
+
+- When TryggFörsäkring insures both the BRF and the individual, coordination is simpler and faster
+- When different insurers are involved, the customer may receive two separate settlements
+- The customer should not need to coordinate between insurers themselves — this is the claims handler's responsibility
+- Cross-claim coordination is one of the main reasons water damage claims take longer to settle for bostadsrätt properties

--- a/docs/phase-2-home-property/user-stories/water-damage-deductible.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-deductible.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 21
+---
+
+# US-HCW-012: View Deductible (Självrisk) for Claim
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** understand what my deductible (självrisk) is for this water damage claim,
+**so that** I know my out-of-pocket cost before the settlement is processed.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Deductible transparency is required for fair claims handling and reduces post-settlement complaints.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active water damage claim
+  **WHEN** the customer views the claim details in the web portal or mobile app
+  **THEN** the system displays the applicable deductible amount based on the policy terms and the claim type
+
+- **GIVEN** a customer's policy has a variable deductible (valbar självrisk)
+  **WHEN** the system determines the deductible for a water damage claim
+  **THEN** the system applies the deductible level selected at policy purchase (e.g., SEK 1,500, SEK 3,000, SEK 5,000)
+
+- **GIVEN** the water damage claim involves both the BRF building insurance and the individual's policy
+  **WHEN** the customer views the deductible information
+  **THEN** the system shows the deductible applicable to the individual's policy only (the BRF's deductible is the BRF's responsibility)
+
+- **GIVEN** the claims handler presents the settlement offer to the customer
+  **WHEN** the customer reviews the settlement breakdown
+  **THEN** the deductible is clearly itemized as a separate line, showing how it reduces the net settlement amount
+
+## Deductible Structure
+
+| Policy Type            | Typical Deductible Range | Notes                           |
+| ---------------------- | ------------------------ | ------------------------------- |
+| Hemförsäkring (rental) | SEK 1,500 -- 3,000       | Fixed or selectable at purchase |
+| Bostadsrättsförsäkring | SEK 1,500 -- 5,000       | Selectable at purchase          |
+| Villahemförsäkring     | SEK 3,000 -- 10,000      | Selectable at purchase          |
+| BRF building insurance | SEK 10,000 -- 50,000     | Set by BRF board                |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the deductible must be correctly applied and clearly communicated
+- **FSA-004** — Consumer protection: the customer must understand their out-of-pocket cost before settlement
+- **FSA-012** — Insurance contract disclosure: deductible terms must be clearly stated in the policy and IPID
+
+## Dependencies
+
+- Depends on US-HCW-001 (Water Damage FNOL) — claim must be registered
+- Policy terms and deductible configuration
+
+## Notes
+
+- Some policies offer a reduced deductible for water damage caused by sudden and unforeseen events vs. gradual damage
+- The deductible is typically deducted from the settlement payment, not paid separately by the customer
+- For direct repair billing, the customer pays the deductible directly to the contractor

--- a/docs/phase-2-home-property/user-stories/water-damage-dispatch.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-dispatch.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 11
+---
+
+# US-HCW-002: Dispatch Restoration Company (Saneringsfirma)
+
+## User Story
+
+**As a** customer (privatkund),
+**I want** the insurer to dispatch a saneringsfirma directly after I report water damage,
+**so that** professional drying starts within hours and further damage is prevented.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md), [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Rapid restoration company dispatch is essential to minimize water damage extent and total claim cost.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim has been registered
+  **WHEN** the system processes the emergency report
+  **THEN** the system automatically dispatches the nearest available saneringsfirma under the framework agreement (Polygon, BELFOR, or other contracted partner)
+
+- **GIVEN** a saneringsfirma has been dispatched
+  **WHEN** the restoration company accepts the assignment
+  **THEN** the system records the dispatch time, estimated arrival time, and assigned company, and notifies the customer with the expected arrival window
+
+- **GIVEN** the customer has reported that water is still flowing
+  **WHEN** the system triages the emergency
+  **THEN** the system marks the dispatch as urgent (akut) with a target response time of 2 hours
+
+- **GIVEN** a saneringsfirma has arrived at the property
+  **WHEN** the restoration company begins work
+  **THEN** the system records the actual arrival time and updates the claim status to "Emergency Response in Progress"
+
+- **GIVEN** the property is a bostadsrätt in a BRF
+  **WHEN** the damage may affect shared areas (gemensamma utrymmen)
+  **THEN** the system notifies the claims handler to coordinate with the [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md) regarding building access and shared area assessment
+
+## Dispatch Priority Rules
+
+| Condition                                    | Priority      | Target Response Time |
+| -------------------------------------------- | ------------- | -------------------- |
+| Water still flowing                          | Urgent (Akut) | 2 hours              |
+| Water stopped but significant standing water | High          | 4 hours              |
+| Water stopped, limited damage                | Normal        | 24 hours             |
+| Slow leak discovered, no emergency           | Scheduled     | Next business day    |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: prompt dispatch of restoration services is part of the insurer's obligation to handle claims without undue delay
+- **GDPR-003** — Claims processing: sharing customer address and contact details with the saneringsfirma requires a data processing agreement and must be limited to data necessary for the restoration work
+
+## Dependencies
+
+- Depends on US-HCW-001 (Water Damage FNOL)
+- Saneringsfirma API integration (Polygon/BELFOR) for automated dispatch
+- Framework agreements with restoration companies
+
+## Notes
+
+- The customer should not need to find and contact a saneringsfirma themselves — the insurer manages this as part of the claims service
+- For after-hours reports, the 24/7 emergency service handles dispatch directly
+- Multiple restoration companies may be needed for large-scale damage (e.g., entire apartment building)

--- a/docs/phase-2-home-property/user-stories/water-damage-drying-progress.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-drying-progress.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 16
+---
+
+# US-HCW-007: Track Drying Progress
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** track the drying progress of my property,
+**so that** I know when repairs can begin and I can plan accordingly.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md), [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Should Have** — Transparency into the drying process reduces customer anxiety and support calls during what is typically a 2-8 week waiting period.
+
+## Acceptance Criteria
+
+- **GIVEN** drying is in progress at the customer's property
+  **WHEN** the customer views the claim status in the web portal or mobile app
+  **THEN** the system displays the current drying phase, latest moisture readings, estimated completion date, and next scheduled measurement
+
+- **GIVEN** the saneringsfirma has submitted a new drying measurement
+  **WHEN** the system receives the updated moisture data
+  **THEN** the system updates the claim timeline and notifies the customer that a new measurement is available
+
+- **GIVEN** the drying process is taking longer than initially estimated
+  **WHEN** the estimated completion date is revised
+  **THEN** the system notifies the customer of the new timeline and the reason for the extension
+
+- **GIVEN** the drying phase is complete (moisture levels within acceptable range)
+  **WHEN** the saneringsfirma submits the final measurement
+  **THEN** the system updates the claim status to "Drying Complete" and notifies the customer that the repair phase can begin
+
+## Drying Status Information
+
+| Field                    | Description                                                |
+| ------------------------ | ---------------------------------------------------------- |
+| Current phase            | Emergency response, active drying, monitoring, or complete |
+| Drying start date        | When drying equipment was installed                        |
+| Latest moisture readings | Most recent measurement per room                           |
+| Trend                    | Improving, stable, or concerning                           |
+| Estimated completion     | Expected date based on current progress                    |
+| Next measurement date    | When the saneringsfirma will take new readings             |
+| Equipment installed      | Types and count of drying equipment                        |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: keeping the customer informed of progress is part of fair claims handling
+- **FSA-004** — Consumer protection: the customer must receive clear, understandable status information throughout the claims process
+
+## Dependencies
+
+- Depends on US-HCW-002 (Dispatch Restoration Company)
+- Depends on US-HCW-004 (Receive Moisture Measurement Report)
+- Saneringsfirma API for automated status updates
+
+## Notes
+
+- Typical drying duration: 2-8 weeks depending on damage extent, material types, and season
+- Customers frequently call to ask about drying progress — self-service tracking reduces call volume
+- Drying equipment (dehumidifiers, fans) increases electricity costs; some policies cover this

--- a/docs/phase-2-home-property/user-stories/water-damage-drying-protocol.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-drying-protocol.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 17
+---
+
+# US-HCW-008: Submit Drying Protocol (Torkprotokoll)
+
+## User Story
+
+**As a** saneringsfirma (restoration company),
+**I want to** submit torkprotokoll (drying protocols) digitally to the insurer,
+**so that** the claims handler can monitor drying progress and approve the next steps.
+
+## Actors
+
+- **Primary:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Drying protocols are the primary documentation for the restoration process and form the basis for cost approval.
+
+## Acceptance Criteria
+
+- **GIVEN** a saneringsfirma has an active drying assignment
+  **WHEN** the technician performs a scheduled moisture measurement
+  **THEN** the system accepts the torkprotokoll submission via API or web portal, including measurement date, moisture levels per room, equipment status, and technician notes
+
+- **GIVEN** a torkprotokoll has been submitted
+  **WHEN** the system processes the submission
+  **THEN** the system stores the protocol linked to the claim and restoration order, updates the drying progress timeline, and notifies the claims handler
+
+- **GIVEN** the torkprotokoll shows moisture levels have reached acceptable limits
+  **WHEN** the saneringsfirma marks drying as complete
+  **THEN** the system alerts the claims handler to review the final protocol and approve transition to the repair phase
+
+- **GIVEN** the torkprotokoll shows unexpected moisture increase or stalled progress
+  **WHEN** the system detects an anomaly in the moisture trend
+  **THEN** the system flags the claim for claims handler review and potential reassessment of the drying plan
+
+- **GIVEN** multiple torkprotokoll have been submitted for a claim
+  **WHEN** the claims handler reviews the drying history
+  **THEN** the system displays a timeline view showing moisture level trends across all measurement points
+
+## Torkprotokoll Data Model
+
+| Field                | Type      | Required       | Description                                            |
+| -------------------- | --------- | -------------- | ------------------------------------------------------ |
+| Protocol ID          | String    | Auto-generated | Unique identifier                                      |
+| Restoration order ID | Reference | Yes            | Link to the active restoration order                   |
+| Measurement date     | Date      | Yes            | When measurements were taken                           |
+| Technician name      | String    | Yes            | Name of the technician performing measurement          |
+| Moisture levels      | Object[]  | Yes            | Room-by-room moisture readings (location, value, unit) |
+| Equipment status     | Object[]  | Yes            | List of equipment (type, operating status, placement)  |
+| Drying assessment    | Enum      | Yes            | On track, delayed, complete, or requires reassessment  |
+| Technician notes     | Text      | No             | Observations, concerns, or recommendations             |
+| Photos               | File[]    | No             | Updated damage and equipment photos                    |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: regular drying documentation ensures the restoration process is monitored and not unduly delayed
+- **FSA-014** — Record keeping: all torkprotokoll must be retained as part of the claims file for 10 years
+- **GDPR-003** — Claims processing: torkprotokoll may contain property details; data minimization applies to any personal data
+
+## Dependencies
+
+- Depends on US-HCW-002 (Dispatch Restoration Company)
+- Saneringsfirma API integration for digital protocol submission
+
+## Notes
+
+- Torkprotokoll are typically submitted weekly during active drying
+- Industry standard moisture measurement units: relative humidity (RH%), wood moisture content (%), concrete moisture (RH%)
+- Acceptable drying thresholds vary by material: concrete < 85% RH, wood < 16% moisture content

--- a/docs/phase-2-home-property/user-stories/water-damage-final-inspection.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-final-inspection.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 23
+---
+
+# US-HCW-014: Verify Restoration via Final Inspection
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** verify that restoration is complete via a final inspection,
+**so that** the claim can be closed with confidence that the property has been properly restored.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal/customer.md), [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md)
+
+## Priority
+
+**Should Have** — Final inspection ensures quality and prevents reopened claims, though not all claims require a formal inspection.
+
+## Acceptance Criteria
+
+- **GIVEN** repairs have been completed by the contractor
+  **WHEN** the contractor reports completion
+  **THEN** the system updates the claim status to "Repair Complete — Pending Verification" and prompts the claims handler to schedule or waive final inspection
+
+- **GIVEN** a final inspection is required
+  **WHEN** the claims handler or besiktningsman completes the inspection
+  **THEN** the system records the inspection results including restoration quality assessment, any remaining deficiencies, and photos of the completed restoration
+
+- **GIVEN** the final inspection identifies deficiencies
+  **WHEN** the inspector reports incomplete or substandard restoration
+  **THEN** the system flags the deficiencies, notifies the contractor, and keeps the claim in "Repair in Progress" until the issues are resolved
+
+- **GIVEN** the final inspection confirms satisfactory restoration
+  **WHEN** the claims handler approves the inspection results
+  **THEN** the system updates the claim status to "Restoration Verified" and the claim can proceed to closure
+
+- **GIVEN** the customer confirms they are satisfied with the restoration
+  **WHEN** the customer provides sign-off (digitally or verbally recorded by the claims handler)
+  **THEN** the system records the customer acceptance as part of the claim closure documentation
+
+## Final Inspection Triggers
+
+| Condition                                     | Inspection Required          |
+| --------------------------------------------- | ---------------------------- |
+| Total claim cost exceeds SEK 100,000          | Yes                          |
+| BRF/individual split claim                    | Recommended                  |
+| Customer reports dissatisfaction with repairs | Yes                          |
+| Routine low-value claim                       | Customer sign-off sufficient |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: final verification must not cause undue delay to claim closure and payment
+- **FSA-014** — Record keeping: final inspection reports and customer sign-off must be retained for 10 years
+- **FSA-011** — Complaints handling: if the customer is dissatisfied with the restoration quality, the complaints process must be accessible
+
+## Dependencies
+
+- Depends on US-HCW-009 (Approve Repair Scope and Contractor)
+- Depends on US-HCW-008 (Submit Drying Protocol) — drying must be complete before repairs
+
+## Notes
+
+- For smaller claims, a phone call or photo submission from the customer may substitute for a formal inspection
+- The saneringsfirma typically provides a completion report and warranty for their work
+- Quality issues discovered after claim closure may result in the claim being reopened

--- a/docs/phase-2-home-property/user-stories/water-damage-fnol.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-fnol.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 10
+---
+
+# US-HCW-001: Report Water Damage Emergency (24/7)
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** report a water damage emergency at any time of day or night,
+**so that** the response process starts immediately and further damage is minimized.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Water damage is the most common home insurance claim in Sweden (~100,000 per year). Rapid FNOL is critical to minimize damage through early drying intervention.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active home insurance policy (hemförsäkring, villahemförsäkring, or bostadsrättsförsäkring)
+  **WHEN** the customer opens the water damage reporting form via web, mobile app, or phone at any time
+  **THEN** the system accepts the report 24/7 and creates a claim record with status "Emergency Reported"
+
+- **GIVEN** a customer is reporting a water damage emergency
+  **WHEN** the customer selects the damage type
+  **THEN** the system displays water damage cause categories: burst pipe (sprucket rör), appliance leak (maskinläckage), bathroom membrane failure (tätskiktsbrott), frozen pipes (frysskada), and other
+
+- **GIVEN** a customer is filling out the water damage FNOL form
+  **WHEN** the customer enters damage details (affected rooms, water source, whether water is still flowing)
+  **THEN** the system validates that the incident date falls within the policy's active coverage period
+
+- **GIVEN** a customer has completed the water damage FNOL
+  **WHEN** the customer submits the report
+  **THEN** the system creates a claim record with a unique claim number (skadenummer), links it to the policy, and sends the customer a confirmation with the claim number and expected next steps
+
+- **GIVEN** a water damage claim has been submitted outside business hours
+  **WHEN** the system processes the emergency report
+  **THEN** the system routes the claim to the 24/7 emergency service for immediate saneringsfirma dispatch
+
+- **GIVEN** a customer must verify their identity for the claim
+  **WHEN** the customer signs in
+  **THEN** the system authenticates the customer via [BankID](../../actors/external/bankid.md)
+
+## Data Captured at FNOL
+
+| Field                    | Required    | Description                                                       |
+| ------------------------ | ----------- | ----------------------------------------------------------------- |
+| Incident date and time   | Yes         | When the water damage was discovered                              |
+| Property address         | Yes         | Address of the affected property                                  |
+| Property type            | Yes         | Villa, bostadsrätt, or hyresrätt                                  |
+| Damage cause category    | Yes         | Burst pipe, appliance leak, membrane failure, frozen pipes, other |
+| Affected rooms           | Yes         | List of rooms with water damage                                   |
+| Water still flowing      | Yes         | Whether the water source is still active                          |
+| Emergency measures taken | No          | What the customer has done (shut off water, moved belongings)     |
+| Photos                   | No          | Damage photos taken at discovery                                  |
+| BRF contact information  | Conditional | Required for bostadsrätt claims                                   |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the claims process must begin promptly upon FNOL; 24/7 availability ensures no undue delay for emergency claims
+- **FSA-014** — Record keeping: the FNOL and all associated data must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization principles; collect only what is necessary for the claim
+- **FSA-004** — Consumer protection: the customer must receive clear confirmation and next-step information
+
+## Dependencies
+
+- Active home insurance policy must exist
+- Actor definitions (Customer, Claims Handler)
+- BankID integration for identity verification
+- 24/7 emergency service integration
+
+## Notes
+
+- Water damage is time-critical: every hour of delay increases damage scope and cost significantly
+- Customers should be guided to shut off the water supply (avstängningsventil) as an immediate step
+- Phone-reported FNOL follows the same registration process as online, with the claims handler entering details on behalf of the customer

--- a/docs/phase-2-home-property/user-stories/water-damage-inspection.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-inspection.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 15
+---
+
+# US-HCW-006: Document Damage With Inspection
+
+## User Story
+
+**As a** besiktningsman (property inspector),
+**I want to** document the water damage cause and extent with photos and measurements,
+**so that** the claim assessment is evidence-based and the correct restoration scope is established.
+
+## Actors
+
+- **Primary:** [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Should Have** — Independent inspection is not required for every water damage claim but is critical for complex, high-value, or disputed claims.
+
+## Acceptance Criteria
+
+- **GIVEN** a claims handler has determined that a besiktningsman inspection is needed
+  **WHEN** the claims handler requests an inspection
+  **THEN** the system creates an inspection order linked to the claim and dispatches it to a contracted besiktningsman
+
+- **GIVEN** a besiktningsman has completed the inspection
+  **WHEN** the besiktningsman submits the inspection report
+  **THEN** the system stores the report linked to the claim, including cause determination, damage extent, affected structural elements, photos, and any identified construction defects (dolda fel)
+
+- **GIVEN** the inspection report identifies a construction defect (dolda fel) as the cause
+  **WHEN** the claims handler reviews the report
+  **THEN** the system flags the claim for potential subrogation against the seller or builder and records the defect details
+
+- **GIVEN** the inspection report is complete
+  **WHEN** the claims handler reviews all evidence
+  **THEN** the system provides a consolidated view of the moisture report (from saneringsfirma) and the inspection report side by side for informed decision-making
+
+## Inspection Triggers
+
+| Condition                                    | Inspection Required |
+| -------------------------------------------- | ------------------- |
+| Estimated cost exceeds SEK 200,000           | Yes                 |
+| Cause is disputed between BRF and individual | Yes                 |
+| Suspected construction defect (dolda fel)    | Yes                 |
+| Suspected fraud indicators                   | Yes                 |
+| Routine low-value claim with clear cause     | No                  |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: inspection findings must be considered promptly; inspections should not cause undue delay
+- **FSA-014** — Record keeping: inspection reports are part of the claims file and must be retained for 10 years
+- **GDPR-003** — Claims processing: inspection reports may contain personal data (property owner identity, photos of property interior); data minimization applies
+
+## Dependencies
+
+- Depends on US-HCW-004 (Receive Moisture Measurement Report)
+- Contracted besiktningsman network
+
+## Notes
+
+- Besiktningsman inspections are typically needed for only 20-30% of water damage claims
+- The inspection report may support or contradict the saneringsfirma's initial assessment
+- For dolda fel cases, the inspection report becomes key evidence for subrogation claims

--- a/docs/phase-2-home-property/user-stories/water-damage-moisture-report.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-moisture-report.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 13
+---
+
+# US-HCW-004: Receive Moisture Measurement Report
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** receive the saneringsfirma's moisture measurement report digitally,
+**so that** I can assess the damage scope and approve the restoration plan.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md)
+
+## Priority
+
+**Must Have** — Moisture measurement data is the foundation for assessing water damage scope, planning restoration, and estimating costs.
+
+## Acceptance Criteria
+
+- **GIVEN** a saneringsfirma has completed the initial emergency response
+  **WHEN** the restoration company submits the moisture measurement report
+  **THEN** the system receives and stores the report linked to the claim, including moisture levels by room, affected materials, and recommended drying plan
+
+- **GIVEN** a moisture measurement report has been received
+  **WHEN** the claims handler reviews the report
+  **THEN** the system displays the report with moisture readings, affected area measurements (square meters), material types affected, and the saneringsfirma's cost estimate for drying
+
+- **GIVEN** a moisture measurement report indicates extensive damage
+  **WHEN** the estimated restoration cost exceeds a configurable threshold
+  **THEN** the system flags the claim for senior claims handler review and potential besiktningsman inspection
+
+- **GIVEN** a claims handler has reviewed the moisture measurement report
+  **WHEN** the claims handler approves the drying plan
+  **THEN** the system updates the claim status to "Drying Approved" and notifies the saneringsfirma to proceed
+
+- **GIVEN** a claims handler questions the moisture measurement findings
+  **WHEN** the claims handler requests additional assessment
+  **THEN** the system notifies the saneringsfirma and optionally dispatches a [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md) for an independent assessment
+
+## Moisture Report Data
+
+| Field                     | Type      | Description                                          |
+| ------------------------- | --------- | ---------------------------------------------------- |
+| Report date               | Date      | When measurements were taken                         |
+| Rooms assessed            | List      | Each room with moisture readings                     |
+| Moisture levels           | Numeric[] | Readings per measurement point (relative humidity %) |
+| Affected materials        | List      | Concrete, wood, plaster, insulation, etc.            |
+| Affected area (m²)        | Numeric   | Total area requiring drying                          |
+| Drying equipment needed   | List      | Dehumidifiers, fans, heat panels                     |
+| Estimated drying duration | Text      | Expected time in weeks                               |
+| Estimated drying cost     | Currency  | Cost estimate for drying phase                       |
+| Photos                    | File[]    | Damage documentation photos                          |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: timely review of the moisture report prevents delays in the restoration process
+- **FSA-014** — Record keeping: moisture measurement reports must be retained as part of the claims file for 10 years
+- **GDPR-003** — Claims processing: reports may contain property owner details; data minimization applies
+
+## Dependencies
+
+- Depends on US-HCW-002 (Dispatch Restoration Company)
+- Saneringsfirma API integration for digital report submission
+
+## Notes
+
+- Moisture measurement technology includes pin-type moisture meters, non-destructive capacitance meters, and thermal imaging cameras
+- Initial moisture readings serve as the baseline for tracking drying progress
+- The saneringsfirma's report is the primary input for estimating total claim cost

--- a/docs/phase-2-home-property/user-stories/water-damage-registration.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-registration.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 12
+---
+
+# US-HCW-003: Register FNOL With Damage Classification
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** register the water damage FNOL with damage type, location, and suspected cause,
+**so that** the claim is properly categorized and routed for efficient handling.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal/customer.md)
+
+## Priority
+
+**Must Have** — Proper claim categorization at registration determines the investigation path, restoration approach, and coverage assessment.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage FNOL has been received (online or by phone)
+  **WHEN** the claims handler opens the claim for registration
+  **THEN** the system displays the FNOL details and a structured registration form with water damage-specific fields
+
+- **GIVEN** the claims handler is registering the claim
+  **WHEN** the claims handler selects the damage cause category
+  **THEN** the system provides subcategories: burst pipe (sprucket rör), appliance leak (maskinläckage — dishwasher, washing machine, refrigerator), bathroom membrane failure (tätskiktsbrott), frozen pipes (frysskada), roof leak (takläckage), and external water ingress (yttre vatten)
+
+- **GIVEN** the claims handler has entered all required fields
+  **WHEN** the claims handler submits the registration
+  **THEN** the system validates completeness, assigns a claims handler based on workload and specialization, and sets the claim status to "Registered"
+
+- **GIVEN** a claim involves a bostadsrätt property
+  **WHEN** the claims handler registers the claim
+  **THEN** the system flags the claim for BRF/individual responsibility determination and prompts the handler to record the BRF's building insurance details
+
+- **GIVEN** a claim involves multiple affected apartments in a BRF
+  **WHEN** the claims handler identifies additional affected units
+  **THEN** the system allows creating linked claims for each affected apartment while maintaining a parent claim for coordination
+
+## Damage Cause Categories
+
+| Category                  | Swedish Term   | Typical Coverage                              |
+| ------------------------- | -------------- | --------------------------------------------- |
+| Burst pipe                | Sprucket rör   | Hemförsäkring / Villahemförsäkring            |
+| Appliance leak            | Maskinläckage  | Hemförsäkring / Villahemförsäkring            |
+| Bathroom membrane failure | Tätskiktsbrott | Depends on age and BRF/individual boundary    |
+| Frozen pipes              | Frysskada      | Hemförsäkring / Villahemförsäkring            |
+| Roof leak                 | Takläckage     | Villahemförsäkring / BRF fastighetsförsäkring |
+| External water ingress    | Yttre vatten   | Varies by policy terms                        |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: proper registration ensures claims are not delayed by misclassification
+- **FSA-014** — Record keeping: the complete registration record must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at registration must follow data minimization; collect only what is necessary
+
+## Dependencies
+
+- Depends on US-HCW-001 (Water Damage FNOL)
+- BRF building insurance lookup capability
+
+## Notes
+
+- The damage cause category directly influences the investigation path and coverage determination
+- For BRF claims, the claims handler must record both the individual's policy number and the BRF's building insurance policy number
+- Multi-apartment claims require a coordinated approach with a single lead claims handler

--- a/docs/phase-2-home-property/user-stories/water-damage-repair-approval.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-repair-approval.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 18
+---
+
+# US-HCW-009: Approve Repair Scope and Contractor
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** approve the repair scope and contractor after drying is complete,
+**so that** restoration costs are controlled and the customer's property is properly restored.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal/customer.md)
+
+## Priority
+
+**Must Have** — Repair scope approval is a critical cost control step and ensures the restoration matches the covered damage.
+
+## Acceptance Criteria
+
+- **GIVEN** drying is complete and the final torkprotokoll has been approved
+  **WHEN** the claims handler reviews the claim for repair phase
+  **THEN** the system presents the damage assessment, approved drying costs, and prompts for repair scope definition
+
+- **GIVEN** a repair scope has been defined
+  **WHEN** the claims handler reviews contractor quotes
+  **THEN** the system allows the handler to compare quotes, select a contractor, and approve the repair budget
+
+- **GIVEN** the repair cost exceeds a configurable threshold
+  **WHEN** the claims handler submits the approval
+  **THEN** the system requires senior claims handler authorization before the repair can proceed
+
+- **GIVEN** the claims handler has approved the repair scope
+  **WHEN** the approval is confirmed
+  **THEN** the system notifies the customer of the approved scope, selected contractor, and estimated repair timeline
+
+- **GIVEN** the customer requests specific materials or finishes beyond standard replacement
+  **WHEN** the upgrade cost exceeds the insured replacement value
+  **THEN** the system records the customer's choice and calculates the customer's additional out-of-pocket cost (mellanskillnad)
+
+## Repair Approval Thresholds
+
+| Total Repair Cost     | Approval Authority    |
+| --------------------- | --------------------- |
+| Up to SEK 50,000      | Claims handler        |
+| SEK 50,001 -- 200,000 | Senior claims handler |
+| Over SEK 200,000      | Claims manager        |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: repair approval must not cause undue delay; the customer is entitled to timely restoration
+- **FSA-004** — Consumer protection: the customer must be informed of the approved repair scope and their right to choose a contractor (subject to policy terms)
+
+## Dependencies
+
+- Depends on US-HCW-008 (Submit Drying Protocol) — drying must be complete
+- Depends on US-HCW-004 (Receive Moisture Measurement Report) — for damage scope
+- Contractor network and pricing agreements
+
+## Notes
+
+- Customers generally have the right to choose their own contractor, but the insurer may limit reimbursement to the cost of a network contractor
+- Repair scope must match the original condition — betterment is the customer's responsibility
+- For BRF claims, repair scope approval may require coordination between the BRF and individual member

--- a/docs/phase-2-home-property/user-stories/water-damage-settlement.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-settlement.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 20
+---
+
+# US-HCW-011: Calculate Settlement With Age Deduction
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** calculate the settlement amount considering åldersavdrag (age deduction) for affected materials and fixtures,
+**so that** the payment reflects fair value based on the age and condition of the damaged property.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal/customer.md)
+
+## Priority
+
+**Must Have** — Age deduction is a standard element of Swedish home insurance settlement calculations and must be applied correctly.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim has been approved and the repair scope is defined
+  **WHEN** the claims handler calculates the settlement
+  **THEN** the system applies åldersavdrag (age deduction) based on the age and type of damaged materials, using the insurer's published deduction tables
+
+- **GIVEN** the settlement calculation includes age deduction
+  **WHEN** the system calculates the net settlement
+  **THEN** the calculation follows the formula: Replacement cost − Age deduction − Deductible (självrisk) = Net settlement amount
+
+- **GIVEN** the settlement has been calculated
+  **WHEN** the claims handler presents the settlement to the customer
+  **THEN** the system generates a clear breakdown showing replacement cost, age deduction per item category, deductible, and the net settlement amount
+
+- **GIVEN** a customer disputes the age deduction applied
+  **WHEN** the customer provides evidence that the materials were newer than assumed
+  **THEN** the claims handler can override the default age deduction with documented justification
+
+- **GIVEN** the claim involves both BRF building insurance and individual bostadsrättsförsäkring
+  **WHEN** the settlement is calculated
+  **THEN** the system calculates separate settlement amounts for the BRF portion and the individual portion, each with their own deductibles and age deductions
+
+## Age Deduction (Åldersavdrag) Tables
+
+| Material/Fixture                  | Deduction Start | Annual Deduction | Maximum Deduction |
+| --------------------------------- | --------------- | ---------------- | ----------------- |
+| Bathroom waterproofing (tätskikt) | Year 6          | 2% per year      | 50%               |
+| Kitchen appliances                | Year 3          | 5% per year      | 70%               |
+| Flooring (wood/laminate)          | Year 5          | 3% per year      | 60%               |
+| Pipes (visible)                   | Year 10         | 2% per year      | 50%               |
+| Pipes (concealed)                 | Year 15         | 1% per year      | 40%               |
+| Interior walls/ceilings           | Year 5          | 2% per year      | 50%               |
+
+## Settlement Formula
+
+```text
+Replacement Cost (per item category)
+− Åldersavdrag (age deduction per category)
+= Adjusted Replacement Value
+
+Total Adjusted Replacement Value
++ Drying Costs (approved)
++ Temporary Housing Costs (if applicable)
+− Självrisk (deductible)
+= Net Settlement Amount
+```
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: settlement amounts must be fair, transparently calculated, and paid without undue delay
+- **FSA-004** — Consumer protection: the age deduction calculation must be explained to the customer in plain language
+- **FSA-014** — Record keeping: settlement calculations and all supporting documentation must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCW-009 (Approve Repair Scope and Contractor) — repair scope defines settlement items
+- Depends on US-HCW-008 (Submit Drying Protocol) — drying costs are part of the settlement
+- Depends on US-HCW-010 (Temporary Housing) — housing costs included if applicable
+- Age deduction tables maintained in system configuration
+
+## Notes
+
+- Age deduction tables are product-specific and may vary between insurers; TryggFörsäkring's tables must be published in the policy terms
+- Customers often find age deductions surprising — clear communication at settlement is essential to reduce complaints
+- For newly renovated bathrooms, the customer should be advised to save receipts as proof of renovation date

--- a/docs/phase-2-home-property/user-stories/water-damage-temporary-housing.md
+++ b/docs/phase-2-home-property/user-stories/water-damage-temporary-housing.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 19
+---
+
+# US-HCW-010: Arrange Temporary Housing (Evakueringsboende)
+
+## User Story
+
+**As a** customer (privatkund),
+**I want** temporary housing (evakueringsboende) if my home is uninhabitable during water damage restoration,
+**so that** my family has a place to stay while repairs are completed.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Temporary housing is a core coverage component of Swedish home insurance when the property is uninhabitable.
+
+## Acceptance Criteria
+
+- **GIVEN** a water damage claim has rendered the customer's home uninhabitable
+  **WHEN** the claims handler or customer requests temporary housing
+  **THEN** the system creates a temporary housing order linked to the claim and initiates the booking process
+
+- **GIVEN** a temporary housing request has been approved
+  **WHEN** the system arranges accommodation
+  **THEN** the system records the accommodation details (type, location, daily cost, start date) and notifies the customer with booking confirmation
+
+- **GIVEN** temporary housing is in effect
+  **WHEN** the daily cost exceeds the policy's coverage limit for temporary accommodation
+  **THEN** the system alerts the claims handler and notifies the customer of the coverage limit and any excess cost they must bear
+
+- **GIVEN** the customer's home has been restored to habitable condition
+  **WHEN** the claims handler confirms restoration is complete
+  **THEN** the system ends the temporary housing period, records the total cost, and includes it in the claim settlement
+
+- **GIVEN** the drying and repair process extends beyond the initially estimated timeline
+  **WHEN** the temporary housing period needs extension
+  **THEN** the claims handler can extend the housing order, and the system updates the cost projection and notifies the customer
+
+## Temporary Housing Coverage
+
+| Accommodation Type          | Typical Daily Cost | Notes                      |
+| --------------------------- | ------------------ | -------------------------- |
+| Hotel                       | SEK 1,000 -- 2,000 | Short-term (up to 2 weeks) |
+| Furnished apartment         | SEK 500 -- 1,500   | Medium-term (2-8 weeks)    |
+| Extended-stay accommodation | SEK 400 -- 1,000   | Long-term (8+ weeks)       |
+
+## Temporary Housing Data Model
+
+| Field              | Type      | Required       | Description                               |
+| ------------------ | --------- | -------------- | ----------------------------------------- |
+| Housing ID         | String    | Auto-generated | Unique identifier                         |
+| Claim ID           | Reference | Yes            | Link to the water damage claim            |
+| Start date         | Date      | Yes            | When temporary housing begins             |
+| End date           | Date      | No             | When housing ends (updated on completion) |
+| Accommodation type | Enum      | Yes            | Hotel, furnished apartment, extended-stay |
+| Daily cost         | Currency  | Yes            | Daily accommodation cost                  |
+| Total cost         | Currency  | Calculated     | Accumulated cost over housing period      |
+| Coverage limit     | Currency  | Yes            | Policy maximum for temporary housing      |
+| Provider           | String    | No             | Accommodation provider name               |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: temporary housing must be arranged promptly when the home is uninhabitable
+- **FSA-004** — Consumer protection: the customer must be informed of their temporary housing entitlement and any coverage limits
+- **FSA-012** — Insurance contract disclosure: temporary housing coverage terms must be clearly stated in the policy
+
+## Dependencies
+
+- Depends on US-HCW-001 (Water Damage FNOL)
+- Temporary housing provider agreements or booking integration
+
+## Notes
+
+- Temporary housing is typically covered for the duration of restoration, subject to policy limits
+- For families with children or pets, accommodation suitability is an important consideration
+- The customer may choose to stay with friends or family and receive a reduced daily allowance instead
+- Temporary housing costs can be a significant portion of the total claim cost for large water damage claims


### PR DESCRIPTION
## Summary
- Add 15 user stories (US-HCW-001 to US-HCW-015) covering the complete water damage claim lifecycle for Phase 2 Home & Property Insurance
- Add use case UC-HCW-001 (Water Damage Claim Lifecycle) with full main flow, 5 alternative flows, 2 exception flows, data model, business rules, and regulatory traceability
- Create Phase 2 user-stories and use-cases index files with water damage claims section

## Changes
- New directory: `docs/phase-2-home-property/user-stories/` — 15 water damage user stories + index
- New directory: `docs/phase-2-home-property/use-cases/` — UC-HCW-001 lifecycle use case + index
- Stories cover: FNOL (24/7), saneringsfirma dispatch, damage classification, moisture measurement, BRF/individual responsibility, besiktningsman inspection, drying progress tracking, torkprotokoll, repair approval, temporary housing, settlement with åldersavdrag, deductible, cross-claim coordination, final inspection, and claim closure
- Data model: WaterDamageClaim, RestorationOrder, DryingProtocol, TemporaryHousing
- External integrations: Saneringsfirma API (Polygon/BELFOR), BRF building insurer, temporary housing provider
- Regulatory traceability: FSA-004, FSA-005, FSA-010, FSA-011, FSA-012, FSA-014, GDPR-003, GDPR-006

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting check passes
- [x] Docusaurus build succeeds (links, frontmatter validated)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)