### PR TITLE
docs(#73): Add Phase 2 fire & natural event user stories and use case

### DIFF
--- a/docs/phase-2-home-property/use-cases/index.md
+++ b/docs/phase-2-home-property/use-cases/index.md
@@ -30,6 +30,12 @@ covers:
 | ------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------- |
 | [UC-HCW-001](uc-water-damage-lifecycle.md) | Water Damage Claim Lifecycle | End-to-end flow from FNOL through emergency response, drying, repair, settlement, and closure |
 
+## Fire & Natural Events (Brand/Naturhändelser)
+
+| ID                                               | Title                              | Scope                                                                                                                         |
+| ------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [UC-HCF-001](uc-fire-natural-event-lifecycle.md) | Fire/Natural Event Claim Lifecycle | End-to-end flow from emergency FNOL through structural assessment, total/partial loss determination, restoration, and closure |
+
 ## Burglary and Theft
 
 The [Burglary Claim Processing](burglary-and-theft.md) use case (UC-HCB-001)

--- a/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
@@ -1,0 +1,308 @@
+---
+sidebar_position: 20
+---
+
+# UC-HCF-001: Fire/Natural Event Claim Lifecycle
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a fire or natural event (brand/naturhändelse) claim — from emergency FNOL through structural assessment, total/partial loss determination, restoration or rebuild, settlement, and closure. Fire and natural event claims are low-frequency but high-severity, involving evacuation, total loss assessment, environmental hazard remediation, multi-party coordination, and extended temporary housing. The lifecycle differs significantly from water damage claims due to the scale of destruction, involvement of räddningstjänsten (fire department), and the total loss vs rebuild decision.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md), [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Fire Department (Räddningstjänsten)](../../actors/external/fire-department.md), [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md), [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md), [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md)
+
+## Preconditions
+
+1. The customer holds an active home insurance policy (hemförsäkring, villahemförsäkring, or bostadsrättsförsäkring) with TryggFörsäkring
+2. A fire, storm, flood, lightning strike, or other natural event has occurred at the insured property
+3. The customer has access to the web portal, mobile app, or claims phone line
+
+## Postconditions
+
+**Success:**
+
+- Claim is settled and closed with full documentation
+- Property has been repaired or rebuilt, or cash settlement has been paid
+- Customer has received the settlement amount (minus deductible and any age deductions or underinsurance adjustments)
+- Temporary housing has been provided for the duration of displacement
+- BRF/individual responsibility has been determined (if applicable)
+- Subrogation has been pursued against responsible third parties (if applicable)
+- Claims data has been recorded for underwriting risk assessment and catastrophe reserve reporting
+
+**Failure:**
+
+- Claim is denied with documented reason (e.g., excluded peril, lapsed policy, arson by policyholder)
+- Customer has been informed of the denial reason and FSA complaints procedure
+- Emergency temporary housing may still be provided pending investigation
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[1. Customer reports fire/natural event] --> B[2. FNOL registration and classification]
+    B --> C{Property habitable?}
+    C -->|No| D[3a. Arrange temporary housing]
+    C -->|Yes| E[3. Obtain räddningstjänsten incident report]
+    D --> E
+    E --> F[4. Besiktningsman inspects property]
+    F --> G{Environmental hazards?}
+    G -->|Yes| H[5a. Environmental remediation]
+    G -->|No| I{Total loss or partial loss?}
+    H --> I
+    I -->|Total loss| J[6. Calculate total loss settlement]
+    I -->|Partial loss| K[7. Approve repair scope and contractors]
+    J --> L{Customer rebuilds?}
+    L -->|Yes| M[8a. Coordinate rebuild]
+    L -->|No| N[8b. Process cash settlement]
+    K --> O[9. Contractor performs repairs]
+    M --> P[10. Staged payments during rebuild]
+    N --> Q[11. Process settlement payment]
+    O --> R[12. Final inspection]
+    P --> R
+    R --> S{Restoration satisfactory?}
+    S -->|No| O
+    S -->|Yes| T[13. Close claim and update risk data]
+    Q --> T
+
+    style A fill:#e1f5fe
+    style T fill:#e8f5e9
+    style D fill:#fff3e0
+    style H fill:#fff3e0
+    style J fill:#fce4ec
+    style N fill:#fce4ec
+```
+
+## Main Flow (Fire/Natural Event Claim Lifecycle)
+
+| Step | Actor          | Action                                                                              | System Response                                                                   | Reference                                                             |
+| ---- | -------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1    | Customer       | Reports fire or natural event via web, app, or phone (available 24/7)               | Creates FNOL record with claim number, flags as high-priority, sends confirmation | [US-HCF-001](../user-stories/fire-natural-fnol.md)                    |
+| 2    | Claims Handler | Registers FNOL with event type, damage extent, and habitability status              | Validates coverage, classifies event type, assigns claims handler                 | [US-HCF-003](../user-stories/fire-natural-event-classification.md)    |
+| 3    | Claims Handler | Requests räddningstjänsten incident report                                          | Records document request, tracks report receipt                                   | [US-HCF-002](../user-stories/fire-natural-incident-report.md)         |
+| 4    | Besiktningsman | Inspects property for structural integrity and safety                               | Records inspection report, structural assessment, and hazard findings             | [US-HCF-005](../user-stories/fire-natural-structural-inspection.md)   |
+| 5    | Claims Handler | Reviews inspection; checks for environmental hazards                                | Records hazard assessment; blocks repair if remediation needed                    | [US-HCF-006](../user-stories/fire-natural-environmental-hazards.md)   |
+| 6    | Claims Handler | Determines total loss or partial loss based on inspection and cost analysis         | Activates the appropriate settlement path                                         | [US-HCF-004](../user-stories/fire-natural-total-loss-assessment.md)   |
+| 7    | Claims Handler | For total loss: calculates settlement (rebuild cost or sum insured)                 | Generates settlement breakdown with underinsurance check                          | [US-HCF-007](../user-stories/fire-natural-valuation.md)               |
+| 8    | Claims Handler | Coordinates with contractors for repair (partial) or rebuild (total)                | Records contractor assignment, scope, and budget                                  | [US-HCF-008](../user-stories/fire-natural-contractor-coordination.md) |
+| 9    | Contractor     | Performs repairs or rebuild per approved scope                                      | Tracks progress, costs, and milestones                                            | [US-HCF-008](../user-stories/fire-natural-contractor-coordination.md) |
+| 10   | Claims Handler | Processes settlement payments (staged for rebuilds, lump sum for cash settlements)  | Records payment details, updates claim status                                     | [US-HCF-007](../user-stories/fire-natural-valuation.md)               |
+| 11   | Claims Handler | Verifies restoration is complete via final inspection or customer sign-off          | Records inspection results and customer acceptance                                | [US-HCF-008](../user-stories/fire-natural-contractor-coordination.md) |
+| 12   | Claims Handler | Pursues subrogation against responsible third party if applicable                   | Tracks subrogation separately from customer settlement                            | [US-HCF-011](../user-stories/fire-natural-subrogation.md)             |
+| 13   | System         | Closes claim and records data for risk assessment and catastrophe reserve reporting | Archives claim file, updates property claims history and geographic risk data     | [US-HCF-012](../user-stories/fire-natural-risk-update.md)             |
+
+## Alternative Flow: Emergency Temporary Housing
+
+| Step | Actor          | Action                                                                | System Response                                               |
+| ---- | -------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1a.1 | Customer       | Reports property is uninhabitable during FNOL                         | Flags claim for immediate temporary housing                   |
+| 1a.2 | Claims Handler | Approves temporary housing and arranges accommodation                 | Creates housing order, books accommodation, notifies customer |
+| 1a.3 | System         | Monitors temporary housing duration and costs against policy limits   | Alerts claims handler at 80% of coverage limit                |
+| 1a.4 | Claims Handler | Extends housing as needed during rebuild; ends when property restored | Records total housing cost, includes in settlement            |
+
+Reference: [US-HCF-009](../user-stories/fire-natural-temporary-housing.md)
+
+## Alternative Flow: Multi-Unit Event (Apartment Building)
+
+| Step | Actor          | Action                                                                  | System Response                                   |
+| ---- | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------- |
+| 2a.1 | Claims Handler | Identifies that multiple units are affected                             | Creates parent event record, links all claims     |
+| 2a.2 | Claims Handler | Assigns lead handler for coordinated management                         | Links sub-claims to parent, shows event dashboard |
+| 2a.3 | Claims Handler | Coordinates shared contractors for building-level repairs               | Tracks progress per unit and overall timeline     |
+| 2a.4 | Claims Handler | Determines BRF building vs individual bostadsrättsförsäkring boundaries | Records responsibility split for each unit        |
+
+Reference: [US-HCF-010](../user-stories/fire-natural-multi-unit.md)
+
+## Alternative Flow: Catastrophe Response (Large-Scale Natural Event)
+
+| Step | Actor          | Action                                            | System Response                                                         |
+| ---- | -------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
+| 2b.1 | Claims Handler | Declares a catastrophe event (katastrof)          | Creates catastrophe event record with geographic scope                  |
+| 2b.2 | System         | Enables bulk claim registration for affected area | Simplified FNOL flow for affected policyholders                         |
+| 2b.3 | Claims Handler | Assigns dedicated claims team to the catastrophe  | Routes all linked claims to the dedicated team                          |
+| 2b.4 | System         | Generates aggregate reserve and exposure reports  | Reports total exposure by geographic zone for FSA catastrophe reporting |
+
+Reference: [US-HCF-010](../user-stories/fire-natural-multi-unit.md)
+
+## Alternative Flow: Environmental Hazard Remediation
+
+| Step | Actor                  | Action                                                 | System Response                                         |
+| ---- | ---------------------- | ------------------------------------------------------ | ------------------------------------------------------- |
+| 5a.1 | Besiktningsman         | Identifies environmental hazards (asbestos, PCB, lead) | Records hazard type and location                        |
+| 5a.2 | Claims Handler         | Orders specialized environmental remediation           | Creates remediation order, assigns certified contractor |
+| 5a.3 | Remediation Contractor | Performs remediation and submits certification         | Records certification, unblocks repair phase            |
+| 5a.4 | Claims Handler         | Includes remediation cost in claim total               | Updates claim cost breakdown                            |
+
+Reference: [US-HCF-006](../user-stories/fire-natural-environmental-hazards.md)
+
+## Alternative Flow: Fire Cause Under Investigation
+
+| Step | Actor          | Action                                                              | System Response                                                  |
+| ---- | -------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 3a.1 | Claims Handler | Receives incident report indicating pending brandorsaksutredning    | Flags claim as "Pending Cause Investigation"                     |
+| 3a.2 | Claims Handler | Continues assessment and temporary housing while investigation runs | Records that settlement decision is deferred for cause findings  |
+| 3a.3 | Claims Handler | Receives final cause determination                                  | Updates claim; if arson by policyholder, flags for denial review |
+
+Reference: [US-HCF-002](../user-stories/fire-natural-incident-report.md)
+
+## Alternative Flow: Underinsured Property
+
+| Step | Actor          | Action                                                                | System Response                                             |
+| ---- | -------------- | --------------------------------------------------------------------- | ----------------------------------------------------------- |
+| 7a.1 | System         | Detects sum insured is below estimated rebuild cost                   | Calculates underinsurance ratio and proportional settlement |
+| 7a.2 | Claims Handler | Explains underinsurance to the customer with proportional calculation | Records customer communication and underinsurance finding   |
+| 7a.3 | Customer       | Acknowledges or disputes the underinsurance determination             | Records acknowledgment or creates dispute record            |
+
+Reference: [US-HCF-007](../user-stories/fire-natural-valuation.md)
+
+## Exception Flow: Suspected Arson
+
+| Step | Actor          | Action                                    | System Response                                                             |
+| ---- | -------------- | ----------------------------------------- | --------------------------------------------------------------------------- |
+| 3b.1 | Claims Handler | Incident report indicates suspected arson | Flags claim for fraud investigation                                         |
+| 3b.2 | Claims Handler | Suspends settlement pending investigation | Records suspension reason, continues temporary housing                      |
+| 3b.3 | Claims Handler | Reviews investigation outcome             | If cleared: resumes settlement; if confirmed arson by insured: denies claim |
+
+Reference: [US-HCF-002](../user-stories/fire-natural-incident-report.md), [US-HCF-011](../user-stories/fire-natural-subrogation.md)
+
+## Validation Rules
+
+| Rule       | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------- |
+| VR-HCF-001 | Incident date must not be in the future                                         |
+| VR-HCF-002 | Incident date must fall within the policy's active coverage period              |
+| VR-HCF-003 | Property address must match the insured property on the policy                  |
+| VR-HCF-004 | Event type must be a covered peril under the policy terms                       |
+| VR-HCF-005 | Environmental remediation must be verified complete before repair phase         |
+| VR-HCF-006 | Total loss settlement must include underinsurance check                         |
+| VR-HCF-007 | Repair/rebuild cost exceeding threshold requires senior claims handler approval |
+| VR-HCF-008 | All required documentation must be complete before claim closure                |
+| VR-HCF-009 | Fire cause investigation must conclude before final settlement (if pending)     |
+
+## Data Model
+
+### FireNaturalEventClaim
+
+| Field                | Type      | Required       | Description                                                                       |
+| -------------------- | --------- | -------------- | --------------------------------------------------------------------------------- |
+| claimId              | String    | Auto-generated | Unique claim identifier (skadenummer)                                             |
+| policyId             | Reference | Yes            | Link to the insured policy                                                        |
+| eventDate            | Date      | Yes            | Date of the fire or natural event                                                 |
+| reportDate           | Timestamp | Auto-set       | Date and time of FNOL submission                                                  |
+| eventType            | Enum      | Yes            | Fire, storm, flood, lightning, explosion, other natural event                     |
+| secondaryEventType   | Enum      | No             | Secondary peril if multiple types involved                                        |
+| causeOfLoss          | Text      | No             | Determined cause (from incident report or investigation)                          |
+| propertyType         | Enum      | Yes            | Villa, bostadsrätt, hyresrätt                                                     |
+| propertyHabitable    | Boolean   | Yes            | Whether the property is safe for occupancy                                        |
+| lossClassification   | Enum      | No             | Total loss (totalskada) or partial loss (delskada)                                |
+| brfInvolved          | Boolean   | Yes            | Whether BRF coordination is required                                              |
+| brfPolicyId          | Reference | Conditional    | BRF building insurance policy (if applicable)                                     |
+| catastropheEventId   | Reference | No             | Link to parent catastrophe event (for multi-claim events)                         |
+| environmentalHazards | Boolean   | No             | Whether environmental hazards were identified                                     |
+| estimatedCost        | Currency  | No             | Initial cost estimate                                                             |
+| rebuildCost          | Currency  | No             | Estimated nybyggnadsvärde for total loss                                          |
+| sumInsured           | Currency  | Yes            | Policy's building sum insured (försäkringsbelopp)                                 |
+| underinsured         | Boolean   | No             | Whether underinsurance was detected                                               |
+| totalClaimCost       | Currency  | Calculated     | Final total cost (repair/rebuild + temporary housing + remediation)               |
+| status               | Enum      | Auto-set       | Emergency Reported, Classified, Under Assessment, Repair/Rebuild, Settled, Closed |
+| assignedHandler      | Reference | Auto-set       | Claims handler assigned to the claim                                              |
+
+### IncidentReport
+
+| Field                  | Type      | Required       | Description                                     |
+| ---------------------- | --------- | -------------- | ----------------------------------------------- |
+| reportId               | String    | Auto-generated | Unique report identifier                        |
+| claimId                | Reference | Yes            | Link to the fire/natural event claim            |
+| raddningstjanstenRef   | String    | Yes            | Räddningstjänsten's incident reference number   |
+| incidentDate           | Date      | Yes            | Official date and time of incident              |
+| causeCategory          | Enum      | Yes            | Fire, storm, flood, lightning, explosion, other |
+| causeDetermination     | Text      | No             | Detailed cause finding                          |
+| criminalSuspicion      | Boolean   | No             | Whether arson or criminal activity suspected    |
+| policeReportRef        | String    | Conditional    | Police report reference (if criminal suspicion) |
+| environmentalHazards   | Boolean   | No             | Whether hazardous materials were identified     |
+| causeInvestigationOpen | Boolean   | No             | Whether a brandorsaksutredning is pending       |
+
+### StructuralInspection
+
+| Field                | Type      | Required       | Description                                            |
+| -------------------- | --------- | -------------- | ------------------------------------------------------ |
+| inspectionId         | String    | Auto-generated | Unique inspection identifier                           |
+| claimId              | Reference | Yes            | Link to the fire/natural event claim                   |
+| inspectionDate       | Date      | Yes            | Date of on-site inspection                             |
+| inspectorName        | String    | Yes            | Besiktningsman name and certification number           |
+| structuralIntegrity  | Enum      | Yes            | Safe, unsafe, conditionally safe                       |
+| roofIntegrity        | Enum      | Yes            | Intact, partially damaged, destroyed                   |
+| utilitySystems       | Object    | Yes            | Status of electrical, plumbing, gas, heating           |
+| environmentalHazards | Boolean   | Yes            | Whether hazards found (asbestos, chemicals, etc.)      |
+| lossRecommendation   | Enum      | Yes            | Inspector's recommendation: total loss or partial loss |
+| estimatedDamageCost  | Currency  | No             | Preliminary cost estimate                              |
+
+### TemporaryHousing
+
+| Field             | Type      | Required       | Description                               |
+| ----------------- | --------- | -------------- | ----------------------------------------- |
+| housingId         | String    | Auto-generated | Unique housing record identifier          |
+| claimId           | Reference | Yes            | Link to the fire/natural event claim      |
+| startDate         | Date      | Yes            | Temporary housing start date              |
+| endDate           | Date      | No             | End date (updated on completion)          |
+| accommodationType | Enum      | Yes            | Hotel, furnished apartment, extended-stay |
+| dailyCost         | Currency  | Yes            | Daily accommodation cost                  |
+| totalCost         | Currency  | Calculated     | Total accumulated housing cost            |
+| coverageLimit     | Currency  | Yes            | Policy maximum for temporary housing      |
+| provider          | String    | No             | Accommodation provider name               |
+
+## Business Rules
+
+| Rule       | Description                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-HCF-001 | Fire/natural event claims are classified as high-priority and routed for immediate handling                                            |
+| BR-HCF-002 | Temporary housing must be arranged within 24 hours when property is uninhabitable                                                      |
+| BR-HCF-003 | Structural inspection must be scheduled within 48 hours of räddningstjänsten clearance                                                 |
+| BR-HCF-004 | Environmental remediation must be completed and certified before standard repair work begins                                           |
+| BR-HCF-005 | Total loss settlement is based on nybyggnadsvärde (rebuild cost) for fullvärdesförsäkring policies                                     |
+| BR-HCF-006 | Underinsurance triggers proportional settlement: claim amount x (sum insured / rebuild cost)                                           |
+| BR-HCF-007 | Repair or rebuild costs exceeding SEK 500,000 require senior claims handler approval                                                   |
+| BR-HCF-008 | The customer must not be left out of pocket for covered portions while subrogation is in progress                                      |
+| BR-HCF-009 | Catastrophe events must be reported to FSA per natural disaster reserve requirements                                                   |
+| BR-HCF-010 | Fire cause investigation must conclude before final settlement; temporary housing and emergency measures continue during investigation |
+
+## External Integrations
+
+| System                                          | Purpose                                                      | Data Exchanged                                                |
+| ----------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------- |
+| Räddningstjänsten                               | Incident reports for fire and natural event cause and extent | Incident reports, cause determinations, criminal referrals    |
+| Approved contractor network (ramavtalspartners) | Repair and rebuild coordination                              | Scope of work, progress updates, invoices                     |
+| Environmental remediation contractors           | Specialized hazard cleanup (asbestos, PCB, etc.)             | Remediation orders, certifications                            |
+| BRF building insurer                            | Cross-claim coordination for split-responsibility claims     | Claim details, responsibility determination, settlement split |
+| Temporary housing provider                      | Accommodation booking for uninhabitable properties           | Booking requests, availability, cost confirmation             |
+| Lantmäteriet                                    | Property data and building valuation                         | Property register data, rebuilding cost estimates             |
+| Police (Polismyndigheten)                       | Criminal investigation for arson cases                       | Police report references, investigation status                |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the entire claims lifecycle must proceed without undue delay; SLAs must be tracked from FNOL through settlement
+- **FSA-016** — Building valuation: total loss settlements must reflect adequate building valuation; underinsurance rules apply per proportional settlement formula
+- **FSA-018** — Natural disaster reserves: fire and natural event claims data must support catastrophe reserve calculations and FSA reporting by peril type and geography
+- **FSA-004** — Consumer protection: the customer must receive clear communication at each stage, particularly regarding total loss vs partial loss determination and settlement basis
+- **FSA-005** — Product governance: claims data must be available for product reviews
+- **FSA-003** — Solvency II compliance: catastrophe risk exposure data supports SCR calculations
+- **FSA-011** — Complaints handling: the customer must be informed of the complaints procedure if they dispute any aspect of the claim
+- **FSA-014** — Record keeping: the complete claims file must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data shared with contractors, inspectors, and housing providers must be limited to what is necessary
+- **GDPR-008** — Restoration company data sharing: data sharing with restoration companies and contractors must follow data minimization and be covered by data processing agreements
+
+## Related User Stories
+
+- [US-HCF-001](../user-stories/fire-natural-fnol.md) — Report Fire or Natural Event Emergency
+- [US-HCF-002](../user-stories/fire-natural-incident-report.md) — Obtain Räddningstjänsten Incident Report
+- [US-HCF-003](../user-stories/fire-natural-event-classification.md) — Classify Event Type and Coverage
+- [US-HCF-004](../user-stories/fire-natural-total-loss-assessment.md) — Assess Total Loss vs Partial Loss
+- [US-HCF-005](../user-stories/fire-natural-structural-inspection.md) — Inspect Property for Structural Integrity
+- [US-HCF-006](../user-stories/fire-natural-environmental-hazards.md) — Check for Environmental Hazards
+- [US-HCF-007](../user-stories/fire-natural-valuation.md) — Explain Rebuild Cost vs Market Value Settlement
+- [US-HCF-008](../user-stories/fire-natural-contractor-coordination.md) — Coordinate Contractors for Rebuild or Repair
+- [US-HCF-009](../user-stories/fire-natural-temporary-housing.md) — Provide Continued Temporary Housing During Rebuild
+- [US-HCF-010](../user-stories/fire-natural-multi-unit.md) — Manage Multi-Unit Claims
+- [US-HCF-011](../user-stories/fire-natural-subrogation.md) — Process Subrogation Against Responsible Third Party
+- [US-HCF-012](../user-stories/fire-natural-risk-update.md) — Flag Property for Updated Risk Assessment

--- a/docs/phase-2-home-property/user-stories/fire-natural-contractor-coordination.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-contractor-coordination.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 37
+---
+
+# US-HCF-008: Coordinate Contractors for Rebuild or Repair
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** coordinate with contractors for rebuild or repair,
+**so that** restoration begins promptly and meets quality standards.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md), [Customer (Privatkund)](../../actors/internal/customer.md)
+
+## Priority
+
+**Must Have** — Timely contractor engagement is critical for both partial loss repairs and total loss rebuilds. Delays in contractor coordination extend the customer's displacement and increase temporary housing costs.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been classified as partial loss and the repair scope is approved
+  **WHEN** the claims handler initiates contractor coordination
+  **THEN** the system presents the approved contractor network (ramavtalspartners) and allows the claims handler to assign a contractor or the customer to choose their own
+
+- **GIVEN** a fire/natural event claim has been classified as total loss and the customer chooses to rebuild
+  **WHEN** the claims handler initiates rebuild coordination
+  **THEN** the system creates a rebuild project record, tracks contractor selection, building permit status, and construction milestones
+
+- **GIVEN** a contractor has been selected
+  **WHEN** the claims handler confirms the assignment
+  **THEN** the system records the contractor details, sends the approved scope of work and budget to the contractor, and notifies the customer of the contractor assignment and expected timeline
+
+- **GIVEN** the customer prefers to use their own contractor instead of the insurer's network
+  **WHEN** the customer nominates a contractor
+  **THEN** the claims handler verifies the contractor's credentials and insurance, records the customer's choice, and notes that the insurer's responsibility is limited to the approved repair/rebuild cost
+
+- **GIVEN** repair or rebuild work is in progress
+  **WHEN** the contractor submits progress updates or invoices
+  **THEN** the system records the progress, tracks costs against the approved budget, and alerts the claims handler if costs approach or exceed the approved amount
+
+- **GIVEN** the repair cost exceeds the approved budget
+  **WHEN** the contractor submits a cost variation
+  **THEN** the system flags the variation for claims handler review and, if above the threshold, requires senior claims handler approval before authorizing additional costs
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: contractor coordination must not cause undue delay in the restoration process
+- **FSA-004** — Consumer protection: the customer has the right to choose their own contractor; the insurer must respect this choice while managing cost expectations
+- **GDPR-008** — Restoration company data sharing: personal data shared with contractors must follow data minimization; share only claim-relevant information
+- **FSA-014** — Record keeping: contractor assignments, scope of work, invoices, and progress records must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCF-004 (Assess Total Loss vs Partial Loss)
+- Depends on US-HCF-005 (Inspect Property for Structural Integrity)
+- Depends on US-HCF-006 (Check for Environmental Hazards) — remediation must be complete before repair
+- Approved contractor network (ramavtalspartners)
+
+## Notes
+
+- For total loss rebuilds, the process can take 12-18 months; milestone tracking is essential
+- The customer's right to choose their own contractor is protected, but the insurer only covers reasonable costs (up to the approved scope)
+- For partial loss repairs after fire, the contractor must verify that fire-damaged materials are fully removed before new materials are installed
+- Building permits (bygglov) may be required for significant structural repairs or rebuilds; the system should track permit status

--- a/docs/phase-2-home-property/user-stories/fire-natural-environmental-hazards.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-environmental-hazards.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 35
+---
+
+# US-HCF-006: Check for Environmental Hazards
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** check for environmental hazards (asbestos, chemicals) at the damaged property,
+**so that** cleanup is safe and compliant with environmental regulations.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md), [Restoration Company (Saneringsfirma)](../../actors/external/restoration-company.md)
+
+## Priority
+
+**Should Have** — Environmental hazard assessment is critical for pre-1980 buildings and properties with known hazardous materials. It ensures worker and occupant safety during restoration.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim involves a property built before 1980
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system automatically flags the claim for environmental hazard assessment, noting that pre-1980 buildings may contain asbestos in insulation, roofing, or pipe lagging
+
+- **GIVEN** the structural inspection (US-HCF-005) identifies environmental hazards
+  **WHEN** the claims handler reviews the inspection report
+  **THEN** the system records the hazard type (asbestos, lead paint, chemical contamination, other), location within the property, and estimated remediation scope
+
+- **GIVEN** environmental hazards have been confirmed
+  **WHEN** the claims handler arranges remediation
+  **THEN** the system creates a specialized remediation order, assigns a certified environmental cleanup contractor, and blocks standard repair work until remediation is completed and certified
+
+- **GIVEN** environmental remediation has been completed
+  **WHEN** the contractor submits the remediation certification
+  **THEN** the system records the certification, unblocks the repair phase, and includes the remediation cost in the claim total
+
+- **GIVEN** no environmental hazards are identified
+  **WHEN** the claims handler confirms the property is clear
+  **THEN** the system records the assessment result as "No hazards found" and allows the claim to proceed to the repair phase without remediation
+
+## Common Environmental Hazards
+
+| Hazard               | Prevalence in Swedish Buildings         | Impact on Claims Process                                                |
+| -------------------- | --------------------------------------- | ----------------------------------------------------------------------- |
+| Asbestos (asbest)    | Common in buildings built before 1977   | Must be removed by certified contractor before any demolition or repair |
+| Lead paint (blyfärg) | Found in pre-1970 buildings             | Requires safe removal procedures during restoration                     |
+| PCB (in sealants)    | Used in buildings from 1956--1973       | Environmental reporting required; specialized disposal                  |
+| Radon                | Varies by region and building material  | May require mitigation during rebuild                                   |
+| Chemical spill       | From damaged household/industrial items | Cleanup depends on substance; fire department may handle                |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: environmental remediation should not cause undue delay; the claims handler must communicate the timeline impact to the customer
+- **FSA-014** — Record keeping: hazard assessments, remediation orders, and certifications must be retained for 10 years
+- **GDPR-008** — Restoration company data sharing: property details shared with remediation contractors must follow data minimization principles
+
+## Dependencies
+
+- Depends on US-HCF-005 (Inspect Property for Structural Integrity)
+- Certified environmental cleanup contractors
+- Environmental regulations (Arbetsmiljöverket guidelines on asbestos handling)
+
+## Notes
+
+- Asbestos assessment is strongly recommended for any demolition or significant structural repair in pre-1980 buildings, even if not immediately visible
+- Environmental remediation costs can be substantial and are typically covered under the policy as a necessary part of the restoration
+- The customer should be informed that environmental remediation may extend the overall timeline but is essential for safety
+- Fire can disturb previously encapsulated asbestos, creating airborne exposure risk

--- a/docs/phase-2-home-property/user-stories/fire-natural-event-classification.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-event-classification.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 32
+---
+
+# US-HCF-003: Classify Event Type and Coverage
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** classify the event type (fire, storm, flood, or lightning),
+**so that** the correct coverage and claims process apply.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** System
+
+## Priority
+
+**Must Have** — Correct event classification determines which coverage terms, deductibles, and settlement paths apply. Misclassification leads to incorrect settlements.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been registered
+  **WHEN** the claims handler classifies the event
+  **THEN** the system presents the event categories: fire (brand), storm (storm), flood (översvämning), lightning (blixtnedslag), explosion (explosion), and other natural event (annan naturhändelse)
+
+- **GIVEN** the claims handler selects an event type
+  **WHEN** the system applies the classification
+  **THEN** the system retrieves the applicable policy coverage terms, deductible (självrisk), and any event-specific sub-limits or exclusions for that event type
+
+- **GIVEN** the event type is classified as flood (översvämning)
+  **WHEN** the system checks coverage
+  **THEN** the system verifies whether the policy includes flood coverage, as some basic policies exclude flood from natural perils, and alerts the claims handler if coverage is excluded or sub-limited
+
+- **GIVEN** the event may involve multiple peril types (e.g., storm causes flooding, lightning causes fire)
+  **WHEN** the claims handler classifies the event
+  **THEN** the system allows a primary and secondary event type to be recorded, with the primary type determining the settlement path
+
+- **GIVEN** a large-scale natural event affects multiple policyholders
+  **WHEN** the claims handler classifies the event
+  **THEN** the system allows linking the claim to a catastrophe event record (katastrof) so that all related claims are grouped for monitoring and reserve management
+
+- **GIVEN** the classification is complete
+  **WHEN** the system updates the claim record
+  **THEN** the claim status advances to "Classified" and the applicable coverage terms are attached to the claim for reference during assessment and settlement
+
+## Event Type Reference
+
+| Event Type          | Swedish Term        | Typical Coverage        | Common Sub-limits             |
+| ------------------- | ------------------- | ----------------------- | ----------------------------- |
+| Fire                | Brand               | Always covered          | None (standard coverage)      |
+| Storm               | Storm               | Covered if wind >21 m/s | May have higher deductible    |
+| Flood               | Översvämning        | Varies by policy tier   | Often sub-limited or excluded |
+| Lightning           | Blixtnedslag        | Always covered          | Electrical damage sub-limit   |
+| Explosion           | Explosion           | Always covered          | None (standard coverage)      |
+| Other natural event | Annan naturhändelse | Per policy terms        | Case-by-case assessment       |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: correct classification ensures the right coverage terms are applied, supporting a fair outcome
+- **FSA-004** — Consumer protection: the customer must be informed which event type classification has been applied and how it affects their coverage
+- **FSA-018** — Natural disaster reserves: event classification feeds into catastrophe reserve reporting by peril type
+- **FSA-014** — Record keeping: the classification rationale must be documented and retained
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Policy product configuration with coverage terms per event type
+- Catastrophe event register for large-scale events
+
+## Notes
+
+- Classification should be based on the primary cause of loss, consistent with the räddningstjänsten incident report when available
+- For catastrophe events (e.g., Gävle 2021 flooding), the system should support bulk classification and grouping
+- Some policies have different deductibles for different natural perils — the classification directly affects the customer's out-of-pocket cost
+- The claims handler may reclassify the event if new information (e.g., incident report) changes the determination

--- a/docs/phase-2-home-property/user-stories/fire-natural-fnol.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-fnol.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 30
+---
+
+# US-HCF-001: Report Fire or Natural Event Emergency
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** report a fire or natural event and get immediate help with temporary housing,
+**so that** my family is safe and the claims process begins without delay.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Fire and natural event claims are high-severity emergencies requiring immediate response. Rapid FNOL triggers evacuation support and secures the property.
+
+## Acceptance Criteria
+
+- **GIVEN** a customer has an active home insurance policy (hemförsäkring, villahemförsäkring, or bostadsrättsförsäkring)
+  **WHEN** the customer reports a fire or natural event via web, mobile app, or phone at any time
+  **THEN** the system accepts the report 24/7, creates a claim record with status "Emergency Reported", and routes it as high-priority
+
+- **GIVEN** a customer is reporting a fire or natural event
+  **WHEN** the customer selects the event type
+  **THEN** the system displays event categories: fire (brand), storm (storm), flood (översvämning), lightning (blixtnedslag), and other natural event (annan naturhändelse)
+
+- **GIVEN** a customer is filling out the fire/natural event FNOL form
+  **WHEN** the customer enters event details (event type, affected areas, whether property is habitable, whether emergency services have responded)
+  **THEN** the system validates that the incident date falls within the policy's active coverage period
+
+- **GIVEN** a customer has completed the fire/natural event FNOL
+  **WHEN** the customer submits the report
+  **THEN** the system creates a claim record with a unique claim number (skadenummer), links it to the policy, and sends the customer confirmation with the claim number, emergency contact numbers, and expected next steps
+
+- **GIVEN** a fire/natural event claim indicates the property is uninhabitable
+  **WHEN** the system processes the emergency report
+  **THEN** the system immediately flags the claim for temporary housing (evakueringsboende) and notifies the claims handler
+
+- **GIVEN** a customer must verify their identity for the claim
+  **WHEN** the customer signs in
+  **THEN** the system authenticates the customer via [BankID](../../actors/external/bankid.md)
+
+## Data Captured at FNOL
+
+| Field                        | Required    | Description                                            |
+| ---------------------------- | ----------- | ------------------------------------------------------ |
+| Incident date and time       | Yes         | When the fire/natural event occurred or was discovered |
+| Property address             | Yes         | Address of the affected property                       |
+| Property type                | Yes         | Villa, bostadsrätt, or hyresrätt                       |
+| Event type                   | Yes         | Fire, storm, flood, lightning, other natural event     |
+| Property habitable           | Yes         | Whether the property is safe for occupancy             |
+| Emergency services contacted | Yes         | Whether räddningstjänsten has been called              |
+| Affected areas               | Yes         | Which parts of the property are damaged                |
+| Injuries reported            | No          | Whether any personal injuries occurred                 |
+| Emergency measures taken     | No          | What the customer has done (evacuated, shut utilities) |
+| Photos                       | No          | Damage photos if safely obtainable                     |
+| BRF contact information      | Conditional | Required for bostadsrätt claims                        |
+| Räddningstjänsten ref number | No          | Fire department incident reference if available        |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the claims process must begin promptly upon FNOL; 24/7 availability ensures no undue delay for emergency claims
+- **FSA-014** — Record keeping: the FNOL and all associated data must be retained for 10 years
+- **GDPR-003** — Claims processing: personal data collected at FNOL must follow data minimization principles; collect only what is necessary for the claim
+- **FSA-004** — Consumer protection: the customer must receive clear confirmation, emergency contacts, and next-step information
+
+## Dependencies
+
+- Active home insurance policy must exist
+- Actor definitions (Customer, Claims Handler)
+- BankID integration for identity verification
+- 24/7 emergency service integration
+
+## Notes
+
+- Fire and natural event claims are typically high-severity with significant property damage; priority routing is essential
+- Customers should be guided to ensure personal safety first, then contact räddningstjänsten before filing the claim
+- Phone-reported FNOL follows the same registration process as online, with the claims handler entering details on behalf of the customer
+- For multi-unit events (e.g., apartment building fire), each affected unit generates a separate claim linked to a parent event

--- a/docs/phase-2-home-property/user-stories/fire-natural-incident-report.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-incident-report.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 31
+---
+
+# US-HCF-002: Obtain Räddningstjänsten Incident Report
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want** the räddningstjänsten incident report (insatsrapport),
+**so that** the cause and extent of the fire or natural event are officially documented.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Fire Department (Räddningstjänsten)](../../actors/external/fire-department.md)
+
+## Priority
+
+**Must Have** — The fire department incident report is the primary official record of cause and extent for fire and natural event claims. It is essential for liability determination and settlement.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been registered
+  **WHEN** the claims handler requests the räddningstjänsten incident report
+  **THEN** the system creates a document request linked to the claim and records the request date
+
+- **GIVEN** an incident report request has been sent
+  **WHEN** the fire department provides the insatsrapport
+  **THEN** the claims handler uploads the report to the claim file, and the system records: incident cause, extent of damage, actions taken by räddningstjänsten, and whether a fire cause investigation (brandorsaksutredning) is pending
+
+- **GIVEN** the incident report indicates the fire cause is under investigation
+  **WHEN** the claims handler reviews the report
+  **THEN** the system flags the claim as "Pending Cause Investigation" and prevents final settlement until the investigation is concluded
+
+- **GIVEN** the incident report has been received and reviewed
+  **WHEN** the claims handler classifies the event based on the report
+  **THEN** the system validates that the reported cause is a covered peril under the customer's policy terms
+
+- **GIVEN** the incident report indicates suspected arson or criminal activity
+  **WHEN** the claims handler reviews the report
+  **THEN** the system flags the claim for fraud investigation and records the police report reference number
+
+## Incident Report Data
+
+| Field                     | Type    | Description                                                  |
+| ------------------------- | ------- | ------------------------------------------------------------ |
+| Incident reference number | String  | Räddningstjänsten's reference number                         |
+| Incident date and time    | Date    | Official date and time of the incident                       |
+| Incident type             | Enum    | Fire, storm, flood, lightning, explosion, other              |
+| Cause determination       | Text    | Determined or suspected cause of the event                   |
+| Extent of damage          | Text    | Description of damage scope                                  |
+| Actions taken             | Text    | Fire department response actions                             |
+| Fire cause investigation  | Boolean | Whether a brandorsaksutredning is pending                    |
+| Criminal suspicion        | Boolean | Whether criminal activity (e.g., arson) is suspected         |
+| Police report reference   | String  | Reference number for any associated police report            |
+| Environmental hazards     | Boolean | Whether hazardous materials were identified (asbestos, etc.) |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the incident report is a key evidence document; delays in obtaining it must not cause undue delay in the overall claims process
+- **FSA-014** — Record keeping: the incident report must be retained as part of the claim file for 10 years
+- **GDPR-003** — Claims processing: personal data in the incident report must be processed under data minimization principles
+- **GDPR-008** — Restoration company data sharing: incident report details may be shared with contractors only as needed for restoration
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Fire department actor definition
+- Integration or manual process for requesting and receiving insatsrapporter
+
+## Notes
+
+- Räddningstjänsten incident reports are public documents (offentlig handling) but may take days to weeks to become available
+- For large-scale events (storms, flooding), incident reports may cover multiple properties; the claims handler must extract the relevant portions
+- Fire cause investigations (brandorsaksutredning) are conducted by the fire department or police and may take several weeks or months
+- The claims handler should begin the assessment process in parallel while waiting for the incident report, to avoid unnecessary delays

--- a/docs/phase-2-home-property/user-stories/fire-natural-multi-unit.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-multi-unit.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 39
+---
+
+# US-HCF-010: Manage Multi-Unit Claims
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** manage multi-unit claims (e.g., apartment building fire affecting multiple households),
+**so that** all affected policyholders are handled fairly and coordination is maintained.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Customer (Privatkund)](../../actors/internal/customer.md), [BRF Board (BRF-styrelse)](../../actors/external/brf-board.md)
+
+## Priority
+
+**Must Have** — Apartment building fires and natural events can affect dozens of policyholders simultaneously. Without coordinated claims handling, individual customers receive inconsistent treatment and the insurer faces operational chaos.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event affects multiple units in the same building
+  **WHEN** the claims handler identifies the multi-unit impact
+  **THEN** the system creates a parent event record (katastrof/storskada) and links all individual claims to it for coordinated management
+
+- **GIVEN** a parent event record exists
+  **WHEN** additional affected policyholders report claims
+  **THEN** the system automatically suggests linking the new claim to the existing parent event based on matching property address and incident date
+
+- **GIVEN** multiple claims are linked to a parent event
+  **WHEN** the claims handler views the event dashboard
+  **THEN** the system displays: total number of affected units, claim status per unit, total estimated cost, shared contractor assignments, and overall timeline
+
+- **GIVEN** a multi-unit event involves a BRF building
+  **WHEN** the claims handler coordinates with the BRF board
+  **THEN** the system records the BRF building insurance policy, identifies the boundary between BRF building insurance (structural) and individual bostadsrättsförsäkring (interior/contents), and tracks settlement for each layer
+
+- **GIVEN** a multi-unit event requires coordinated contractor work
+  **WHEN** the claims handler assigns contractors
+  **THEN** the system supports assigning a shared contractor for building-level repairs (roof, structure, shared spaces) while allowing individual contractors for unit-level repairs
+
+- **GIVEN** a catastrophe event (katastrof) is declared for a large-scale natural event
+  **WHEN** the system activates catastrophe response
+  **THEN** the system enables: bulk claim registration, simplified FNOL for affected policyholders, dedicated claims team assignment, and aggregate reserve reporting per FSA-018
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: all affected policyholders must receive fair and consistent treatment; coordination must not delay individual settlements
+- **FSA-018** — Natural disaster reserves: multi-unit and catastrophe events must be tracked for reserve management and FSA catastrophe reporting
+- **FSA-004** — Consumer protection: each affected customer must receive individual communication and support, even in a coordinated event
+- **GDPR-003** — Claims processing: personal data from individual claims must not be shared between affected policyholders; each claim is confidential
+- **FSA-014** — Record keeping: the parent event record and all linked claims must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Depends on US-HCF-003 (Classify Event Type and Coverage)
+- BRF board actor definition
+- Catastrophe event register
+
+## Notes
+
+- In Sweden, apartment building fires typically affect 5-20 units; large-scale storms or flooding can affect hundreds or thousands of properties
+- The BRF building insurance and individual bostadsrättsförsäkring policies may be with different insurers, requiring cross-company coordination
+- Catastrophe response may involve external resources (e.g., Svensk Försäkring's catastrophe coordination, municipal housing services)
+- Individual claims privacy must be maintained even within a coordinated event — one customer's claim details must not be visible to another

--- a/docs/phase-2-home-property/user-stories/fire-natural-risk-update.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-risk-update.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 41
+---
+
+# US-HCF-012: Flag Property for Updated Risk Assessment
+
+## User Story
+
+**As the** system,
+**I want to** flag the property and area for updated risk assessment after a fire or natural event,
+**so that** underwriting reflects the new risk data and reserves are adjusted accordingly.
+
+## Actors
+
+- **Primary:** System
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Fire and natural event claims data is essential for catastrophe risk modeling and underwriting accuracy. Without updated risk data, the insurer cannot price risk correctly or maintain adequate reserves.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been closed
+  **WHEN** the system records the claim for risk assessment
+  **THEN** the system captures: event type, cause, total claim cost, property type, property age, geographic location (municipality and postal code), restoration duration, and loss classification (total/partial)
+
+- **GIVEN** a natural event claim is linked to a catastrophe event record
+  **WHEN** the system updates risk data
+  **THEN** the system aggregates all claims for the event and records: total number of claims, total cost, geographic spread, event severity category, and peril type for catastrophe reserve reporting
+
+- **GIVEN** the claim data has been recorded
+  **WHEN** the renewal cycle approaches for the affected policy
+  **THEN** the underwriting system can access the claims history to assess whether a premium adjustment is warranted based on the fire/natural event
+
+- **GIVEN** a geographic area has experienced a significant natural event
+  **WHEN** the system detects a cluster of claims in a postal code or municipality
+  **THEN** the system generates a risk alert for underwriting review, flagging the area for potential portfolio-wide reassessment
+
+- **GIVEN** the claim data is available for risk modeling
+  **WHEN** the actuarial team accesses the data
+  **THEN** the system provides aggregated and anonymized claim data by: peril type, geographic zone, property type, property age, and loss severity for use in catastrophe models and pricing
+
+## Risk Assessment Data
+
+| Data Point           | Description                                    | Use in Underwriting                    |
+| -------------------- | ---------------------------------------------- | -------------------------------------- |
+| Event type           | Fire, storm, flood, lightning, explosion       | Risk factor by peril type              |
+| Cause                | Electrical fault, arson, weather, etc.         | Cause-based risk modeling              |
+| Total claim cost     | All costs including rebuild, temporary housing | Loss ratio and severity analysis       |
+| Property type        | Villa, bostadsrätt, hyresrätt                  | Risk segmentation                      |
+| Property age         | Construction year                              | Age-related risk curves                |
+| Geographic location  | Municipality and postal code                   | Regional risk and catastrophe mapping  |
+| Restoration duration | Days from FNOL to closure                      | Claims efficiency and severity metrics |
+| Loss classification  | Total loss or partial loss                     | Severity distribution                  |
+| Catastrophe link     | Whether part of a multi-claim event            | Catastrophe reserve adequacy           |
+
+## Regulatory
+
+- **FSA-018** — Natural disaster reserves: claims data by peril type and geography must support catastrophe reserve calculations and FSA reporting
+- **FSA-005** — Product governance: claims data must be available for product reviews to ensure products continue to meet customer needs and are priced adequately
+- **FSA-003** — Solvency II compliance: catastrophe risk exposure data supports SCR calculations for natural catastrophe risk
+- **FSA-014** — Record keeping: risk assessment data derived from claims must be retained for 10 years
+- **GDPR-003** — Claims processing: claims data used for risk assessment should use aggregated or anonymized data where possible for statistical analysis
+
+## Dependencies
+
+- Depends on all prior user stories in the fire/natural event claims lifecycle
+- Underwriting risk model integration
+- Actuarial catastrophe modeling tools
+- Geographic information system (GIS) for regional risk mapping
+
+## Notes
+
+- Fire and natural event claims data is particularly valuable for catastrophe risk modeling due to their high severity and geographic correlation
+- Climate change is increasing the frequency of storm and flood events in Sweden; historical data must be supplemented with forward-looking climate risk models
+- The Gävle 2021 flooding demonstrated the importance of aggregate exposure monitoring; a single event caused hundreds of claims
+- Risk updates should be available at both individual property level (for renewals) and portfolio level (for catastrophe reserves)

--- a/docs/phase-2-home-property/user-stories/fire-natural-structural-inspection.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-structural-inspection.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 34
+---
+
+# US-HCF-005: Inspect Property for Structural Integrity
+
+## User Story
+
+**As a** besiktningsman (property inspector),
+**I want to** inspect the property for structural integrity after fire or storm,
+**so that** safety is confirmed before re-entry and the damage extent is documented.
+
+## Actors
+
+- **Primary:** [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Structural inspection after fire or severe storm is a safety requirement. Re-entry without inspection can endanger occupants and expose the insurer to liability.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim requires structural assessment
+  **WHEN** the claims handler requests a structural inspection
+  **THEN** the system creates an inspection order with the property address, event type, and known damage details, and assigns it to an available besiktningsman
+
+- **GIVEN** an inspection order has been created
+  **WHEN** the besiktningsman schedules the inspection
+  **THEN** the system records the scheduled date and notifies the customer of the inspection appointment
+
+- **GIVEN** the besiktningsman has completed the inspection
+  **WHEN** the besiktningsman submits the inspection report
+  **THEN** the system records the report with: structural integrity assessment (safe/unsafe/conditional), load-bearing structure status, roof integrity, utility systems status (electrical, plumbing, gas), and a recommendation for total loss or partial loss classification
+
+- **GIVEN** the inspection report indicates the property is unsafe for re-entry
+  **WHEN** the claims handler reviews the report
+  **THEN** the system confirms that temporary housing is in effect and records the safety restriction on the claim
+
+- **GIVEN** the inspection report identifies environmental hazards (asbestos, chemicals)
+  **WHEN** the claims handler reviews the report
+  **THEN** the system flags the claim for specialized environmental cleanup and notifies the claims handler that remediation must occur before further assessment or repair
+
+- **GIVEN** the inspection is complete and the report submitted
+  **WHEN** the claims handler reviews the results
+  **THEN** the system updates the claim with the inspection findings and advances the claim to the appropriate settlement path (total loss or partial loss)
+
+## Inspection Report Data
+
+| Field                        | Type     | Required | Description                                              |
+| ---------------------------- | -------- | -------- | -------------------------------------------------------- |
+| Inspection date              | Date     | Yes      | Date of the on-site inspection                           |
+| Inspector name and cert. no. | String   | Yes      | Besiktningsman identity and SBR certification            |
+| Structural integrity         | Enum     | Yes      | Safe, unsafe, conditionally safe                         |
+| Load-bearing assessment      | Text     | Yes      | Status of foundation, walls, beams, and roof structure   |
+| Roof integrity               | Enum     | Yes      | Intact, partially damaged, destroyed                     |
+| Utility systems              | Object   | Yes      | Status of electrical, plumbing, gas, and heating systems |
+| Environmental hazards        | Boolean  | Yes      | Whether asbestos, chemicals, or other hazards were found |
+| Hazard details               | Text     | Cond.    | Description of environmental hazards if found            |
+| Loss classification          | Enum     | Yes      | Inspector's recommendation: total loss or partial loss   |
+| Estimated damage cost        | Currency | No       | Preliminary cost estimate if determinable                |
+| Photos and documentation     | Files    | Yes      | Photographic evidence of structural condition            |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: structural inspection must not cause undue delay; inspections should be scheduled within 48 hours for fire claims
+- **FSA-014** — Record keeping: inspection reports must be retained as part of the claim file for 10 years
+- **GDPR-008** — Restoration company data sharing: property details shared with the besiktningsman must be limited to what is necessary for the inspection
+- **FSA-016** — Building valuation: the inspection informs the rebuild cost assessment for total loss scenarios
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Depends on US-HCF-003 (Classify Event Type and Coverage)
+- Property inspector (besiktningsman) availability
+- Räddningstjänsten clearance for site access (for fire-damaged properties)
+
+## Notes
+
+- After a fire, räddningstjänsten must clear the property before any inspection can take place; this can take hours to days
+- Structural inspections after storms focus on roof damage, water ingress points, and foundation stability
+- In older buildings (pre-1980), the inspector should specifically check for asbestos-containing materials disturbed by the event
+- The inspection report is a key input for the total loss vs partial loss determination (US-HCF-004)

--- a/docs/phase-2-home-property/user-stories/fire-natural-subrogation.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-subrogation.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 40
+---
+
+# US-HCF-011: Process Subrogation Against Responsible Third Party
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** process subrogation against a responsible third party (e.g., arsonist, negligent neighbor),
+**so that** costs are recovered from the party that caused the damage.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** System
+
+## Priority
+
+**Should Have** — Subrogation recovers claim costs from responsible third parties, improving the insurer's loss ratio. It is a standard insurance practice but does not block the customer's settlement.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim investigation identifies a responsible third party
+  **WHEN** the claims handler determines that subrogation may apply
+  **THEN** the system creates a subrogation record linked to the claim, recording: the third party's identity (if known), the basis of liability (arson, negligence, product defect, etc.), and the estimated recovery amount
+
+- **GIVEN** a subrogation record exists
+  **WHEN** the customer's claim is settled
+  **THEN** the system ensures the customer receives their full settlement regardless of subrogation status; subrogation is pursued separately by the insurer
+
+- **GIVEN** the incident report indicates arson or criminal activity
+  **WHEN** the claims handler reviews the subrogation opportunity
+  **THEN** the system records the police report reference, tracks the criminal investigation status, and notes that civil recovery depends on the criminal proceedings outcome
+
+- **GIVEN** the cause is a negligent neighbor (e.g., fire spread from adjacent property)
+  **WHEN** the claims handler initiates subrogation
+  **THEN** the system records the neighbor's insurer details and initiates a subrogation demand to the neighbor's liability insurance
+
+- **GIVEN** the cause is a product defect (e.g., faulty electrical appliance causing fire)
+  **WHEN** the claims handler identifies the manufacturer or seller
+  **THEN** the system creates a product liability subrogation record with the manufacturer/seller details, product identification, and applicable product liability legislation
+
+- **GIVEN** subrogation recovery is received
+  **WHEN** the third party or their insurer pays the subrogation demand
+  **THEN** the system records the recovery amount, updates the claim's net cost, and closes the subrogation record
+
+## Subrogation Basis
+
+| Cause                   | Liable Party                   | Legal Basis                             | Typical Recovery |
+| ----------------------- | ------------------------------ | --------------------------------------- | ---------------- |
+| Arson (mordbrand)       | Perpetrator                    | Skadeståndslagen (Tort law)             | Low (criminal)   |
+| Negligent neighbor      | Neighbor / neighbor's insurer  | Skadeståndslagen, grannelagsrätt        | Medium to high   |
+| Product defect          | Manufacturer / seller          | Produktansvarslagen (Product liability) | Medium to high   |
+| Contractor negligence   | Contractor / contractor's ins. | Skadeståndslagen, contract law          | High             |
+| Electrical fault (grid) | Grid operator (elnätsföretag)  | Ellagen (Electricity Act)               | Medium           |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the customer's settlement must not be delayed pending subrogation; the insurer settles first and recovers later
+- **FSA-014** — Record keeping: subrogation records, demands, and recoveries must be retained for 10 years
+- **GDPR-003** — Claims processing: third-party personal data collected for subrogation must follow data minimization principles
+- **GDPR-006** — Fraud detection: arson-related subrogation intersects with fraud investigation; data handling must comply with both fraud and claims processing requirements
+
+## Dependencies
+
+- Depends on US-HCF-002 (Obtain Räddningstjänsten Incident Report) — incident report determines cause
+- Depends on US-HCF-004 (Assess Total Loss vs Partial Loss) — settlement amount determines subrogation value
+- Legal team or external counsel for complex subrogation cases
+- Police investigation outcome for arson cases
+
+## Notes
+
+- Subrogation is the insurer's right, not the customer's obligation; the customer should not be burdened with the recovery process
+- Recovery rates vary widely: arson subrogation against convicted arsonists typically yields low recovery; negligent neighbor subrogation through liability insurance has higher success rates
+- The claims handler should identify subrogation potential early in the claims process to preserve evidence
+- For large claims, the subrogation amount can be significant and materially affect the claim's impact on the loss ratio

--- a/docs/phase-2-home-property/user-stories/fire-natural-temporary-housing.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-temporary-housing.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 38
+---
+
+# US-HCF-009: Provide Continued Temporary Housing During Rebuild
+
+## User Story
+
+**As a** customer (privatkund),
+**I want** continued temporary housing coverage during the rebuild period,
+**so that** my family has stability while our home is being restored.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Fire and natural event rebuilds can take 6-18 months. Continuous temporary housing is a core coverage component that ensures the customer is not left without shelter.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has rendered the customer's home uninhabitable
+  **WHEN** the claims handler or customer requests temporary housing
+  **THEN** the system creates a temporary housing order linked to the claim, records the start date, and initiates accommodation booking
+
+- **GIVEN** temporary housing has been arranged
+  **WHEN** the system tracks the housing duration
+  **THEN** the system monitors the housing period against the policy's coverage limit and displays: current duration, daily cost, accumulated cost, remaining coverage, and estimated restoration completion date
+
+- **GIVEN** the rebuild or repair extends beyond 6 months
+  **WHEN** the temporary housing period needs extension
+  **THEN** the claims handler can extend the housing order, the system checks the extension against policy limits, and the customer is notified of the extension and any coverage implications
+
+- **GIVEN** the policy's temporary housing coverage limit is approaching
+  **WHEN** the accumulated cost reaches 80% of the coverage limit
+  **THEN** the system alerts the claims handler and notifies the customer of the remaining coverage, so that alternative arrangements can be planned if needed
+
+- **GIVEN** the customer prefers to arrange their own temporary housing
+  **WHEN** the customer opts for a daily allowance (traktamente) instead of insurer-arranged accommodation
+  **THEN** the system records the customer's choice, calculates the daily allowance amount per policy terms, and tracks payments against the coverage limit
+
+- **GIVEN** the customer's home has been restored to habitable condition
+  **WHEN** the claims handler confirms restoration is complete
+  **THEN** the system ends the temporary housing period, records the total cost, and includes it in the claim settlement
+
+## Temporary Housing Coverage
+
+| Accommodation Type            | Typical Daily Cost | Use Case                          |
+| ----------------------------- | ------------------ | --------------------------------- |
+| Hotel                         | SEK 1,000 -- 2,500 | Immediate evacuation (first days) |
+| Furnished apartment           | SEK 500 -- 1,500   | Short to medium term (weeks)      |
+| Extended-stay accommodation   | SEK 400 -- 1,200   | Long-term rebuild (months)        |
+| Daily allowance (traktamente) | Per policy terms   | Customer arranges own housing     |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: temporary housing must be arranged promptly; the customer must not be left without shelter due to insurer delays
+- **FSA-004** — Consumer protection: the customer must be informed of their temporary housing entitlement, coverage limits, and the option of a daily allowance
+- **FSA-012** — Insurance contract disclosure: temporary housing coverage terms, limits, and duration must be clearly stated in the policy
+- **FSA-014** — Record keeping: all temporary housing arrangements, costs, and customer communications must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Depends on US-HCF-004 (Assess Total Loss vs Partial Loss)
+- Temporary housing provider agreements or booking integration
+- Policy configuration with temporary housing coverage limits
+
+## Notes
+
+- Fire and natural event claims often require longer temporary housing periods than water damage claims due to the severity of structural damage
+- For families with children in school, accommodation should be arranged as close to the original property as feasible
+- The customer may choose to stay with relatives and receive a reduced daily allowance; this option should be communicated clearly
+- Total loss rebuilds may require temporary housing for 12-18 months; the claims handler should set realistic expectations early
+- If the policy coverage limit is insufficient, the claims handler should discuss options with the customer proactively

--- a/docs/phase-2-home-property/user-stories/fire-natural-total-loss-assessment.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-total-loss-assessment.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 33
+---
+
+# US-HCF-004: Assess Total Loss vs Partial Loss
+
+## User Story
+
+**As a** claims handler (skadereglerare),
+**I want to** assess whether the damage is total loss (totalskada) or partial loss (delskada),
+**so that** the correct settlement path is followed.
+
+## Actors
+
+- **Primary:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Property Inspector (Besiktningsman)](../../actors/external/property-inspector.md)
+
+## Priority
+
+**Must Have** — The total loss vs partial loss determination is the most critical decision in fire/natural event claims. It determines whether the customer receives a rebuild/cash settlement or a repair-based settlement.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been classified
+  **WHEN** the claims handler evaluates the damage extent
+  **THEN** the system presents the loss classification options: total loss (totalskada) — property is destroyed or damaged beyond economic repair, or partial loss (delskada) — property can be repaired to pre-damage condition
+
+- **GIVEN** the claims handler classifies the damage as total loss
+  **WHEN** the system records the determination
+  **THEN** the system activates the total loss settlement path: calculate settlement based on rebuild cost (nybyggnadsvärde) or sum insured, and check for underinsurance (underförsäkring)
+
+- **GIVEN** the claims handler classifies the damage as partial loss
+  **WHEN** the system records the determination
+  **THEN** the system activates the partial loss settlement path: approve repair scope, engage contractors, and calculate settlement based on repair cost minus age deduction
+
+- **GIVEN** the damage extent is uncertain
+  **WHEN** the claims handler cannot determine total vs partial loss without expert assessment
+  **THEN** the system creates an inspection order for a besiktningsman to assess structural integrity and produce a determination recommendation
+
+- **GIVEN** a total loss determination for a villa
+  **WHEN** the system calculates the preliminary settlement range
+  **THEN** the system displays: estimated rebuild cost (nybyggnadsvärde), current sum insured (försäkringsbelopp), market value (marknadsvärde), and any underinsurance gap
+
+- **GIVEN** a total loss determination for a bostadsrätt
+  **WHEN** the claims handler reviews the claim
+  **THEN** the system identifies that BRF building insurance covers the structural damage while the individual policy covers interior fixtures and personal property
+
+## Total Loss Decision Criteria
+
+| Factor                      | Total Loss Indicator                                          | Partial Loss Indicator                             |
+| --------------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| Structural integrity        | Load-bearing structures compromised                           | Structure intact, damage is cosmetic or localized  |
+| Repair cost vs rebuild cost | Repair cost exceeds 70-80% of rebuild cost                    | Repair cost is substantially below rebuild cost    |
+| Safety assessment           | Property condemned or unsafe for habitation                   | Property habitable after targeted repairs          |
+| Environmental contamination | Extensive asbestos or hazardous material requiring demolition | Localized contamination manageable during repair   |
+| Building code compliance    | Repair would not bring building to current code               | Repair can meet current building code requirements |
+
+## Regulatory
+
+- **FSA-010** — Fair and timely claims settlement: the total loss vs partial loss determination must be made promptly and fairly, based on documented evidence
+- **FSA-016** — Building valuation: the settlement must reflect adequate building valuation; underinsurance rules (proportional settlement) apply if the sum insured is below rebuild cost
+- **FSA-004** — Consumer protection: the customer must understand the determination and its implications for their settlement
+- **FSA-014** — Record keeping: the determination rationale, inspection reports, and cost estimates must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCF-001 (Report Fire or Natural Event Emergency)
+- Depends on US-HCF-003 (Classify Event Type and Coverage)
+- Property inspector (besiktningsman) availability
+- Building valuation data (rebuild cost estimates)
+
+## Notes
+
+- Total loss determinations are rare but high-value; they typically involve senior claims handler review
+- The 70-80% repair-to-rebuild cost threshold is an industry guideline, not a statutory requirement; each case must be assessed individually
+- For older buildings, total loss may be triggered by building code requirements that make repair impractical (e.g., fire safety, energy efficiency upgrades)
+- Environmental contamination (asbestos in pre-1980 buildings) can shift a partial loss to total loss due to cleanup costs

--- a/docs/phase-2-home-property/user-stories/fire-natural-valuation.md
+++ b/docs/phase-2-home-property/user-stories/fire-natural-valuation.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 36
+---
+
+# US-HCF-007: Explain Rebuild Cost vs Market Value Settlement
+
+## User Story
+
+**As a** customer (privatkund),
+**I want to** understand the difference between nybyggnadsvärde (rebuild cost) and marknadsvärde (market value),
+**so that** I know what settlement amount I will receive.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md)
+- **Supporting:** [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+
+## Priority
+
+**Must Have** — Settlement basis (rebuild cost vs market value) is the most common source of confusion and disputes in total loss claims. Clear communication reduces complaints.
+
+## Acceptance Criteria
+
+- **GIVEN** a fire/natural event claim has been determined as total loss
+  **WHEN** the claims handler presents the settlement options to the customer
+  **THEN** the system generates a clear explanation of the two settlement bases: nybyggnadsvärde (what it costs to rebuild the same property) and marknadsvärde (what the property is worth on the open market)
+
+- **GIVEN** the customer's policy is fullvärdesförsäkring (full value insurance)
+  **WHEN** the system calculates the settlement
+  **THEN** the settlement is based on nybyggnadsvärde (rebuild cost) without a fixed sum cap, and the system displays: estimated rebuild cost, any applicable deductions, deductible (självrisk), and net settlement amount
+
+- **GIVEN** the customer's policy specifies a fixed sum insured (försäkringsbelopp)
+  **WHEN** the system calculates the settlement
+  **THEN** the settlement is the lesser of the actual rebuild cost and the sum insured, and the system checks for underinsurance (underförsäkring) per FSA-016
+
+- **GIVEN** the rebuild cost exceeds the sum insured (underinsurance scenario)
+  **WHEN** the system detects underinsurance
+  **THEN** the system calculates the proportional settlement (proportional settlement = claim amount x sum insured / rebuild cost), displays a clear explanation of underinsurance to the customer, and records the underinsurance finding
+
+- **GIVEN** the customer chooses not to rebuild at the same location
+  **WHEN** the customer opts for a cash settlement instead
+  **THEN** the system calculates the settlement based on marknadsvärde or rebuild cost (per policy terms), minus site clearance costs if the insurer bears those, and presents the settlement to the customer
+
+- **GIVEN** the settlement explanation has been presented
+  **WHEN** the customer reviews the settlement
+  **THEN** the system records the customer's acknowledgment or dispute and provides the FSA complaints procedure reference if the customer disagrees
+
+## Settlement Basis Comparison
+
+| Settlement Basis        | Swedish Term             | Description                                            | When Applied                         |
+| ----------------------- | ------------------------ | ------------------------------------------------------ | ------------------------------------ |
+| Rebuild cost            | Nybyggnadsvärde          | Cost to rebuild the same property at the same location | Fullvärdesförsäkring, rebuild chosen |
+| Market value            | Marknadsvärde            | Current market sale price of the property              | Cash settlement, older policies      |
+| Sum insured             | Försäkringsbelopp        | Fixed coverage amount stated in the policy             | Fixed-sum policies                   |
+| Proportional settlement | Proportionell ersättning | Reduced settlement due to underinsurance               | When sum insured < rebuild cost      |
+
+## Regulatory
+
+- **FSA-016** — Building valuation: the insurer must ensure adequate sum insured and apply underinsurance rules correctly; the customer must be informed of underinsurance implications
+- **FSA-010** — Fair and timely claims settlement: the settlement must be fair and based on transparent calculations
+- **FSA-004** — Consumer protection: the settlement explanation must be in clear, plain language so the customer can understand the basis
+- **FSA-011** — Complaints handling: the customer must be informed of the complaints procedure if they dispute the settlement basis
+- **FSA-014** — Record keeping: settlement calculations and customer communications must be retained for 10 years
+
+## Dependencies
+
+- Depends on US-HCF-004 (Assess Total Loss vs Partial Loss)
+- Building valuation data (rebuild cost estimate from Lantmäteriet or valuation tool)
+- Policy terms specifying settlement basis
+
+## Notes
+
+- Nybyggnadsvärde (rebuild cost) is typically the more favorable basis for the customer and is standard in modern fullvärdesförsäkring policies
+- Marknadsvärde may be lower than rebuild cost in rural areas where property values are below construction costs, or higher in urban areas
+- Underinsurance disputes are among the most common complaints in total loss claims — clear pre-loss communication (at policy inception and renewal) is the best prevention
+- The customer may choose to rebuild at a different location; policy terms determine whether this affects the settlement amount

--- a/docs/phase-2-home-property/user-stories/index.md
+++ b/docs/phase-2-home-property/user-stories/index.md
@@ -73,6 +73,46 @@ emergency FNOL through restoration and settlement.
 | [US-HCW-014](water-damage-final-inspection.md) | Verify Restoration via Final Inspection    | Should Have |
 | [US-HCW-015](water-damage-closure.md)          | Close Claim and Record for Risk Assessment | Must Have   |
 
+## Fire & Natural Events (Brand/Naturhändelser)
+
+Fire, storm, flood, lightning, and other natural event claims are low-frequency but
+high-severity. These user stories cover the complete fire/natural event claim
+lifecycle including emergency FNOL, structural inspection, total/partial loss
+assessment, environmental hazard remediation, rebuild or repair coordination,
+temporary housing, multi-unit coordination, and subrogation.
+
+### Emergency & FNOL
+
+| ID                                                 | Title                                    | Priority  |
+| -------------------------------------------------- | ---------------------------------------- | --------- |
+| [US-HCF-001](fire-natural-fnol.md)                 | Report Fire or Natural Event Emergency   | Must Have |
+| [US-HCF-002](fire-natural-incident-report.md)      | Obtain Räddningstjänsten Incident Report | Must Have |
+| [US-HCF-003](fire-natural-event-classification.md) | Classify Event Type and Coverage         | Must Have |
+
+### Assessment
+
+| ID                                                  | Title                                     | Priority    |
+| --------------------------------------------------- | ----------------------------------------- | ----------- |
+| [US-HCF-004](fire-natural-total-loss-assessment.md) | Assess Total Loss vs Partial Loss         | Must Have   |
+| [US-HCF-005](fire-natural-structural-inspection.md) | Inspect Property for Structural Integrity | Must Have   |
+| [US-HCF-006](fire-natural-environmental-hazards.md) | Check for Environmental Hazards           | Should Have |
+
+### Settlement & Restoration
+
+| ID                                                    | Title                                              | Priority  |
+| ----------------------------------------------------- | -------------------------------------------------- | --------- |
+| [US-HCF-007](fire-natural-valuation.md)               | Explain Rebuild Cost vs Market Value Settlement    | Must Have |
+| [US-HCF-008](fire-natural-contractor-coordination.md) | Coordinate Contractors for Rebuild or Repair       | Must Have |
+| [US-HCF-009](fire-natural-temporary-housing.md)       | Provide Continued Temporary Housing During Rebuild | Must Have |
+| [US-HCF-010](fire-natural-multi-unit.md)              | Manage Multi-Unit Claims                           | Must Have |
+
+### Closure
+
+| ID                                        | Title                                               | Priority    |
+| ----------------------------------------- | --------------------------------------------------- | ----------- |
+| [US-HCF-011](fire-natural-subrogation.md) | Process Subrogation Against Responsible Third Party | Should Have |
+| [US-HCF-012](fire-natural-risk-update.md) | Flag Property for Updated Risk Assessment           | Must Have   |
+
 ## Burglary and Theft
 
 The [burglary-and-theft user stories](burglary-and-theft.md) cover claims


### PR DESCRIPTION
## Summary
- 12 user stories (US-HCF-001 through US-HCF-012) covering the complete fire/natural event claims lifecycle: emergency FNOL, räddningstjänsten incident reports, event classification, total/partial loss assessment, structural inspection, environmental hazard remediation, rebuild cost vs market value settlement, contractor coordination, continued temporary housing, multi-unit claims management, subrogation, and risk assessment updates
- Use case UC-HCF-001 with main flow, 6 alternative flows, and exception flow for suspected arson
- Data models: FireNaturalEventClaim, IncidentReport, StructuralInspection, TemporaryHousing
- Full regulatory traceability: FSA-003/004/005/010/011/014/016/018, GDPR-003/006/008

## Changes
- Added 12 user story files in `docs/phase-2-home-property/user-stories/fire-natural-*.md`
- Added use case `docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md`
- Updated `docs/phase-2-home-property/user-stories/index.md` with Fire & Natural Events section
- Updated `docs/phase-2-home-property/use-cases/index.md` with UC-HCF-001 entry

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting check passes
- [x] Docusaurus build succeeds

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)