### PR TITLE
docs(#77): Add Phase 2 intro & index pages — site structure

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -81,10 +81,12 @@ product scope.
 | Phase                         | Scope                           | Key Topics                                                                                                     |
 | ----------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | **Phase 1 — Motor Insurance** | Personal motor policies         | Quotes, policy administration, claims, renewals, cancellations, trafikförsäkring, underwriting and bonus rules |
-| **Phase 2 — Home & Property** | Homeowner and property policies | Property damage claims, natural disaster coverage                                                              |
+| **Phase 2 — Home & Property** | Homeowner and property policies | Quotes, policy administration, water damage, fire/natural events, burglary/theft claims                        |
 | **Phase 3 — Commercial**      | Business insurance              | Liability coverage, fleet insurance, commercial property                                                       |
 
-Phase 1 is the current focus. Phases 2 and 3 will be documented as the project
+Phase 1 is complete. Phase 2 documentation is in progress — quote and bind,
+policy administration, and claims handling (water damage, fire/natural events,
+burglary/theft) are documented. Phase 3 will be documented as the project
 progresses.
 
 ## Regulatory Traceability
@@ -106,8 +108,11 @@ that no regulatory obligation is overlooked during implementation.
 
 - **Start here** to understand the project context and documentation approach.
 - **Actors and Personas** define the people and systems involved.
-- **Phase sections** contain the user stories and use cases grouped by
-  insurance product.
+- **[Phase 1 — Motor](phase-1-motor/index.md)** covers personal motor
+  insurance policies.
+- **[Phase 2 — Home & Property](phase-2-home-property/index.md)** covers
+  hemförsäkring, villahemförsäkring, bostadsrättsförsäkring, and
+  fritidshusförsäkring.
 - **Regulatory section** provides the full compliance requirements that user
   stories reference.
 - **Glossary** defines Swedish insurance terms and domain-specific vocabulary.

--- a/docs/phase-2-home-property/index.md
+++ b/docs/phase-2-home-property/index.md
@@ -23,9 +23,23 @@ and fritidshusförsäkring (vacation home).
 | --------------------- | ---------- | ---------------------------------------------- |
 | Quote and Bind        | Documented | Customer inquiry through policy issuance       |
 | Policy Administration | Documented | Mid-term adjustments, endorsements             |
-| Claims Handling       | Planned    | FNOL through settlement                        |
+| Claims Handling       | Documented | FNOL through settlement                        |
 | Renewals              | Documented | Annual renewal and huvudförfallodag processing |
 | Cancellations         | Planned    | Customer and insurer-initiated cancellations   |
+
+## Regulatory Framework
+
+Home and property insurance requirements are subject to the same regulatory
+framework as motor insurance. Key regulatory considerations for this phase:
+
+| Regulation | Home & Property Relevance                                                |
+| ---------- | ------------------------------------------------------------------------ |
+| **FSA**    | Consumer protection, claims handling standards, solvency requirements    |
+| **GDPR**   | Property data, tenant/BRF member data, claims documentation, consent     |
+| **IDD**    | Demands-and-needs assessment for coverage tiers, product governance, KID |
+
+See the [regulatory section](../regulatory/fsa-requirements.md) for full
+requirement details.
 
 ## Documentation
 
@@ -39,6 +53,10 @@ and fritidshusförsäkring (vacation home).
 - [Water Damage Claims](user-stories/index.md#water-damage-claims-vattenskada) —
   15 user stories covering the water damage claim lifecycle (US-HCW-001
   through US-HCW-015)
+- [Fire & Natural Events](user-stories/index.md#fire--natural-events-brandnaturhändelser) —
+  12 user stories covering emergency FNOL, structural inspection, total loss
+  assessment, rebuild coordination, and subrogation (US-HCF-001 through
+  US-HCF-012)
 - [Burglary and Theft](user-stories/burglary-and-theft.md) — 12 user stories
   covering burglary claims, stolen property, allrisk/drulle, and crisis
   support (HCB-01 through HCB-12)
@@ -56,6 +74,9 @@ and fritidshusförsäkring (vacation home).
   (UC-HPA-002), and family member management (UC-HPA-003)
 - [Water Damage Claim Lifecycle](use-cases/uc-water-damage-lifecycle.md) —
   Complete use case (UC-HCW-001) covering FNOL through settlement and closure
+- [Fire/Natural Event Claim Lifecycle](use-cases/uc-fire-natural-event-lifecycle.md) —
+  Complete use case (UC-HCF-001) covering emergency FNOL through structural
+  assessment, total/partial loss determination, restoration, and closure
 - [Burglary Claim Processing](use-cases/burglary-and-theft.md) — Complete
   use case (UC-HCB-001) covering emergency response, FNOL, fraud screening,
   settlement with åldersavdrag, and allrisk/drulle claims


### PR DESCRIPTION
## Summary
- Updates `intro.md` with Phase 2 documentation status, expanded scope description, and direct navigation links to Phase 1 and Phase 2 sections
- Adds regulatory framework summary (FSA, GDPR, IDD) to the Phase 2 Home & Property index page
- Updates scope table to reflect that claims handling is now documented (water damage, fire/natural events, burglary/theft)
- Adds missing fire/natural events links to both user stories and use cases documentation sections

## Changes
- `docs/intro.md` — Updated Phase 2 scope description, phased delivery status text, and navigation section with direct links
- `docs/phase-2-home-property/index.md` — Added regulatory framework table, updated claims handling status to "Documented", added fire/natural events documentation links

## Testing
- [x] Markdownlint passes (zero warnings)
- [x] Prettier passes
- [x] `npm run build` succeeds (all links valid)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)