### PR TITLE
docs(#75): Add Home Renewals user stories and use case

### DIFF
--- a/docs/phase-2-home-property/index.md
+++ b/docs/phase-2-home-property/index.md
@@ -24,7 +24,7 @@ and fritidshusförsäkring (vacation home).
 | Quote and Bind        | Documented | Customer inquiry through policy issuance       |
 | Policy Administration | Planned    | Mid-term adjustments, endorsements             |
 | Claims Handling       | Planned    | FNOL through settlement                        |
-| Renewals              | Planned    | Annual renewal and huvudförfallodag processing |
+| Renewals              | Documented | Annual renewal and huvudförfallodag processing |
 | Cancellations         | Planned    | Customer and insurer-initiated cancellations   |
 
 ## Documentation
@@ -39,6 +39,9 @@ and fritidshusförsäkring (vacation home).
 - [Burglary and Theft](user-stories/burglary-and-theft.md) — 12 user stories
   covering burglary claims, stolen property, allrisk/drulle, and crisis
   support (HCB-01 through HCB-12)
+- [Home Renewals](user-stories/home-renewals.md) — 10 user stories covering
+  annual renewal, index adjustments, premium recalculation, and coverage
+  modifications (HRN-01 through HRN-10)
 
 ### Use Cases
 
@@ -50,3 +53,6 @@ and fritidshusförsäkring (vacation home).
 - [Burglary Claim Processing](use-cases/burglary-and-theft.md) — Complete
   use case (UC-HCB-001) covering emergency response, FNOL, fraud screening,
   settlement with åldersavdrag, and allrisk/drulle claims
+- [Annual Home Insurance Renewal](use-cases/home-renewals.md) — Complete
+  use case (UC-HRN-001) covering index adjustments, premium recalculation,
+  renewal notices, and customer response handling

--- a/docs/phase-2-home-property/use-cases/home-renewals.md
+++ b/docs/phase-2-home-property/use-cases/home-renewals.md
@@ -1,0 +1,291 @@
+---
+sidebar_position: 4
+---
+
+# Use Case: Annual Home Insurance Renewal
+
+End-to-end use case for annual renewal (förnyelse) of home and property
+insurance policies at TryggFörsäkring. Covers the complete renewal lifecycle
+from policy identification through index adjustment of sums insured, premium
+recalculation, renewal notice dispatch, customer response handling, automatic
+renewal processing, and coverage modification at renewal. Includes
+byggkostnadsindex and konsumentprisindex methodology, underwriter review of
+flagged renewals, and IDD demands-and-needs reassessment.
+
+## Use Case Summary
+
+| Field                | Value                                                                                                |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Use Case ID**      | UC-HRN-001                                                                                           |
+| **Name**             | Annual Home Insurance Renewal                                                                        |
+| **Primary Actor**    | System (automated batch process)                                                                     |
+| **Secondary Actors** | Customer (Privatkund), Customer Service Agent, Underwriter (Försäkringsgivare)                       |
+| **Goal**             | Renew home insurance policies with updated sums insured, accurate premium, and customer notification |
+| **Preconditions**    | Customer has an active home insurance policy approaching its huvudförfallodag                        |
+| **Postconditions**   | Policy renewed with updated terms, or cancelled per customer request                                 |
+| **Trigger**          | Policy reaches T-60 days before huvudförfallodag                                                     |
+
+## Stakeholders and Interests
+
+| Stakeholder            | Interest                                                            |
+| ---------------------- | ------------------------------------------------------------------- |
+| Customer               | Fair premium, adequate coverage, clear notice, freedom to cancel    |
+| Customer Service Agent | Process phone modifications accurately, meet disclosure obligations |
+| Underwriter            | Accurate risk pricing, appropriate continued coverage decisions     |
+| Compliance Officer     | Regulatory notice timing met, IDD obligations fulfilled             |
+| TryggFörsäkring        | Customer retention, accurate pricing, regulatory compliance         |
+| SCB                    | Provides official index data (byggkostnadsindex, KPI)               |
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[T-60: Identify policies approaching huvudförfallodag] --> B[Retrieve index data from SCB]
+    B --> C[Recalculate building sum using byggkostnadsindex]
+    C --> D[Recalculate contents sum using KPI]
+    D --> E[Recalculate premium with updated risk factors]
+    E --> F{Premium increase > 15% or multiple claims?}
+    F -->|Yes| G[Route to underwriter review]
+    F -->|No| H[Approve renewal automatically]
+    G --> I{Underwriter decision?}
+    I -->|Approve| H
+    I -->|Conditional| J[Add conditions to renewal terms]
+    I -->|Non-renewal| K[Generate non-renewal notice at T-30]
+    J --> H
+    H --> L[T-30: Generate and send förnyelseavisering]
+    L --> M{Customer response before T-0?}
+    M -->|Modify coverage| N[Recalculate with new terms]
+    M -->|Cancel / Flyttanmälan| O[Process cancellation]
+    M -->|No response / Accept| P[T-0: Automatic renewal on huvudförfallodag]
+    N --> P
+    P --> Q[Generate renewed policy documents]
+    Q --> R[Update payment schedule]
+    R --> S[Send renewal confirmation]
+
+    style A fill:#e1f5fe
+    style S fill:#e8f5e9
+    style G fill:#fff3e0
+    style K fill:#ffebee
+    style O fill:#ffebee
+```
+
+## Main Success Scenario
+
+### 1. Policy Identification (T-60 Days)
+
+1. The renewal batch process identifies all home insurance policies with a
+   huvudförfallodag within the next 60 days
+2. System retrieves each policy's current terms: coverage tier, sums insured,
+   add-ons, deductible, and premium
+3. System flags policies by type (hemförsäkring, villahemförsäkring,
+   bostadsrättsförsäkring, fritidshusförsäkring) for appropriate index
+   treatment
+
+### 2. Index Adjustment of Sums Insured (T-60 Days)
+
+1. System retrieves the current byggkostnadsindex from SCB
+2. For policies with a building component (villa, fritidshus):
+   - New Building Sum = Previous Building Sum x (Current Index / Previous Index)
+   - System stores both index values and the adjustment percentage
+3. System retrieves the current konsumentprisindex (KPI) from SCB
+4. For all policies with contents coverage:
+   - New Contents Sum = Previous Contents Sum x (Current KPI / Previous KPI)
+   - Floor rule: contents sum is never reduced below the previous level
+   - System stores both KPI values and the adjustment percentage
+5. If the building sum index adjustment exceeds 10%, the renewal is flagged for
+   underwriter review
+
+### 3. Premium Recalculation (T-60 Days)
+
+1. System recalculates the annual premium using:
+   - Updated sums insured (after index adjustment)
+   - Current claims history (claims count, types, total paid)
+   - Current area risk zone for the property
+   - Coverage tier and active add-ons
+   - Current deductible level
+   - Applicable tariff version
+2. System records a factor breakdown showing each component's contribution to
+   the premium change
+3. If the premium increase exceeds 15% or the customer has 2+ claims in the
+   expiring period, the renewal is flagged for underwriter review
+
+### 4. Underwriter Review (T-45 Days, If Flagged)
+
+1. Flagged renewals appear in the underwriter's review queue with the trigger
+   reason
+2. Underwriter reviews: claims history, premium factor breakdown, property risk
+   data, and index adjustments
+3. Underwriter makes a decision:
+   - **Approve** — renewal proceeds with calculated terms
+   - **Conditional** — renewal proceeds with added conditions (increased
+     deductible, coverage exclusion, required improvements)
+   - **Non-renewal** — policy will not be renewed; non-renewal notice must be
+     sent at T-30
+
+### 5. Renewal Notice Dispatch (T-30 Days)
+
+1. System generates the förnyelseavisering containing:
+   - New premium and premium change explanation (factor breakdown)
+   - Updated building and contents sums with index adjustment details
+   - Coverage tier and add-on summary
+   - Year-over-year comparison table
+   - Customer's right to cancel before huvudförfallodag
+   - Instructions for modifying coverage
+   - Any underwriter-imposed conditions
+2. Notice is dispatched via the customer's preferred channel (postal letter,
+   digital mailbox, Mina Sidor)
+3. System records the dispatch date, channel, and delivery status
+
+### 6. Customer Response Window (T-30 to T-0)
+
+1. Customer reviews the renewal notice
+2. Customer may:
+   - **Accept** (explicitly or by inaction) — no action needed
+   - **Modify coverage** — change tier, add/remove add-ons, adjust deductible
+     (via Mina Sidor or phone)
+   - **Cancel** — submit cancellation before the huvudförfallodag
+3. If the customer requests modifications:
+   - System recalculates the premium with the new terms
+   - Customer confirms the updated terms
+   - Modification is recorded in the renewal record
+4. If the customer cancels:
+   - Cancellation is effective on the huvudförfallodag
+   - Automatic renewal is suppressed
+   - Cancellation confirmation is sent
+
+### 7. Automatic Renewal (T-0, Huvudförfallodag)
+
+1. For all policies not cancelled:
+   - System creates a new policy period with updated terms (premium, sums
+     insured, coverage, any underwriter conditions)
+   - New policy period starts at 00:00 on the huvudförfallodag
+   - Expiring policy period ends at 00:00 on the huvudförfallodag (no gap)
+2. System generates an updated policy document
+3. System updates the payment schedule with the new premium amount
+4. System sends a renewal confirmation to the customer within 1 business day
+
+## Extensions (Alternative Flows)
+
+### 3a. Significant Premium Increase (>15%)
+
+1. System detects that the recalculated premium exceeds 15% over the previous
+   year
+2. Renewal is flagged for underwriter review (step 4) and for agent outreach
+3. Customer service is notified to proactively contact the customer after the
+   notice is sent to explain the increase and discuss options
+4. Flow continues from step 4
+
+### 3b. Multiple Claims in Past Year
+
+1. System detects 2 or more claims during the expiring policy period
+2. Renewal is flagged for underwriter review of continued coverage
+3. Underwriter may impose conditions or decide on non-renewal
+4. Flow continues from step 4
+
+### 4a. Customer Has Requested Changes Before Renewal Processing
+
+1. Customer previously requested modifications via Mina Sidor or phone
+2. System incorporates the requested changes into the renewal calculation
+3. Modified terms are reflected in the renewal notice
+4. Flow continues from step 5
+
+### 6a. Customer Requests Modifications via Phone
+
+1. Customer calls to modify their renewal terms
+2. Customer service agent opens the renewal record (HRN-08)
+3. Agent modifies coverage, recalculates premium, and obtains verbal
+   confirmation
+4. Agent records the modification with verification details
+5. Flow continues from step 7
+
+### 6b. Customer Cancels Before Renewal
+
+1. Customer submits a cancellation request before the huvudförfallodag (HRN-04)
+2. System records the cancellation effective on the huvudförfallodag
+3. Automatic renewal is suppressed
+4. Customer receives cancellation confirmation with a reminder to arrange
+   replacement coverage
+
+### 6c. Competitor Insurer Sends Flyttanmälan
+
+1. System receives a flyttanmälan from a competitor insurer
+2. System validates the request against the policy's huvudförfallodag
+3. If valid, the policy is cancelled effective on the huvudförfallodag
+4. System responds with confirmation and the customer's policy history summary
+
+### 7a. Non-Renewal by Insurer
+
+1. Underwriter has decided not to renew the policy (step 4)
+2. System generates a non-renewal notice sent to the customer at T-30
+3. Non-renewal notice includes: reason for non-renewal, effective date, and the
+   customer's right to seek coverage elsewhere
+4. Policy ends on the huvudförfallodag with no new period created
+
+### 7b. Payment Method Invalid
+
+1. System detects the customer's payment method is invalid or expired
+2. Renewal proceeds but the payment is flagged
+3. System sends the customer a request to update their payment details
+4. If not resolved within the grace period, the standard non-payment process
+   applies
+
+## Business Rules
+
+| Rule ID   | Rule                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------- |
+| BR-HRN-01 | Renewal notice must be sent at least 30 days before huvudförfallodag per Försäkringsavtalslagen   |
+| BR-HRN-02 | Building sum insured is adjusted annually using byggkostnadsindex from SCB                        |
+| BR-HRN-03 | Contents sum insured is adjusted annually using konsumentprisindex (KPI) from SCB                 |
+| BR-HRN-04 | Contents sum floor rule: KPI adjustment must not reduce the contents sum below the previous level |
+| BR-HRN-05 | Premium recalculation uses the tariff version effective on the huvudförfallodag                   |
+| BR-HRN-06 | Premium increases above 15% require underwriter review before notice dispatch                     |
+| BR-HRN-07 | Two or more claims in the expiring period trigger underwriter review                              |
+| BR-HRN-08 | Building sum index adjustment above 10% triggers underwriter review                               |
+| BR-HRN-09 | Automatic renewal is the default; customer must explicitly cancel to prevent renewal              |
+| BR-HRN-10 | Non-renewal notices must be sent at least 30 days before huvudförfallodag                         |
+| BR-HRN-11 | Coverage modifications requested before huvudförfallodag take effect at renewal                   |
+| BR-HRN-12 | Coverage modifications requested after huvudförfallodag are processed as mid-term endorsements    |
+| BR-HRN-13 | The new policy period starts at 00:00 on the huvudförfallodag with no coverage gap                |
+| BR-HRN-14 | Hemförsäkring (contents-only) policies do not receive building sum index adjustment               |
+
+## Non-functional Requirements
+
+| Requirement               | Target                                                               |
+| ------------------------- | -------------------------------------------------------------------- |
+| Renewal batch processing  | Complete for all eligible policies within 24 hours at T-60           |
+| Index data retrieval      | SCB data refreshed monthly; fallback to cached values if unavailable |
+| Premium recalculation     | Complete within 2 seconds per policy                                 |
+| Renewal notice generation | All notices dispatched within 24 hours at T-30                       |
+| Notice delivery tracking  | Delivery confirmation within 48 hours for digital channels           |
+| Customer modification     | Premium recalculation in real time (under 3 seconds)                 |
+| Audit trail               | All steps logged with timestamps, actor identity, and data versions  |
+| Availability              | Renewal self-service on Mina Sidor available 24/7                    |
+| Data retention            | Renewal records retained for 10 years per FSA-014                    |
+
+## Regulatory Compliance Summary
+
+| Regulation   | Requirements Addressed                                                          |
+| ------------ | ------------------------------------------------------------------------------- |
+| **FSA-003**  | Renewal notice timing (30 days); non-renewal notice timing; cancellation rights |
+| **FSA-004**  | Clear, transparent communication of all changes; plain Swedish language         |
+| **FSA-005**  | Fair treatment; index adjustments protect against underinsurance                |
+| **FSA-006**  | Premium data available for supervisory reporting                                |
+| **FSA-012**  | Modified coverage terms disclosed via updated policy documentation              |
+| **FSA-016**  | Index adjustment methodology and amounts transparently disclosed                |
+| **GDPR-007** | Customer data processed under Article 6(1)(b) contract performance; renewal     |
+|              | records retained per data retention policy                                      |
+| **IDD-006**  | Agent recommendations at renewal constitute advice requiring documentation      |
+| **IDD-011**  | Demands-and-needs review at renewal; significant changes trigger reassessment   |
+
+## Related User Stories
+
+- [HRN-01: Receive Renewal Notice](../user-stories/home-renewals.md#hrn-01-receive-renewal-notice)
+- [HRN-02: View Year-over-Year Comparison](../user-stories/home-renewals.md#hrn-02-view-year-over-year-comparison)
+- [HRN-03: Modify Coverage at Renewal](../user-stories/home-renewals.md#hrn-03-modify-coverage-at-renewal)
+- [HRN-04: Opt Out of Automatic Renewal](../user-stories/home-renewals.md#hrn-04-opt-out-of-automatic-renewal)
+- [HRN-05: Recalculate Building Sum Insured Using Byggkostnadsindex](../user-stories/home-renewals.md#hrn-05-recalculate-building-sum-insured-using-byggkostnadsindex)
+- [HRN-06: Recalculate Contents Sum Insured Using Konsumentprisindex](../user-stories/home-renewals.md#hrn-06-recalculate-contents-sum-insured-using-konsumentprisindex)
+- [HRN-07: Apply Premium Adjustments at Renewal](../user-stories/home-renewals.md#hrn-07-apply-premium-adjustments-at-renewal)
+- [HRN-08: Process Renewal Modifications for Phone Customers](../user-stories/home-renewals.md#hrn-08-process-renewal-modifications-for-phone-customers)
+- [HRN-09: Review Flagged Renewals](../user-stories/home-renewals.md#hrn-09-review-flagged-renewals)
+- [HRN-10: Generate and Send Renewal Notice](../user-stories/home-renewals.md#hrn-10-generate-and-send-renewal-notice)

--- a/docs/phase-2-home-property/use-cases/index.md
+++ b/docs/phase-2-home-property/use-cases/index.md
@@ -43,3 +43,18 @@ describes the complete flow from burglary report through settlement. It covers:
 - Break-in damage repair via partner network
 - Allrisk/drulle simplified claims process
 - Crisis support (krisstöd) for burglary victims
+
+## Home Renewals (Förnyelse)
+
+The [Annual Home Insurance Renewal](home-renewals.md) use case (UC-HRN-001)
+describes the complete renewal lifecycle from policy identification through
+automatic renewal. It covers:
+
+- Index adjustment of building sum insured using byggkostnadsindex
+- Index adjustment of contents sum insured using konsumentprisindex (KPI)
+- Premium recalculation with claims history and area risk factors
+- Underwriter review of flagged renewals (significant premium increase, multiple claims)
+- Renewal notice (förnyelseavisering) dispatch at T-30 days
+- Customer response handling (accept, modify, cancel)
+- Automatic renewal on huvudförfallodag
+- Agent-assisted modifications and demands-and-needs reassessment

--- a/docs/phase-2-home-property/user-stories/home-renewals.md
+++ b/docs/phase-2-home-property/user-stories/home-renewals.md
@@ -1,0 +1,759 @@
+---
+sidebar_position: 4
+---
+
+# Home Renewals — User Stories
+
+User stories for annual renewal (förnyelse) of home and property insurance
+policies. Covers renewal notice generation, index adjustment of building and
+contents sums insured, premium recalculation, coverage modification at renewal,
+opt-out of automatic renewal, year-over-year comparison, agent-assisted
+modifications, underwriter review of flagged renewals, and demands-and-needs
+reassessment.
+
+## Overview
+
+| ID     | Actor                  | Summary                                                                 |
+| ------ | ---------------------- | ----------------------------------------------------------------------- |
+| HRN-01 | Customer               | Receive a renewal notice showing changes in premium and coverage        |
+| HRN-02 | Customer               | View year-over-year comparison of coverage and premium                  |
+| HRN-03 | Customer               | Modify coverage at renewal (upgrade/downgrade tier, add/remove add-ons) |
+| HRN-04 | Customer               | Opt out of automatic renewal before the deadline                        |
+| HRN-05 | System                 | Recalculate building sum insured using byggkostnadsindex                |
+| HRN-06 | System                 | Recalculate contents sum insured using konsumentprisindex               |
+| HRN-07 | System                 | Apply premium adjustments based on claims history and risk changes      |
+| HRN-08 | Customer Service Agent | Process renewal modifications for phone customers                       |
+| HRN-09 | Underwriter            | Review renewals flagged for significant risk changes                    |
+| HRN-10 | System                 | Generate and send renewal notice 30 days before huvudförfallodag        |
+
+---
+
+## HRN-01: Receive Renewal Notice
+
+**As a** customer (privatkund),
+**I want to** receive a clear renewal notice showing what has changed (premium,
+coverage, index adjustments),
+**so that** I can review the new terms before my policy automatically renews.
+
+### Acceptance Criteria
+
+- **GIVEN** my home insurance policy's huvudförfallodag is approaching
+  **WHEN** the renewal notice is dispatched (at least 30 days before renewal)
+  **THEN** I receive the notice via my preferred channel (postal letter, digital
+  mailbox, or Mina Sidor) showing: current premium, new premium, premium change
+  amount and percentage, coverage tier, sums insured (building and contents),
+  index adjustments applied, and the huvudförfallodag
+
+- **GIVEN** the renewal notice includes a premium change
+  **WHEN** I review the notice
+  **THEN** each contributing factor is listed separately: index adjustment of
+  building sum, index adjustment of contents sum, claims history impact, area
+  risk zone changes, and any tariff adjustments
+
+- **GIVEN** the renewal notice has been sent
+  **WHEN** the system records the delivery
+  **THEN** it logs the sent date, delivery channel, content version, and
+  delivery confirmation status
+
+- **GIVEN** the renewal notice cannot be delivered (returned post, bounced
+  email)
+  **WHEN** the delivery failure is detected
+  **THEN** the system retries via an alternative channel and alerts operations
+  staff if all channels fail
+
+- **GIVEN** the renewal notice has been sent
+  **WHEN** the customer reads it
+  **THEN** the notice clearly states the customer's right to cancel before the
+  huvudförfallodag without penalty and explains how to do so
+
+### Data Requirements
+
+| Data Element               | Source               | Required |
+| -------------------------- | -------------------- | -------- |
+| Policy number              | Policy record        | Yes      |
+| Policyholder name          | Policy record        | Yes      |
+| Property address           | Policy record        | Yes      |
+| Coverage tier              | Policy record        | Yes      |
+| Current annual premium     | Policy record        | Yes      |
+| New annual premium         | Renewal calculation  | Yes      |
+| Building sum insured (old) | Policy record        | Yes      |
+| Building sum insured (new) | Index calculation    | Yes      |
+| Contents sum insured (old) | Policy record        | Yes      |
+| Contents sum insured (new) | Index calculation    | Yes      |
+| Index adjustment details   | SCB/index provider   | Yes      |
+| Claims history summary     | Claims system        | Yes      |
+| Huvudförfallodag           | Policy record        | Yes      |
+| Delivery channel           | Customer preferences | Yes      |
+
+### Regulatory
+
+- **FSA-003** — Renewal notice must be sent at least 30 days before
+  huvudförfallodag, per Försäkringsavtalslagen
+- **FSA-004** — Renewal notices must use clear, transparent language and present
+  terms fairly
+- **FSA-016** — Index adjustment amounts and methodology must be transparently
+  disclosed
+- **GDPR-007** — Customer contact data processed for renewal notice delivery;
+  legal basis is Article 6(1)(b) contract performance
+- **IDD-011** — Demands-and-needs review may be triggered at renewal if
+  significant changes occur
+
+---
+
+## HRN-02: View Year-over-Year Comparison
+
+**As a** customer (privatkund),
+**I want to** see a comparison of this year's coverage and premium versus last
+year's,
+**so that** I understand exactly what has changed and can make an informed
+decision about renewing.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer receives a renewal notice or logs into Mina Sidor
+  **WHEN** the customer views the renewal details
+  **THEN** the system displays a side-by-side comparison showing: previous and
+  new annual premium, previous and new building sum insured, previous and new
+  contents sum insured, previous and new coverage tier, add-ons (allrisk/drulle,
+  ID-skydd, etc.), and deductible (självrisk)
+
+- **GIVEN** the comparison shows a change in sums insured
+  **WHEN** the customer views the building or contents sum
+  **THEN** the system shows: previous sum, index adjustment percentage, index
+  adjustment amount (SEK), and resulting new sum
+
+- **GIVEN** the comparison shows a premium change
+  **WHEN** the customer views the premium breakdown
+  **THEN** each factor contributing to the change is displayed with its
+  approximate SEK impact: index-driven change, claims history impact, area risk
+  zone adjustment, and tariff changes
+
+- **GIVEN** the customer wants to understand the index adjustments
+  **WHEN** the customer views the explanation
+  **THEN** the system displays the applicable index name (byggkostnadsindex or
+  konsumentprisindex), the percentage change from the prior year, and how it
+  affects the sums insured
+
+### Data Requirements
+
+| Data Element                | Source              | Required |
+| --------------------------- | ------------------- | -------- |
+| Previous policy terms       | Policy record       | Yes      |
+| New renewal terms           | Renewal calculation | Yes      |
+| Index adjustment breakdown  | SCB/index provider  | Yes      |
+| Premium factor breakdown    | Rating engine       | Yes      |
+| Claims during expiring term | Claims system       | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Year-over-year comparison must be transparent so the customer
+  can make an informed renewal decision
+- **FSA-016** — Index adjustment methodology and impact must be disclosed
+- **IDD-011** — Comparison supports the customer's ability to assess whether
+  coverage still meets their demands and needs
+
+---
+
+## HRN-03: Modify Coverage at Renewal
+
+**As a** customer (privatkund),
+**I want to** modify my coverage at renewal (upgrade or downgrade tier, add or
+remove allrisk/drulle and other add-ons),
+**so that** my policy stays relevant to my current living situation and needs.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has received a renewal notice
+  **WHEN** the customer requests a coverage modification before the
+  huvudförfallodag
+  **THEN** the system allows the customer to change: coverage tier
+  (bas/standard/premium), add-ons (allrisk/drulle, ID-skydd, bostadsrättstillägg),
+  deductible level (självrisk), and contents sum insured
+
+- **GIVEN** the customer selects a new coverage configuration
+  **WHEN** the modification is submitted
+  **THEN** the system recalculates the renewal premium based on the modified
+  terms and displays the updated premium before the customer confirms
+
+- **GIVEN** the customer confirms the coverage modification
+  **WHEN** the modification is recorded
+  **THEN** the system updates the renewal record with the new terms, regenerates
+  the renewal confirmation, and applies the changes effective from the
+  huvudförfallodag
+
+- **GIVEN** the customer requests a modification after the huvudförfallodag
+  **WHEN** the request is submitted
+  **THEN** the system informs the customer that the policy has already renewed
+  and the modification will be processed as a mid-term endorsement instead
+
+- **GIVEN** the modification results in a coverage downgrade
+  **WHEN** the customer confirms the downgrade
+  **THEN** the system displays a clear warning about the reduced coverage scope
+  and obtains explicit confirmation
+
+### Data Requirements
+
+| Data Element                | Source                    | Required |
+| --------------------------- | ------------------------- | -------- |
+| Current coverage tier       | Policy record             | Yes      |
+| Requested coverage tier     | Customer input            | Yes      |
+| Current add-ons             | Policy record             | Yes      |
+| Requested add-on changes    | Customer input            | Yes      |
+| Current deductible level    | Policy record             | Yes      |
+| Requested deductible        | Customer input            | No       |
+| Recalculated premium        | Rating engine             | Yes      |
+| Modification effective date | System (huvudförfallodag) | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Coverage modifications must be clearly explained so the customer
+  understands the impact
+- **FSA-012** — Modified coverage terms must be disclosed via updated policy
+  documentation
+- **IDD-011** — Coverage modification at renewal constitutes a new
+  demands-and-needs assessment; the system must verify the new configuration
+  meets the customer's stated needs
+- **GDPR-007** — Modification records processed under Article 6(1)(b) contract
+  performance
+
+---
+
+## HRN-04: Opt Out of Automatic Renewal
+
+**As a** customer (privatkund),
+**I want to** opt out of automatic renewal before the deadline,
+**so that** I can switch to another insurer or let the policy lapse.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has received a renewal notice
+  **WHEN** the customer submits a cancellation request before the
+  huvudförfallodag
+  **THEN** the system records the cancellation effective on the huvudförfallodag
+  and confirms the cancellation to the customer
+
+- **GIVEN** the customer cancels before the huvudförfallodag
+  **WHEN** the huvudförfallodag arrives
+  **THEN** the policy ends on the huvudförfallodag, automatic renewal does not
+  proceed, and the customer receives a cancellation confirmation
+
+- **GIVEN** the customer cancels the policy
+  **WHEN** the cancellation is processed
+  **THEN** the system sends a confirmation including: the policy end date, a
+  reminder to arrange replacement coverage for the property, and information
+  about any cooling-off rights for the new policy
+
+- **GIVEN** the customer attempts to cancel after the huvudförfallodag
+  **WHEN** the cancellation request is submitted
+  **THEN** the system informs the customer that the policy has already renewed
+  and they must follow the mid-term cancellation process instead
+
+- **GIVEN** a competitor insurer sends a flyttanmälan for the customer
+  **WHEN** the system receives the request before the huvudförfallodag
+  **THEN** the system processes the cancellation effective on the
+  huvudförfallodag and suppresses automatic renewal
+
+### Data Requirements
+
+| Data Element              | Source                    | Required |
+| ------------------------- | ------------------------- | -------- |
+| Cancellation request date | Customer input            | Yes      |
+| Requested effective date  | System (huvudförfallodag) | Yes      |
+| Cancellation reason       | Customer input            | No       |
+| Channel                   | System                    | Yes      |
+| Confirmation sent date    | System                    | Yes      |
+| Flyttanmälan reference    | Competitor insurer        | No       |
+
+### Regulatory
+
+- **FSA-003** — Cancellation at huvudförfallodag is a customer right under
+  Försäkringsavtalslagen; no penalty applies
+- **FSA-004** — Cancellation process must be clear and accessible
+- **GDPR-007** — Cancellation records processed under Article 6(1)(b) contract
+  performance
+
+---
+
+## HRN-05: Recalculate Building Sum Insured Using Byggkostnadsindex
+
+**As the** system,
+**I want to** automatically recalculate the building sum insured (byggnadssumma)
+using byggkostnadsindex (construction cost index),
+**so that** coverage keeps pace with rising construction costs and the customer
+is not underinsured at renewal.
+
+### Acceptance Criteria
+
+- **GIVEN** a home insurance policy with a building component
+  (villahemförsäkring or fritidshusförsäkring) approaches renewal
+  **WHEN** the renewal batch process runs (T-60 days)
+  **THEN** the system retrieves the current byggkostnadsindex from SCB
+  (Statistiska Centralbyrån) and calculates the new building sum insured
+
+- **GIVEN** the byggkostnadsindex has changed since the last renewal
+  **WHEN** the new building sum is calculated
+  **THEN** the system applies the formula:
+  New Building Sum = Previous Building Sum x (Current Index / Previous Index)
+
+- **GIVEN** the building sum adjustment is calculated
+  **WHEN** the renewal record is updated
+  **THEN** the system stores: previous building sum, previous index value,
+  current index value, index change percentage, and new building sum
+
+- **GIVEN** the index adjustment results in a significant increase (>10% year
+  over year)
+  **WHEN** the renewal is processed
+  **THEN** the system flags the renewal for underwriter review before the
+  renewal notice is sent
+
+- **GIVEN** a hemförsäkring (contents-only) policy approaches renewal
+  **WHEN** the renewal batch process runs
+  **THEN** no building sum adjustment is applied (building coverage belongs to
+  the property owner or BRF)
+
+### Index Adjustment Formula
+
+```text
+New Building Sum = Previous Building Sum x (Current Byggkostnadsindex / Previous Byggkostnadsindex)
+```
+
+### Data Requirements
+
+| Data Element                  | Source         | Required    |
+| ----------------------------- | -------------- | ----------- |
+| Previous building sum insured | Policy record  | Yes         |
+| Previous byggkostnadsindex    | Renewal record | Yes         |
+| Current byggkostnadsindex     | SCB            | Yes         |
+| Index change percentage       | Calculated     | Yes         |
+| New building sum insured      | Calculated     | Yes         |
+| Policy type                   | Policy record  | Yes         |
+| Review flag                   | System         | Conditional |
+
+### External Integrations
+
+- **SCB (Statistiska Centralbyrån)** — Source for byggkostnadsindex data
+
+### Regulatory
+
+- **FSA-016** — Index adjustment methodology must be transparent; the customer
+  must be informed of how the building sum was recalculated
+- **FSA-004** — The index adjustment and its impact on the premium must be
+  communicated clearly
+- **FSA-005** — Building sum must be adequate to cover full reinstatement;
+  index adjustment is a consumer protection measure
+- **GDPR-007** — Property valuation data processed under Article 6(1)(b)
+  contract performance
+
+---
+
+## HRN-06: Recalculate Contents Sum Insured Using Konsumentprisindex
+
+**As the** system,
+**I want to** adjust the contents sum insured (lösöresbelopp) using
+konsumentprisindex (KPI / consumer price index),
+**so that** the contents coverage reflects current replacement costs and the
+customer is not underinsured.
+
+### Acceptance Criteria
+
+- **GIVEN** a home insurance policy with contents coverage approaches renewal
+  **WHEN** the renewal batch process runs (T-60 days)
+  **THEN** the system retrieves the current konsumentprisindex from SCB and
+  calculates the adjusted contents sum insured
+
+- **GIVEN** the konsumentprisindex has changed since the last renewal
+  **WHEN** the new contents sum is calculated
+  **THEN** the system applies the formula:
+  New Contents Sum = Previous Contents Sum x (Current KPI / Previous KPI)
+
+- **GIVEN** the contents sum adjustment is calculated
+  **WHEN** the renewal record is updated
+  **THEN** the system stores: previous contents sum, previous KPI value,
+  current KPI value, KPI change percentage, and new contents sum
+
+- **GIVEN** the customer has manually set a specific contents sum (overriding
+  the default)
+  **WHEN** the renewal batch processes the policy
+  **THEN** the system still applies the KPI adjustment but flags the renewal
+  for customer notification that their custom sum has been index-adjusted
+
+- **GIVEN** the KPI adjustment results in a decrease (deflation)
+  **WHEN** the new contents sum is calculated
+  **THEN** the system does not reduce the contents sum below the previous
+  level, preserving the customer's coverage (floor rule)
+
+### Index Adjustment Formula
+
+```text
+New Contents Sum = Previous Contents Sum x (Current KPI / Previous KPI)
+Floor Rule: New Contents Sum >= Previous Contents Sum
+```
+
+### Data Requirements
+
+| Data Element                  | Source         | Required    |
+| ----------------------------- | -------------- | ----------- |
+| Previous contents sum insured | Policy record  | Yes         |
+| Previous KPI value            | Renewal record | Yes         |
+| Current KPI value             | SCB            | Yes         |
+| KPI change percentage         | Calculated     | Yes         |
+| New contents sum insured      | Calculated     | Yes         |
+| Customer-set override flag    | Policy record  | Conditional |
+
+### External Integrations
+
+- **SCB (Statistiska Centralbyrån)** — Source for konsumentprisindex (KPI) data
+
+### Regulatory
+
+- **FSA-016** — Index adjustment methodology must be transparent; the customer
+  must be informed of how the contents sum was recalculated
+- **FSA-004** — The KPI adjustment and its impact must be communicated clearly
+- **FSA-005** — Contents sum must reflect current replacement values; index
+  adjustment is a consumer protection measure
+- **GDPR-007** — Property valuation data processed under Article 6(1)(b)
+  contract performance
+
+---
+
+## HRN-07: Apply Premium Adjustments at Renewal
+
+**As the** system,
+**I want to** apply premium adjustments based on claims history, area risk zone
+changes, and other rating factors,
+**so that** the renewal premium accurately reflects the current risk profile.
+
+### Acceptance Criteria
+
+- **GIVEN** a home insurance policy approaches renewal (T-60 days)
+  **WHEN** the premium recalculation batch runs
+  **THEN** the system recalculates the premium using: updated sums insured
+  (after index adjustment), current claims history, current area risk zone,
+  coverage tier and add-ons, and the applicable tariff version
+
+- **GIVEN** the customer has had claims during the expiring policy period
+  **WHEN** the premium is recalculated
+  **THEN** the system applies the claims loading factor per the tariff rules
+  and records the number of claims, types, and total paid amounts that
+  influenced the premium
+
+- **GIVEN** the customer's area risk zone has changed (e.g., due to updated
+  flood, burglary, or fire risk mapping)
+  **WHEN** the premium is recalculated
+  **THEN** the new risk zone is applied and the premium factor change is
+  recorded separately
+
+- **GIVEN** the recalculated premium triggers a high-change flag (increase
+  above a configurable threshold, e.g., >15%)
+  **WHEN** the flag is raised
+  **THEN** the renewal is routed to an underwriter for manual review before
+  the renewal notice is sent (HRN-09)
+
+- **GIVEN** the premium recalculation is complete and no flags are triggered
+  **WHEN** the renewal is approved
+  **THEN** the system queues the renewal for notice generation (HRN-10)
+
+### Data Requirements
+
+| Data Element              | Source            | Required |
+| ------------------------- | ----------------- | -------- |
+| Updated sums insured      | Index calculation | Yes      |
+| Claims history            | Claims system     | Yes      |
+| Area risk zone            | Risk mapping      | Yes      |
+| Coverage tier and add-ons | Policy record     | Yes      |
+| Deductible level          | Policy record     | Yes      |
+| Tariff version            | Rating engine     | Yes      |
+| Old annual premium        | Policy record     | Yes      |
+| New annual premium        | Rating engine     | Yes      |
+| Premium factor breakdown  | Rating engine     | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Premium recalculation must be transparent and auditable;
+  customers must understand why the premium changed
+- **FSA-006** — Premium data must be available for supervisory reporting
+- **FSA-016** — Index-driven premium changes must be distinguished from other
+  rating factor changes
+- **IDD-011** — Significant premium changes may trigger a demands-and-needs
+  reassessment
+- **GDPR-007** — Premium calculation data processed under Article 6(1)(b)
+  contract performance
+
+---
+
+## HRN-08: Process Renewal Modifications for Phone Customers
+
+**As a** customer service agent (kundservicehandläggare),
+**I want to** process renewal modifications requested by phone customers,
+**so that** non-digital customers can adjust their coverage at renewal.
+
+### Acceptance Criteria
+
+- **GIVEN** a customer calls to modify their renewal terms
+  **WHEN** the agent opens the customer's renewal record
+  **THEN** the system displays the current renewal terms (premium, coverage
+  tier, sums insured, add-ons, deductible) alongside the changes from the
+  previous year
+
+- **GIVEN** the agent modifies the coverage on behalf of the customer
+  **WHEN** the agent selects new coverage options
+  **THEN** the system recalculates the premium in real time and displays the
+  updated terms for confirmation with the customer over the phone
+
+- **GIVEN** the customer verbally confirms the modification
+  **WHEN** the agent records the confirmation
+  **THEN** the system logs the modification with: agent ID, timestamp, customer
+  verification method (personnummer or BankID), and the specific changes made
+
+- **GIVEN** the modification changes the premium by more than a configured
+  threshold
+  **WHEN** the agent processes the change
+  **THEN** the system requires the agent to read a standardized disclosure
+  statement to the customer explaining the premium impact
+
+- **GIVEN** the customer requests a cancellation (opt-out) over the phone
+  **WHEN** the agent processes the request
+  **THEN** the system follows the same cancellation workflow as HRN-04 and
+  sends written confirmation to the customer
+
+### Data Requirements
+
+| Data Element              | Source         | Required |
+| ------------------------- | -------------- | -------- |
+| Customer personnummer     | Agent input    | Yes      |
+| Agent ID                  | System         | Yes      |
+| Modification timestamp    | System         | Yes      |
+| Verification method       | Agent input    | Yes      |
+| Changes made              | Agent input    | Yes      |
+| Disclosure statement read | Agent checkbox | Yes      |
+| Updated premium           | Rating engine  | Yes      |
+
+### Regulatory
+
+- **FSA-004** — Agent must communicate renewal terms clearly and ensure the
+  customer understands the changes
+- **IDD-011** — Agent-assisted modifications constitute a demands-and-needs
+  interaction; the agent must verify the new configuration meets the customer's
+  needs
+- **IDD-006** — If the agent recommends a coverage change, it constitutes
+  advice and must be documented with rationale
+- **GDPR-007** — Customer identity verification and call records processed
+  under Article 6(1)(b) contract performance; call recording subject to
+  consent requirements
+
+---
+
+## HRN-09: Review Flagged Renewals
+
+**As an** underwriter (försäkringsgivare),
+**I want to** review renewals flagged for significant risk changes (multiple
+claims, area risk zone downgrade, large premium increase),
+**so that** I can verify that continued coverage is appropriate and pricing is
+accurate.
+
+### Acceptance Criteria
+
+- **GIVEN** a renewal has been flagged during premium recalculation (HRN-07)
+  **WHEN** the underwriter opens the renewal queue
+  **THEN** the system displays the flagged renewals with the specific trigger:
+  premium increase above threshold, multiple claims during the period, area risk
+  zone downgrade, or significant index adjustment
+
+- **GIVEN** the underwriter reviews a flagged renewal
+  **WHEN** the underwriter examines the details
+  **THEN** the system provides: full claims history for the expiring period,
+  year-over-year premium comparison with factor breakdown, property details and
+  risk zone information, and any customer-reported changes (renovations, new
+  valuables)
+
+- **GIVEN** the underwriter approves the renewal
+  **WHEN** the approval is recorded
+  **THEN** the system queues the renewal for notice generation (HRN-10) with
+  any underwriter-adjusted terms
+
+- **GIVEN** the underwriter determines that continued coverage requires special
+  conditions
+  **WHEN** the underwriter adds conditions (increased deductible, coverage
+  exclusion, or required property improvements)
+  **THEN** the system records the conditions, includes them in the renewal
+  notice, and requires customer acceptance before renewal proceeds
+
+- **GIVEN** the underwriter decides not to renew the policy
+  **WHEN** the underwriter records the non-renewal decision
+  **THEN** the system generates a non-renewal notice to the customer at least
+  30 days before the huvudförfallodag with a clear explanation of the reasons
+
+### Review Triggers
+
+| Trigger                        | Threshold                         |
+| ------------------------------ | --------------------------------- |
+| Premium increase               | Above 15% year over year          |
+| Claims count                   | 2 or more claims in expiring term |
+| Area risk zone downgrade       | Zone changed to higher risk       |
+| Building sum index increase    | Above 10% year over year          |
+| Customer-reported risk changes | Renovations, new high-value items |
+
+### Data Requirements
+
+| Data Element             | Source             | Required    |
+| ------------------------ | ------------------ | ----------- |
+| Flag trigger reason      | Renewal processing | Yes         |
+| Claims history           | Claims system      | Yes         |
+| Premium factor breakdown | Rating engine      | Yes         |
+| Property risk data       | Risk mapping       | Yes         |
+| Underwriter decision     | Underwriter input  | Yes         |
+| Conditions applied       | Underwriter input  | Conditional |
+| Non-renewal notice       | System             | Conditional |
+
+### Regulatory
+
+- **FSA-003** — Non-renewal decisions must be communicated at least 30 days
+  before huvudförfallodag
+- **FSA-004** — Non-renewal reasons must be communicated clearly and fairly
+- **FSA-005** — Underwriter decisions must be consistent and fair; similar
+  risks must be treated similarly
+- **IDD-011** — Underwriter review at renewal is part of ongoing product
+  governance and oversight
+- **GDPR-007** — Underwriting decision data processed under Article 6(1)(f)
+  legitimate interest (risk management)
+
+---
+
+## HRN-10: Generate and Send Renewal Notice
+
+**As the** system,
+**I want to** generate and send the förnyelseavisering (renewal notice) 30 days
+before the huvudförfallodag,
+**so that** legal notice requirements are met and the customer has time to review
+and respond.
+
+### Acceptance Criteria
+
+- **GIVEN** the renewal has been processed (index adjustments, premium
+  recalculation, and any underwriter review complete)
+  **WHEN** the policy reaches T-30 days before huvudförfallodag
+  **THEN** the system generates a förnyelseavisering containing: new premium,
+  premium change explanation, updated sums insured with index adjustments,
+  coverage summary, year-over-year comparison, customer's right to cancel, and
+  instructions for making modifications
+
+- **GIVEN** the renewal notice is generated
+  **WHEN** the system dispatches the notice
+  **THEN** it is sent via the customer's preferred channel (postal letter,
+  digital mailbox such as Kivra, or Mina Sidor notification) and a copy is
+  stored in the customer's document archive
+
+- **GIVEN** the renewal notice includes index adjustments
+  **WHEN** the notice is formatted
+  **THEN** the adjustments are presented in a clear table showing: previous sum,
+  index name, index change percentage, and resulting new sum for both building
+  and contents
+
+- **GIVEN** the renewal processing window has passed for a policy
+  **WHEN** T-30 days arrives and the notice has not been sent
+  **THEN** the system escalates to operations staff to ensure the notice is
+  dispatched immediately, as late notices risk regulatory non-compliance
+
+- **GIVEN** the renewal notice has been sent to all eligible policies
+  **WHEN** the batch is complete
+  **THEN** the system generates an operations report showing: total notices
+  sent, delivery failures, flagged renewals pending review, and non-renewal
+  notices issued
+
+### Renewal Timeline
+
+| Milestone | Timing            | Action                                                   |
+| --------- | ----------------- | -------------------------------------------------------- |
+| T-60      | 60 days before    | Identify policies approaching huvudförfallodag           |
+| T-60      | 60 days before    | Recalculate index adjustments (HRN-05, HRN-06)           |
+| T-60      | 60 days before    | Recalculate premium (HRN-07)                             |
+| T-45      | 45 days before    | Underwriter reviews flagged renewals (HRN-09)            |
+| T-30      | 30 days before    | Send förnyelseavisering to customer                      |
+| T-30 to 0 | Response window   | Customer reviews, modifies (HRN-03), or cancels (HRN-04) |
+| T-0       | Huvudförfallodag  | Automatic renewal for non-cancelled policies             |
+| T+1       | Day after renewal | Send renewal confirmation and updated policy documents   |
+
+### Data Requirements
+
+| Data Element          | Source              | Required |
+| --------------------- | ------------------- | -------- |
+| Renewal record        | Renewal processing  | Yes      |
+| Customer contact info | Policy record       | Yes      |
+| Preferred channel     | Customer preference | Yes      |
+| Notice content        | System generated    | Yes      |
+| Dispatch timestamp    | System              | Yes      |
+| Delivery confirmation | Channel provider    | Yes      |
+| Operations report     | System generated    | Yes      |
+
+### External Integrations
+
+- **Postal Service** — Physical letter dispatch
+- **Digital Mailbox (Kivra)** — Digital notice delivery
+- **Mina Sidor** — Customer self-service portal notification
+
+### Regulatory
+
+- **FSA-003** — Renewal notice must be sent at least 30 days before
+  huvudförfallodag per Försäkringsavtalslagen
+- **FSA-004** — Notice must use clear, plain Swedish and present all changes
+  transparently
+- **FSA-016** — Index adjustment details must be included in the notice
+- **IDD-011** — Notice must inform the customer of their right to reassess
+  demands and needs at renewal
+- **GDPR-007** — Customer contact data processed for notice delivery under
+  Article 6(1)(b) contract performance
+
+---
+
+## Data Model
+
+### HomeRenewalRecord
+
+| Attribute                   | Type     | Description                                               |
+| --------------------------- | -------- | --------------------------------------------------------- |
+| Renewal ID                  | String   | Unique identifier for the renewal                         |
+| Policy number               | String   | Reference to the home insurance policy                    |
+| Policy type                 | Enum     | Hemförsäkring / Villa / Bostadsrätt / Fritidshus          |
+| Old policy period start     | Date     | Start date of the expiring policy period                  |
+| Old policy period end       | Date     | Huvudförfallodag                                          |
+| New policy period start     | Date     | Start date of the renewed policy period                   |
+| New policy period end       | Date     | End date of the renewed policy period                     |
+| Old annual premium          | Decimal  | Premium for the expiring period (SEK)                     |
+| New annual premium          | Decimal  | Calculated premium for the new period (SEK)               |
+| Old building sum insured    | Decimal  | Building sum during expiring period (SEK)                 |
+| New building sum insured    | Decimal  | Building sum after index adjustment (SEK)                 |
+| Old contents sum insured    | Decimal  | Contents sum during expiring period (SEK)                 |
+| New contents sum insured    | Decimal  | Contents sum after index adjustment (SEK)                 |
+| Byggkostnadsindex previous  | Decimal  | Index value used for previous period                      |
+| Byggkostnadsindex current   | Decimal  | Current index value from SCB                              |
+| KPI previous                | Decimal  | KPI value used for previous period                        |
+| KPI current                 | Decimal  | Current KPI value from SCB                                |
+| Claims count                | Integer  | Number of claims during expiring period                   |
+| Area risk zone              | String   | Current risk zone for the property                        |
+| Coverage tier               | Enum     | Bas / Standard / Premium                                  |
+| Add-ons                     | List     | Active add-ons (allrisk, ID-skydd, etc.)                  |
+| Deductible (självrisk)      | Decimal  | Deductible amount (SEK)                                   |
+| Renewal status              | Enum     | Pending / Notice Sent / Renewed / Cancelled / Non-renewal |
+| Underwriter review required | Boolean  | Whether the renewal was flagged for review                |
+| Underwriter decision        | String   | Approve / Conditional / Non-renewal                       |
+| Notice sent date            | DateTime | When the förnyelseavisering was dispatched                |
+| Renewal processed date      | DateTime | When the renewal was processed on huvudförfallodag        |
+| Cancellation date           | DateTime | When the customer cancelled (if applicable)               |
+| Modification applied        | Boolean  | Whether coverage was modified at renewal                  |
+| Premium factor breakdown    | JSON     | Detailed breakdown of premium rating factors              |
+
+---
+
+## Regulatory Traceability Matrix
+
+| Requirement | HRN-01 | HRN-02 | HRN-03 | HRN-04 | HRN-05 | HRN-06 | HRN-07 | HRN-08 | HRN-09 | HRN-10 |
+| ----------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| FSA-003     | X      |        |        | X      |        |        |        |        | X      | X      |
+| FSA-004     | X      | X      | X      | X      | X      | X      | X      | X      | X      | X      |
+| FSA-005     |        |        |        |        | X      | X      |        |        | X      |        |
+| FSA-006     |        |        |        |        |        |        | X      |        |        |        |
+| FSA-012     |        |        | X      |        |        |        |        |        |        |        |
+| FSA-016     | X      | X      |        |        | X      | X      | X      |        |        | X      |
+| GDPR-007    | X      |        | X      | X      | X      | X      | X      | X      | X      | X      |
+| IDD-006     |        |        |        |        |        |        |        | X      |        |        |
+| IDD-011     | X      | X      | X      |        |        |        | X      | X      | X      | X      |

--- a/docs/phase-2-home-property/user-stories/index.md
+++ b/docs/phase-2-home-property/user-stories/index.md
@@ -93,3 +93,22 @@ post-burglary support:
 | HCB-10 | Customer       | Claim for accidentally damaged or lost property (allrisk/drulle) |
 | HCB-11 | Claims Handler | Process drulle claims with simplified assessment                 |
 | HCB-12 | Customer       | Access krisstöd (crisis support) after a burglary                |
+
+## Home Renewals (Förnyelse)
+
+The [home-renewals user stories](home-renewals.md) cover annual renewal of home
+and property insurance policies, including index adjustment, premium
+recalculation, renewal notices, and coverage modifications:
+
+| ID     | Actor                  | Summary                                                                 |
+| ------ | ---------------------- | ----------------------------------------------------------------------- |
+| HRN-01 | Customer               | Receive a renewal notice showing changes in premium and coverage        |
+| HRN-02 | Customer               | View year-over-year comparison of coverage and premium                  |
+| HRN-03 | Customer               | Modify coverage at renewal (upgrade/downgrade tier, add/remove add-ons) |
+| HRN-04 | Customer               | Opt out of automatic renewal before the deadline                        |
+| HRN-05 | System                 | Recalculate building sum insured using byggkostnadsindex                |
+| HRN-06 | System                 | Recalculate contents sum insured using konsumentprisindex               |
+| HRN-07 | System                 | Apply premium adjustments based on claims history and risk changes      |
+| HRN-08 | Customer Service Agent | Process renewal modifications for phone customers                       |
+| HRN-09 | Underwriter            | Review renewals flagged for significant risk changes                    |
+| HRN-10 | System                 | Generate and send renewal notice 30 days before huvudförfallodag        |


### PR DESCRIPTION
## Summary
- 10 user stories (HRN-01 through HRN-10) for annual home insurance renewal (förnyelse av hemförsäkring)
- Use case UC-HRN-001 covering the complete renewal lifecycle from T-60 identification through automatic renewal on huvudförfallodag
- Documents byggkostnadsindex and konsumentprisindex methodology for index adjustment of sums insured

## Changes
- New file: `docs/phase-2-home-property/user-stories/home-renewals.md` — 10 user stories with acceptance criteria, data requirements, and regulatory traceability
- New file: `docs/phase-2-home-property/use-cases/home-renewals.md` — UC-HRN-001 with main scenario, 7 alternative flows, 14 business rules, Mermaid process flow, and data model
- Updated: `docs/phase-2-home-property/user-stories/index.md` — Added Home Renewals section
- Updated: `docs/phase-2-home-property/use-cases/index.md` — Added Home Renewals section
- Updated: `docs/phase-2-home-property/index.md` — Added Home Renewals to documentation list, updated Renewals scope to "Documented"

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] `npm run build` succeeds

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)