### PR TITLE
docs(#74): Add home liability & legal expenses user stories and use cases

### DIFF
--- a/docs/phase-2-home-property/index.md
+++ b/docs/phase-2-home-property/index.md
@@ -60,6 +60,10 @@ requirement details.
 - [Burglary and Theft](user-stories/burglary-and-theft.md) — 12 user stories
   covering burglary claims, stolen property, allrisk/drulle, and crisis
   support (HCB-01 through HCB-12)
+- [Liability & Legal Expenses](user-stories/liability-and-legal.md) — 10 user
+  stories covering liability claims (ansvarsskydd), legal expenses
+  (rättsskydd), settlement negotiation, defense, and BRF boundary
+  determination (HCL-01 through HCL-10)
 - [Home Renewals](user-stories/home-renewals.md) — 10 user stories covering
   annual renewal, index adjustments, premium recalculation, and coverage
   modifications (HRN-01 through HRN-10)
@@ -80,6 +84,12 @@ requirement details.
 - [Burglary Claim Processing](use-cases/burglary-and-theft.md) — Complete
   use case (UC-HCB-001) covering emergency response, FNOL, fraud screening,
   settlement with åldersavdrag, and allrisk/drulle claims
+- [Liability Claim Assessment](use-cases/uc-liability-claim-lifecycle.md) —
+  Complete use case (UC-HCL-001) covering liability assessment, settlement
+  negotiation, defense against unfounded claims, and cross-insurer coordination
+- [Legal Expenses Management](use-cases/uc-legal-expenses-lifecycle.md) —
+  Complete use case (UC-HCL-002) covering rättsskydd application, eligibility
+  verification, lawyer approval, cost tracking, and dispute resolution
 - [Annual Home Insurance Renewal](use-cases/home-renewals.md) — Complete
   use case (UC-HRN-001) covering index adjustments, premium recalculation,
   renewal notices, and customer response handling

--- a/docs/phase-2-home-property/use-cases/index.md
+++ b/docs/phase-2-home-property/use-cases/index.md
@@ -61,6 +61,13 @@ describes the complete flow from burglary report through settlement. It covers:
 - Allrisk/drulle simplified claims process
 - Crisis support (krisstöd) for burglary victims
 
+## Liability & Legal Expenses (Ansvar/Rättsskydd)
+
+| ID                                            | Title                                                  | Scope                                                                                                                            |
+| --------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| [UC-HCL-001](uc-liability-claim-lifecycle.md) | Liability Claim Assessment and Settlement              | End-to-end flow from incident report through liability assessment, settlement negotiation or defense, cross-insurer coordination |
+| [UC-HCL-002](uc-legal-expenses-lifecycle.md)  | Legal Expenses (Rättsskydd) Application and Management | End-to-end flow from rättsskydd application through eligibility, lawyer approval, cost tracking, and dispute resolution          |
+
 ## Home Renewals (Förnyelse)
 
 The [Annual Home Insurance Renewal](home-renewals.md) use case (UC-HRN-001)

--- a/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
@@ -1,0 +1,187 @@
+---
+sidebar_position: 31
+---
+
+# UC-HCL-002: Legal Expenses (Rättsskydd) Application and Management
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a legal expenses
+(rättsskydd) claim under home insurance — from application through eligibility
+verification, lawyer approval, cost management, and closure. Rättsskydd covers
+legal costs in qualifying civil disputes, typically at 75–80% of costs up to
+a cap of approximately 300,000 SEK. It is a mandatory component of Swedish
+hemförsäkring.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md),
+  [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** Lawyer (Advokat), Opposing Party, Court/Arbitration Body
+
+## Preconditions
+
+1. The customer holds an active home insurance policy with rättsskydd coverage
+2. A qualifying legal dispute has arisen where the customer needs legal
+   representation
+3. The dispute cannot be resolved without legal proceedings or legal counsel
+
+## Postconditions
+
+**Success:**
+
+- Rättsskydd eligibility verified and approved
+- Lawyer approved with fee estimate within budget
+- Legal costs tracked and paid per coverage terms (75–80% up to cap)
+- Dispute resolved (judgment, settlement, or withdrawal)
+- Full claims file archived for regulatory retention
+
+**Failure:**
+
+- Application denied due to ineligible dispute type, waiting period, or
+  excluded category
+- Customer informed of denial reason and right to appeal via complaints process
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[1. Customer applies for rättsskydd] --> B[2. Register application]
+    B --> C{3. Verify eligibility}
+    C -->|Eligible| D[4. Customer submits lawyer and fee estimate]
+    C -->|Not eligible| E[3a. Deny application with explanation]
+    C -->|Waiting period| F[3b. Check waiting period status]
+    F -->|Passed| D
+    F -->|Not passed| E
+    D --> G{5. Approve lawyer and fees?}
+    G -->|Approved| H[6. Active legal proceedings]
+    G -->|Fees too high| I[5a. Negotiate fee adjustment]
+    I --> G
+    H --> J[7. Track costs and process invoices]
+    J --> K{Costs near cap?}
+    K -->|Yes| L[7a. Notify customer of cap approach]
+    K -->|No| J
+    L --> J
+    J --> M[8. Dispute resolved]
+    M --> N[9. Final settlement and closure]
+
+    style A fill:#e1f5fe
+    style N fill:#e8f5e9
+    style E fill:#fce4ec
+    style I fill:#fff3e0
+    style L fill:#fff3e0
+```
+
+## Main Flow (Rättsskydd Application and Management)
+
+| Step | Actor          | Action                                                                  | System Response                                                                | Reference                                                                                          |
+| ---- | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| 1    | Customer       | Applies for rättsskydd via web, app, or phone                           | Creates rättsskydd claim record, sends confirmation to customer                | [HCL-05](../user-stories/liability-and-legal.md#hcl-05-apply-for-rättsskydd-for-a-legal-dispute)   |
+| 2    | Claims Handler | Registers application with dispute details and opposing party           | Validates coverage status, assigns claims handler                              | [HCL-05](../user-stories/liability-and-legal.md#hcl-05-apply-for-rättsskydd-for-a-legal-dispute)   |
+| 3    | Claims Handler | Verifies eligibility: dispute type, timing, waiting period, exclusions  | Displays eligibility checklist, records determination                          | [HCL-06](../user-stories/liability-and-legal.md#hcl-06-verify-rättsskydd-eligibility)              |
+| 4    | Customer       | Submits chosen lawyer name, firm, and fee estimate                      | Records lawyer details, presents fee reasonableness guidelines                 | [HCL-07](../user-stories/liability-and-legal.md#hcl-07-approve-lawyer-and-fee-estimate)            |
+| 5    | Claims Handler | Reviews and approves lawyer choice and fee estimate                     | Records approval, sets approved budget, notifies customer                      | [HCL-07](../user-stories/liability-and-legal.md#hcl-07-approve-lawyer-and-fee-estimate)            |
+| 6    | Lawyer         | Conducts legal proceedings on behalf of the customer                    | System tracks case status and milestones                                       | [HCL-07](../user-stories/liability-and-legal.md#hcl-07-approve-lawyer-and-fee-estimate)            |
+| 7    | Claims Handler | Reviews and approves lawyer invoices against approved budget            | Processes payment (coverage % of invoice), tracks cumulative costs against cap | [HCL-08](../user-stories/liability-and-legal.md#hcl-08-understand-self-retention-and-coverage-cap) |
+| 8    | Lawyer         | Reports dispute outcome (judgment, settlement, withdrawal)              | Records outcome in claim file                                                  | [HCL-05](../user-stories/liability-and-legal.md#hcl-05-apply-for-rättsskydd-for-a-legal-dispute)   |
+| 9    | Claims Handler | Calculates final settlement, processes remaining payments, closes claim | Archives claim file, records total costs and customer self-retention           | [HCL-08](../user-stories/liability-and-legal.md#hcl-08-understand-self-retention-and-coverage-cap) |
+
+## Alternative Flow: Application Denied
+
+| Step | Actor          | Action                                                              | System Response                                           |
+| ---- | -------------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
+| 3a.1 | Claims Handler | Determines dispute does not qualify (excluded type, timing, amount) | Records denial with specific reason                       |
+| 3a.2 | System         | Sends written denial to customer with explanation                   | Includes right to appeal via complaints process (FSA-009) |
+| 3a.3 | Customer       | May appeal the denial through the complaints process                | Complaint is logged and routed to complaints handler      |
+
+## Alternative Flow: Fee Estimate Exceeds Reasonable Range
+
+| Step | Actor          | Action                                                            | System Response                                              |
+| ---- | -------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| 5a.1 | Claims Handler | Identifies fee estimate as above market range or disproportionate | Flags fee concern, documents reasoning                       |
+| 5a.2 | Claims Handler | Contacts customer to discuss alternatives                         | Records communication, suggests fee adjustment or new lawyer |
+| 5a.3 | Customer       | Submits revised fee estimate or confirms acceptance of cap        | Updates approved budget, notifies customer of approval       |
+
+## Alternative Flow: Customer Changes Lawyer
+
+| Step | Actor          | Action                                                   | System Response                                        |
+| ---- | -------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| 6a.1 | Customer       | Requests to change lawyer during proceedings             | Records change request                                 |
+| 6a.2 | Claims Handler | Reviews new lawyer choice and fee estimate               | Approves new lawyer, adjusts budget for remaining work |
+| 6a.3 | System         | Transfers case file to new lawyer, adjusts cost tracking | Updates lawyer details, recalculates remaining budget  |
+
+## Exception Flow: Costs Exceed Coverage Cap
+
+| Step | Actor          | Action                                                        | System Response                                            |
+| ---- | -------------- | ------------------------------------------------------------- | ---------------------------------------------------------- |
+| 7a.1 | System         | Detects cumulative costs reaching 80% of the coverage cap     | Sends warning notification to customer and claims handler  |
+| 7a.2 | Claims Handler | Informs customer that remaining costs above cap are uninsured | Records cap notification, customer acknowledges in writing |
+| 7a.3 | Customer       | Decides whether to continue proceedings at own cost or settle | Records customer decision, adjusts claim accordingly       |
+
+## Exception Flow: Dispute Settled Before Proceedings
+
+| Step | Actor    | Action                                                    | System Response                                            |
+| ---- | -------- | --------------------------------------------------------- | ---------------------------------------------------------- |
+| 6b.1 | Customer | Reports that the dispute has been settled out of court    | Records settlement details                                 |
+| 6b.2 | System   | Processes final lawyer invoice for work completed to date | Calculates final costs, coverage share, and self-retention |
+| 6b.3 | System   | Closes claim with settlement outcome                      | Archives claim file                                        |
+
+## Validation Rules
+
+| Rule       | Description                                                              |
+| ---------- | ------------------------------------------------------------------------ |
+| VR-HCL-101 | Dispute must fall within a qualifying category (see eligibility table)   |
+| VR-HCL-102 | Dispute must not have arisen before the policy inception date            |
+| VR-HCL-103 | Waiting period must have passed for applicable dispute categories        |
+| VR-HCL-104 | Dispute value must exceed the qualifying threshold (25,000 SEK)          |
+| VR-HCL-105 | Lawyer hourly rate must be within market range for reasonableness        |
+| VR-HCL-106 | Total approved fees must not exceed the coverage cap (300,000 SEK)       |
+| VR-HCL-107 | Excluded dispute types (family law, criminal, business) must be rejected |
+
+## Business Rules
+
+| Rule       | Description                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------- |
+| BR-HCL-101 | Rättsskydd covers 75–80% of approved legal costs; the customer pays the remaining self-retention               |
+| BR-HCL-102 | A base deductible of 1,500 SEK applies in addition to the self-retention percentage                            |
+| BR-HCL-103 | The coverage cap is typically 300,000 SEK per dispute; amounts above the cap are the customer's responsibility |
+| BR-HCL-104 | The customer has the right to choose their own lawyer (advokat); the insurer assesses fee reasonableness       |
+| BR-HCL-105 | Interim invoices are paid as they are approved; the customer's self-retention is collected proportionally      |
+| BR-HCL-106 | The insurer may require the customer to attempt mediation before approving full litigation costs               |
+| BR-HCL-107 | Disputes under 25,000 SEK do not qualify for rättsskydd                                                        |
+
+## External Integrations
+
+| System            | Purpose                                    | Data Exchanged                                  |
+| ----------------- | ------------------------------------------ | ----------------------------------------------- |
+| Payment provider  | Lawyer invoice payments                    | Invoice amount, coverage share, payment details |
+| Law firm / Lawyer | Case management, invoicing, status updates | Fee estimates, invoices, case outcomes          |
+| Court registry    | Verification of legal proceedings          | Case numbers, hearing dates, judgments          |
+
+## Regulatory
+
+- **FSA-005** — Fair settlement: rättsskydd is a mandatory component of
+  hemförsäkring; the insurer must administer it per published policy terms
+- **FSA-003** — Timely claims handling: eligibility determination and fee
+  approval must not delay the customer's access to legal representation
+- **FSA-009** — Complaints handling: the customer must be informed of the
+  right to appeal if the rättsskydd application is denied
+- **FSA-012** — Coverage disclosure: self-retention, coverage cap, and
+  qualifying dispute types must be clearly communicated
+- **FSA-014** — Record keeping: the complete rättsskydd file (application,
+  eligibility assessment, lawyer approval, invoices, outcome) must be
+  retained for 10 years
+- **GDPR-007** — Personal data including dispute details and opposing party
+  information must be processed in accordance with Article 6(1)(b) contract
+  performance; data shared with lawyers must be covered by data processing
+  agreements
+- **IDD-011** — The customer must receive adequate advice on the scope,
+  limitations, self-retention, and coverage cap of rättsskydd before incurring
+  legal costs
+
+## Related User Stories
+
+- [HCL-05](../user-stories/liability-and-legal.md#hcl-05-apply-for-rättsskydd-for-a-legal-dispute) — Apply for Rättsskydd for a Legal Dispute
+- [HCL-06](../user-stories/liability-and-legal.md#hcl-06-verify-rättsskydd-eligibility) — Verify Rättsskydd Eligibility
+- [HCL-07](../user-stories/liability-and-legal.md#hcl-07-approve-lawyer-and-fee-estimate) — Approve Lawyer and Fee Estimate
+- [HCL-08](../user-stories/liability-and-legal.md#hcl-08-understand-self-retention-and-coverage-cap) — Understand Self-Retention and Coverage Cap

--- a/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
@@ -1,0 +1,199 @@
+---
+sidebar_position: 30
+---
+
+# UC-HCL-001: Liability Claim Assessment and Settlement
+
+## Overview
+
+This use case describes the end-to-end lifecycle of a liability claim
+(ansvarsskydd) under home insurance — from initial report through liability
+assessment, settlement negotiation or defense, cross-insurer coordination, and
+closure. Ansvarsskydd covers damage the policyholder accidentally causes to
+others, with typical coverage up to 5,000,000 SEK. The insurer has a dual
+obligation: to compensate justified claims and to defend the policyholder
+against unfounded claims.
+
+## Actors
+
+- **Primary:** [Customer (Privatkund)](../../actors/internal/customer.md),
+  [Claims Handler (Skadereglerare)](../../actors/internal/claims-handler.md)
+- **Supporting:** [Property Inspector
+  (Besiktningsman)](../../actors/external/property-inspector.md), [BRF Board
+  (BRF-styrelse)](../../actors/external/brf-board.md), Injured Party
+  (Skadelidande), Opposing Insurer
+
+## Preconditions
+
+1. The policyholder holds an active home insurance policy (hemförsäkring,
+   villahemförsäkring, or bostadsrättsförsäkring) with ansvarsskydd
+2. An incident has occurred where the policyholder may have caused damage to a
+   third party
+3. The customer or the injured party has reported the incident
+
+## Postconditions
+
+**Success:**
+
+- Liability has been assessed and documented
+- If liable: settlement paid to injured party, policyholder's deductible
+  collected
+- If not liable: policyholder defended, injured party informed of denial
+- Cross-insurer coordination completed (if applicable)
+- Full claims file archived for regulatory retention
+
+**Failure:**
+
+- Claim denied due to policy exclusion (e.g., intentional act, business
+  activity)
+- Customer informed of denial reason and complaints procedure
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A[1. Report liability incident] --> B[2. Register FNOL and verify coverage]
+    B --> C[3. Gather evidence and documentation]
+    C --> D{4. Assess liability}
+    D -->|Liable| E[5. Negotiate settlement with injured party]
+    D -->|Not liable| F[6. Defend policyholder]
+    D -->|Uncertain| G[4a. Commission expert investigation]
+    G --> D
+    E --> H{Settlement agreed?}
+    H -->|Yes| I[7. Process settlement payment]
+    H -->|No| J[5a. Escalate to mediation or legal proceedings]
+    J --> I
+    F --> K{Injured party accepts?}
+    K -->|Yes| L[8. Close claim]
+    K -->|No| M[6a. Engage legal counsel for defense]
+    M --> L
+    I --> N{Cross-insurer coordination needed?}
+    N -->|Yes| O[9. Coordinate with injured party's insurer]
+    N -->|No| L
+    O --> L
+
+    style A fill:#e1f5fe
+    style L fill:#e8f5e9
+    style F fill:#fff3e0
+    style G fill:#fff3e0
+    style J fill:#fff3e0
+    style M fill:#fce4ec
+```
+
+## Main Flow (Liability Claim Assessment and Settlement)
+
+| Step | Actor          | Action                                                                         | System Response                                                              | Reference                                                                                                          |
+| ---- | -------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1    | Customer       | Reports accidental damage caused to a third party via web, app, or phone       | Creates liability claim record, sends confirmation to customer               | [HCL-01](../user-stories/liability-and-legal.md#hcl-01-report-accidental-damage-caused-to-third-party)             |
+| 2    | Claims Handler | Registers FNOL, verifies ansvarsskydd coverage and policy status               | Validates coverage, assigns claims handler, confirms coverage to customer    | [HCL-01](../user-stories/liability-and-legal.md#hcl-01-report-accidental-damage-caused-to-third-party)             |
+| 3    | Claims Handler | Gathers evidence: incident details, photos, witness statements, damage reports | Records evidence, requests additional documentation if needed                | [HCL-02](../user-stories/liability-and-legal.md#hcl-02-assess-policyholder-legal-liability)                        |
+| 4    | Claims Handler | Assesses liability based on evidence, negligence, and causation                | Records liability determination with legal basis                             | [HCL-02](../user-stories/liability-and-legal.md#hcl-02-assess-policyholder-legal-liability)                        |
+| 5    | Claims Handler | Negotiates settlement amount with the injured party                            | Displays coverage limits, tracks negotiation, generates settlement agreement | [HCL-03](../user-stories/liability-and-legal.md#hcl-03-negotiate-settlement-with-injured-party)                    |
+| 6    | Claims Handler | If not liable, sends written denial to injured party with rationale            | Records defense rationale, informs policyholder                              | [HCL-04](../user-stories/liability-and-legal.md#hcl-04-defend-policyholder-against-unfounded-claims)               |
+| 7    | System         | Processes settlement payment to injured party, deducts deductible              | Records payment, updates claim status to "Settled"                           | [HCL-03](../user-stories/liability-and-legal.md#hcl-03-negotiate-settlement-with-injured-party)                    |
+| 8    | Claims Handler | Closes claim and archives documentation                                        | Archives claim file, updates policyholder claims history                     | [HCL-09](../user-stories/liability-and-legal.md#hcl-09-identify-cross-insurance-coordination-for-liability-claims) |
+| 9    | Claims Handler | Coordinates with injured party's insurer for subrogation or split settlement   | Records inter-insurer settlement, ensures no double payment                  | [HCL-09](../user-stories/liability-and-legal.md#hcl-09-identify-cross-insurance-coordination-for-liability-claims) |
+
+## Alternative Flow: Expert Investigation Required
+
+| Step | Actor          | Action                                                           | System Response                                       |
+| ---- | -------------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+| 4a.1 | Claims Handler | Determines expert investigation is needed (e.g., besiktningsman) | Creates referral, notifies expert                     |
+| 4a.2 | Besiktningsman | Inspects site, produces expert report                            | Records report findings in claim file                 |
+| 4a.3 | Claims Handler | Reviews expert report and completes liability assessment         | Updates liability determination based on expert input |
+
+## Alternative Flow: BRF Liability Boundary
+
+| Step | Actor          | Action                                                     | System Response                                                   |
+| ---- | -------------- | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| 4b.1 | Claims Handler | Identifies BRF property involvement                        | Presents BRF/individual liability boundary tool                   |
+| 4b.2 | Claims Handler | Determines BRF vs individual responsibility per stadgar    | Records responsibility assignment with legal basis                |
+| 4b.3 | Claims Handler | Routes claim to correct insurer (BRF or individual policy) | Updates claim routing, notifies relevant insurer and policyholder |
+
+## Alternative Flow: High-Value Settlement
+
+| Step | Actor                 | Action                                                | System Response                                          |
+| ---- | --------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| 5a.1 | Claims Handler        | Submits settlement exceeding threshold (>500,000 SEK) | Flags for senior approval, blocks payment                |
+| 5a.2 | Senior Claims Handler | Reviews and approves or adjusts the settlement amount | Records senior approval, releases payment for processing |
+
+## Alternative Flow: Multiple Injured Parties
+
+| Step | Actor          | Action                                                     | System Response                                              |
+| ---- | -------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
+| 5b.1 | Claims Handler | Identifies multiple injured parties from the same incident | Creates linked sub-claims for each injured party             |
+| 5b.2 | Claims Handler | Negotiates settlement with each party individually         | Tracks aggregate against liability limit, alerts if near cap |
+| 5b.3 | System         | Processes payments to each injured party                   | Records individual and aggregate settlements                 |
+
+## Exception Flow: Injured Party Disputes Denial
+
+| Step | Actor          | Action                                                   | System Response                                    |
+| ---- | -------------- | -------------------------------------------------------- | -------------------------------------------------- |
+| 6a.1 | Injured Party  | Disputes the liability denial                            | Records dispute, notifies claims handler           |
+| 6a.2 | Claims Handler | Evaluates whether to engage legal counsel for defense    | Creates defense authorization record               |
+| 6a.3 | Legal Counsel  | Defends policyholder in mediation, arbitration, or court | Tracks legal costs, updates claim with proceedings |
+| 6a.4 | System         | Records outcome (judgment, settlement, or withdrawal)    | Processes any court-ordered payment, closes claim  |
+
+## Exception Flow: Liability Limit Exceeded
+
+| Step | Actor          | Action                                                      | System Response                                         |
+| ---- | -------------- | ----------------------------------------------------------- | ------------------------------------------------------- |
+| 5c.1 | Claims Handler | Identifies that aggregate claims exceed the liability limit | Alerts handler and policyholder of coverage exhaustion  |
+| 5c.2 | Claims Handler | Informs injured parties that remaining costs are uninsured  | Records cap application, refers policyholder for advice |
+
+## Validation Rules
+
+| Rule       | Description                                                        |
+| ---------- | ------------------------------------------------------------------ |
+| VR-HCL-001 | Incident date must not be in the future                            |
+| VR-HCL-002 | Incident date must fall within the policy's active coverage period |
+| VR-HCL-003 | Ansvarsskydd must be included in the customer's coverage tier      |
+| VR-HCL-004 | Settlement amount must not exceed the policy's liability limit     |
+| VR-HCL-005 | High-value settlements require senior claims handler approval      |
+| VR-HCL-006 | Intentional acts are excluded from liability coverage              |
+| VR-HCL-007 | All liability determinations must include a documented legal basis |
+
+## Business Rules
+
+| Rule       | Description                                                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| BR-HCL-001 | The insurer must both compensate justified claims and defend against unfounded claims (dual obligation)      |
+| BR-HCL-002 | Settlement amounts exceeding 500,000 SEK require senior claims handler approval                              |
+| BR-HCL-003 | The policyholder must not admit liability or make payments to the injured party without insurer approval     |
+| BR-HCL-004 | Cross-insurer coordination must ensure the injured party receives full compensation without double payment   |
+| BR-HCL-005 | BRF/individual liability boundary follows bostadsrättslagen unless BRF stadgar specify otherwise             |
+| BR-HCL-006 | Defense costs (legal counsel, court fees) are covered under ansvarsskydd in addition to the settlement limit |
+
+## External Integrations
+
+| System                                  | Purpose                                     | Data Exchanged                                         |
+| --------------------------------------- | ------------------------------------------- | ------------------------------------------------------ |
+| GSR (Gemensamt Skadeanmälningsregister) | Claims register for fraud prevention        | Claim details, policyholder and injured party identity |
+| Opposing insurer                        | Cross-insurer coordination and subrogation  | Claim details, liability determination, settlement     |
+| Payment provider                        | Settlement payment to injured party         | Payment amount, recipient details                      |
+| Legal counsel network                   | Defense representation for the policyholder | Case details, legal costs, proceedings                 |
+
+## Regulatory
+
+- **FSA-005** — Fair settlement: liability claims must be assessed objectively;
+  the insurer must compensate justified claims and defend against unfounded ones
+- **FSA-003** — Timely claims handling: the entire liability claim lifecycle
+  must proceed without undue delay
+- **FSA-009** — Complaints handling: both the policyholder and the injured party
+  must be informed of the complaints procedure
+- **FSA-014** — Record keeping: the complete claims file must be retained for
+  10 years
+- **GDPR-007** — Personal data of the policyholder and injured party must be
+  processed in accordance with Article 6(1)(b) and 6(1)(f); data shared with
+  opposing insurers must be limited to what is necessary
+- **IDD-011** — The customer must receive adequate advice on the scope and
+  limitations of ansvarsskydd
+
+## Related User Stories
+
+- [HCL-01](../user-stories/liability-and-legal.md#hcl-01-report-accidental-damage-caused-to-third-party) — Report Accidental Damage Caused to Third Party
+- [HCL-02](../user-stories/liability-and-legal.md#hcl-02-assess-policyholder-legal-liability) — Assess Policyholder Legal Liability
+- [HCL-03](../user-stories/liability-and-legal.md#hcl-03-negotiate-settlement-with-injured-party) — Negotiate Settlement with Injured Party
+- [HCL-04](../user-stories/liability-and-legal.md#hcl-04-defend-policyholder-against-unfounded-claims) — Defend Policyholder Against Unfounded Claims
+- [HCL-09](../user-stories/liability-and-legal.md#hcl-09-identify-cross-insurance-coordination-for-liability-claims) — Identify Cross-Insurance Coordination
+- [HCL-10](../user-stories/liability-and-legal.md#hcl-10-determine-brf-liability-vs-individual-liability) — Determine BRF Liability vs Individual Liability

--- a/docs/phase-2-home-property/user-stories/index.md
+++ b/docs/phase-2-home-property/user-stories/index.md
@@ -154,6 +154,40 @@ post-burglary support:
 | HCB-11 | Claims Handler | Process drulle claims with simplified assessment                 |
 | HCB-12 | Customer       | Access krisstöd (crisis support) after a burglary                |
 
+## Liability & Legal Expenses (Ansvar/Rättsskydd)
+
+Liability coverage (ansvarsskydd) handles damage the policyholder accidentally
+causes to others, while legal expenses coverage (rättsskydd) covers legal costs
+in qualifying civil disputes. These user stories cover the complete liability
+and legal expenses claim lifecycle including liability assessment, settlement
+negotiation, defense against unfounded claims, rättsskydd eligibility, lawyer
+approval, and BRF vs individual liability boundaries.
+
+### Liability (Ansvarsskydd)
+
+| ID                                                                                     | Title                                          | Priority  |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------- | --------- |
+| [HCL-01](liability-and-legal.md#hcl-01-report-accidental-damage-caused-to-third-party) | Report Accidental Damage Caused to Third Party | Must Have |
+| [HCL-02](liability-and-legal.md#hcl-02-assess-policyholder-legal-liability)            | Assess Policyholder Legal Liability            | Must Have |
+| [HCL-03](liability-and-legal.md#hcl-03-negotiate-settlement-with-injured-party)        | Negotiate Settlement with Injured Party        | Must Have |
+| [HCL-04](liability-and-legal.md#hcl-04-defend-policyholder-against-unfounded-claims)   | Defend Policyholder Against Unfounded Claims   | Must Have |
+
+### Legal Expenses (Rättsskydd)
+
+| ID                                                                                 | Title                                      | Priority  |
+| ---------------------------------------------------------------------------------- | ------------------------------------------ | --------- |
+| [HCL-05](liability-and-legal.md#hcl-05-apply-for-rättsskydd-for-a-legal-dispute)   | Apply for Rättsskydd for a Legal Dispute   | Must Have |
+| [HCL-06](liability-and-legal.md#hcl-06-verify-rättsskydd-eligibility)              | Verify Rättsskydd Eligibility              | Must Have |
+| [HCL-07](liability-and-legal.md#hcl-07-approve-lawyer-and-fee-estimate)            | Approve Lawyer and Fee Estimate            | Must Have |
+| [HCL-08](liability-and-legal.md#hcl-08-understand-self-retention-and-coverage-cap) | Understand Self-Retention and Coverage Cap | Must Have |
+
+### Cross-Coverage
+
+| ID                                                                                                 | Title                                 | Priority    |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
+| [HCL-09](liability-and-legal.md#hcl-09-identify-cross-insurance-coordination-for-liability-claims) | Identify Cross-Insurance Coordination | Should Have |
+| [HCL-10](liability-and-legal.md#hcl-10-determine-brf-liability-vs-individual-liability)            | Determine BRF vs Individual Liability | Should Have |
+
 ## Home Renewals (Förnyelse)
 
 The [home-renewals user stories](home-renewals.md) cover annual renewal of home

--- a/docs/phase-2-home-property/user-stories/liability-and-legal.md
+++ b/docs/phase-2-home-property/user-stories/liability-and-legal.md
@@ -1,0 +1,757 @@
+---
+sidebar_position: 5
+---
+
+# Liability and Legal Expenses Claims — User Stories
+
+User stories for home insurance liability (ansvarsskydd) and legal expenses
+(rättsskydd) claims processing. Covers accidental damage to third parties,
+liability assessment, settlement negotiation, defense against unfounded claims,
+legal dispute applications, lawyer approval, and BRF vs individual liability
+boundaries.
+
+## Overview
+
+| ID     | Actor           | Summary                                                                |
+| ------ | --------------- | ---------------------------------------------------------------------- |
+| HCL-01 | Customer        | Report accidental damage caused to someone else's property             |
+| HCL-02 | Claims Handler  | Assess whether the policyholder is legally liable                      |
+| HCL-03 | Claims Handler  | Negotiate settlement with the injured party                            |
+| HCL-04 | Claims Handler  | Defend the policyholder against unfounded liability claims             |
+| HCL-05 | Customer        | Apply for rättsskydd for a legal dispute                               |
+| HCL-06 | Claims Handler  | Verify rättsskydd eligibility (dispute type, timing, coverage)         |
+| HCL-07 | Claims Handler  | Approve the customer's choice of lawyer and fee estimate               |
+| HCL-08 | Customer        | Understand self-retention and coverage cap for legal costs             |
+| HCL-09 | Claims Handler  | Identify when a liability claim triggers the injured party's insurance |
+| HCL-10 | BRF Board Chair | Determine when BRF liability vs individual liability applies           |
+
+---
+
+## HCL-01: Report Accidental Damage Caused to Third Party
+
+**As a** customer (privatkund),
+**I want to** report that I accidentally caused damage to someone else's
+property,
+**so that** my liability coverage (ansvarsskydd) handles the claim.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has an active home insurance policy with liability
+  coverage (ansvarsskydd)
+  **WHEN** the customer reports accidental damage caused to a third party via
+  web, app, or phone
+  **THEN** the system creates a liability claim record with claim type
+  "Ansvarsskada", records the incident date, location, and description, and
+  generates a unique claim number (skadenummer)
+
+- **GIVEN** the customer submits the liability report
+  **WHEN** the system processes the initial report
+  **THEN** the system captures: description of the incident, identity of the
+  injured party (skadelidande), nature and extent of the damage, and whether a
+  polisanmälan has been filed
+
+- **GIVEN** the customer has reported the liability incident
+  **WHEN** the claim is created
+  **THEN** the system sends a confirmation to the customer with the claim
+  number, explains the next steps (liability assessment, contact from claims
+  handler), and informs the customer not to admit liability or make any
+  payments to the injured party
+
+- **GIVEN** the injured party has contacted TryggFörsäkring directly
+  **WHEN** the injured party files a claim against the policyholder
+  **THEN** the system creates a liability claim linked to the policyholder's
+  policy and notifies both the policyholder and the claims handler
+
+### Data Requirements
+
+| Data Element          | Source         | Required |
+| --------------------- | -------------- | -------- |
+| Incident date/time    | Customer input | Yes      |
+| Incident location     | Customer input | Yes      |
+| Incident description  | Customer input | Yes      |
+| Injured party name    | Customer input | Yes      |
+| Injured party contact | Customer input | Yes      |
+| Damage description    | Customer input | Yes      |
+| Estimated damage cost | Customer input | No       |
+| Police report number  | Customer input | No       |
+| Policy number         | System lookup  | Yes      |
+
+### External Integrations
+
+- **SMS/Push Gateway** — Customer and injured party notifications
+
+### Regulatory
+
+- **FSA-003** — Timely claims handling; liability claims must be registered
+  promptly upon notification
+- **FSA-005** — Fair settlement; liability coverage is a core component of
+  hemförsäkring
+- **GDPR-007** — Personal data of both the policyholder and injured party is
+  processed; legal basis is Article 6(1)(b) contract performance and
+  Article 6(1)(f) legitimate interest for the injured party's data
+
+---
+
+## HCL-02: Assess Policyholder Legal Liability
+
+**As a** claims handler (skadereglerare),
+**I want to** assess whether the policyholder is legally liable for the
+reported damage,
+**so that** the claim is valid and coverage applies under ansvarsskydd.
+
+### Acceptance Criteria
+
+- **GIVEN** a liability claim has been registered (HCL-01)
+  **WHEN** the claims handler opens the claim for assessment
+  **THEN** the system displays: the incident details, the policyholder's
+  coverage limits (typically up to 5,000,000 SEK), any relevant exclusions,
+  and the injured party's damage claim
+
+- **GIVEN** the claims handler assesses liability
+  **WHEN** the handler evaluates the evidence
+  **THEN** the handler determines one of: (a) policyholder is liable — proceed
+  to settlement negotiation, (b) liability is disputed — further investigation
+  needed, or (c) policyholder is not liable — reject liability and defend the
+  policyholder
+
+- **GIVEN** the claims handler determines the policyholder is liable
+  **WHEN** the liability assessment is recorded
+  **THEN** the system updates the claim status to "Liability Confirmed",
+  records the legal basis for liability (e.g., negligence, strict liability
+  under skadeståndslagen), and proceeds to settlement (HCL-03)
+
+- **GIVEN** the claims handler determines the policyholder is not liable
+  **WHEN** the liability denial is recorded
+  **THEN** the system updates the claim status to "Liability Denied", records
+  the rationale, and triggers the defense process (HCL-04) if the injured
+  party disputes the denial
+
+- **GIVEN** the liability assessment requires expert investigation
+  **WHEN** the claims handler identifies the need for a field inspection or
+  expert opinion
+  **THEN** the system allows the handler to commission a besiktningsman or
+  technical expert and records the referral
+
+### Liability Assessment Factors
+
+| Factor                    | Description                                                              |
+| ------------------------- | ------------------------------------------------------------------------ |
+| Negligence (vårdslöshet)  | Did the policyholder fail to exercise reasonable care?                   |
+| Causation (orsakssamband) | Is there a direct link between the act and the damage?                   |
+| Strict liability          | Does skadeståndslagen impose liability without negligence?               |
+| Contributory negligence   | Did the injured party contribute to the damage?                          |
+| Exclusions                | Does the policy exclude this type of liability (e.g., intentional acts)? |
+
+### Data Requirements
+
+| Data Element            | Source               | Required |
+| ----------------------- | -------------------- | -------- |
+| Liability determination | Claims handler       | Yes      |
+| Legal basis             | Claims handler       | Yes      |
+| Evidence documents      | Customer/third party | No       |
+| Expert opinion          | Besiktningsman       | No       |
+| Coverage verification   | System               | Yes      |
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; liability assessment must be objective and
+  well-documented
+- **FSA-003** — Timely claims handling; assessment must not be unreasonably
+  delayed
+- **FSA-009** — Complaints handling; the policyholder must be informed of the
+  right to complain if they disagree with the assessment
+- **IDD-011** — Adequate advice on liability coverage; the customer must
+  understand what ansvarsskydd covers
+
+---
+
+## HCL-03: Negotiate Settlement with Injured Party
+
+**As a** claims handler (skadereglerare),
+**I want to** negotiate a settlement with the injured party (skadelidande),
+**so that** the liability claim is resolved fairly and efficiently.
+
+### Acceptance Criteria
+
+- **GIVEN** the policyholder's liability has been confirmed (HCL-02)
+  **WHEN** the claims handler initiates settlement negotiation
+  **THEN** the system displays: the injured party's damage claim, supporting
+  documentation, the policyholder's coverage limit, and any deductible
+  (självrisk) applicable to the policyholder
+
+- **GIVEN** the claims handler evaluates the injured party's claim
+  **WHEN** the handler reviews the damage documentation
+  **THEN** the handler assesses: whether the claimed amount is reasonable,
+  whether supporting evidence substantiates the claim, and whether any
+  deductions apply (e.g., betterment, depreciation)
+
+- **GIVEN** the claims handler and injured party reach a settlement agreement
+  **WHEN** the settlement amount is agreed
+  **THEN** the system records the settlement amount, generates a settlement
+  agreement document for the injured party to sign, and calculates the
+  policyholder's deductible
+
+- **GIVEN** the settlement amount exceeds a configured threshold (e.g.,
+  500,000 SEK)
+  **WHEN** the claims handler submits the settlement for approval
+  **THEN** the system escalates to a senior claims handler for authorization
+  before payment
+
+- **GIVEN** the injured party does not accept the settlement offer
+  **WHEN** negotiation fails
+  **THEN** the system records the impasse, and the claims handler informs both
+  parties of options: further negotiation, mediation, or legal proceedings
+
+### Coverage Limits (Ansvarsskydd)
+
+| Coverage Tier | Liability Limit (SEK) | Deductible (SEK) |
+| ------------- | --------------------- | ---------------- |
+| Bas           | 5,000,000             | 1,500            |
+| Standard      | 5,000,000             | 1,500            |
+| Premium       | 10,000,000            | 1,500            |
+
+### Data Requirements
+
+| Data Element         | Source             | Required    |
+| -------------------- | ------------------ | ----------- |
+| Damage claim amount  | Injured party      | Yes         |
+| Damage documentation | Injured party      | Yes         |
+| Settlement amount    | Claims handler     | Yes         |
+| Settlement agreement | System generated   | Yes         |
+| Deductible amount    | System calculation | Yes         |
+| Senior approval      | Senior handler     | Conditional |
+
+### External Integrations
+
+- **Payment Provider** — Settlement payment to injured party
+- **Document Generation** — Settlement agreement creation
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; the injured party must receive fair
+  compensation based on documented losses
+- **FSA-003** — Timely claims handling; settlement negotiation must not be
+  unreasonably prolonged
+- **FSA-009** — Complaints handling; the injured party must be informed of
+  the complaints procedure
+- **GDPR-007** — Injured party personal and financial data processed under
+  Article 6(1)(f) legitimate interest (claims settlement)
+
+---
+
+## HCL-04: Defend Policyholder Against Unfounded Claims
+
+**As a** claims handler (skadereglerare),
+**I want to** defend the policyholder against unfounded or exaggerated
+liability claims,
+**so that** the policyholder is protected from unjustified demands.
+
+### Acceptance Criteria
+
+- **GIVEN** the liability assessment (HCL-02) determines the policyholder is
+  not liable or the claim is exaggerated
+  **WHEN** the claims handler initiates the defense process
+  **THEN** the system records the defense rationale and sends a written denial
+  to the injured party with a clear explanation of why liability is rejected
+
+- **GIVEN** the injured party disputes the denial of liability
+  **WHEN** the injured party escalates the dispute
+  **THEN** the claims handler evaluates whether to engage legal counsel on
+  behalf of the policyholder, covered under the ansvarsskydd defense obligation
+
+- **GIVEN** the insurer decides to engage legal counsel for defense
+  **WHEN** the defense is initiated
+  **THEN** the system records the legal counsel appointment, tracks legal costs
+  separately from any potential settlement, and informs the policyholder of the
+  defense proceedings
+
+- **GIVEN** the dispute proceeds to court or arbitration
+  **WHEN** a judgment or award is rendered
+  **THEN** the system records the outcome, processes any ordered payment under
+  the liability coverage, and closes the claim
+
+- **GIVEN** the injured party's claim is partially valid
+  **WHEN** the claims handler identifies exaggerated elements
+  **THEN** the handler negotiates down to the substantiated amount and records
+  the adjustment rationale
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; the defense obligation is a core function of
+  ansvarsskydd — the insurer must defend the policyholder against unfounded
+  claims
+- **FSA-009** — Complaints handling; both the policyholder and injured party
+  must have access to the complaints process
+- **FSA-003** — Timely claims handling; defense proceedings must be conducted
+  without unreasonable delay
+- **GDPR-007** — Legal proceedings data is processed under Article 6(1)(f)
+  legitimate interest
+
+---
+
+## HCL-05: Apply for Rättsskydd for a Legal Dispute
+
+**As a** customer (privatkund),
+**I want to** apply for rättsskydd (legal expenses insurance) for a legal
+dispute,
+**so that** my legal costs are covered under my home insurance policy.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has an active home insurance policy with rättsskydd
+  coverage
+  **WHEN** the customer submits a rättsskydd application via web, app, or phone
+  **THEN** the system creates a rättsskydd claim record with claim type
+  "Rättsskydd", records the dispute description, opposing party, and generates
+  a claim number
+
+- **GIVEN** the customer submits the application
+  **WHEN** the system processes the request
+  **THEN** the system captures: nature of the dispute, opposing party identity,
+  when the dispute arose, whether an attorney has been engaged, and the
+  estimated legal costs
+
+- **GIVEN** the customer's application is registered
+  **WHEN** the system sends confirmation
+  **THEN** the customer receives the claim number, an explanation of
+  rättsskydd coverage (percentage covered, cap amount, deductible), and
+  expected processing timeline
+
+- **GIVEN** the customer has not yet engaged an attorney
+  **WHEN** the customer requests guidance
+  **THEN** the system informs the customer of their right to choose their own
+  attorney (advokat) and that the attorney's fees must be reasonable and
+  approved by the insurer
+
+### Data Requirements
+
+| Data Element          | Source         | Required |
+| --------------------- | -------------- | -------- |
+| Dispute description   | Customer input | Yes      |
+| Opposing party        | Customer input | Yes      |
+| Dispute start date    | Customer input | Yes      |
+| Attorney name         | Customer input | No       |
+| Estimated legal costs | Customer input | No       |
+| Policy number         | System lookup  | Yes      |
+| Coverage verification | System         | Yes      |
+
+### Regulatory
+
+- **FSA-003** — Timely claims handling; rättsskydd applications must be
+  processed promptly
+- **FSA-005** — Fair settlement; rättsskydd is a mandatory component of
+  hemförsäkring and must be administered per policy terms
+- **IDD-011** — Adequate advice; the customer must understand the scope and
+  limitations of rättsskydd coverage
+- **GDPR-007** — Dispute details and opposing party data processed under
+  Article 6(1)(b) contract performance
+
+---
+
+## HCL-06: Verify Rättsskydd Eligibility
+
+**As a** claims handler (skadereglerare),
+**I want to** verify that the dispute qualifies for rättsskydd coverage
+(dispute type, timing, amount),
+**so that** coverage is correctly applied per the policy terms.
+
+### Acceptance Criteria
+
+- **GIVEN** a rättsskydd application has been registered (HCL-05)
+  **WHEN** the claims handler opens the application for review
+  **THEN** the system displays: the dispute details, policy coverage terms,
+  qualifying dispute types, waiting period status, and any prior rättsskydd
+  claims
+
+- **GIVEN** the claims handler evaluates eligibility
+  **WHEN** the handler checks the dispute type
+  **THEN** the system verifies that the dispute falls within covered categories
+  (see Qualifying Dispute Types table below) and is not excluded (e.g.,
+  disputes arising from criminal proceedings, family law, or business
+  activities)
+
+- **GIVEN** the dispute qualifies for rättsskydd
+  **WHEN** the handler approves the application
+  **THEN** the system updates the claim status to "Rättsskydd Approved",
+  records the applicable coverage terms (percentage, cap, deductible), and
+  notifies the customer
+
+- **GIVEN** the dispute does not qualify for rättsskydd
+  **WHEN** the handler denies the application
+  **THEN** the system records the denial reason, sends a written explanation to
+  the customer, and informs them of the right to appeal via the complaints
+  process
+
+- **GIVEN** the dispute arose before the policy inception or during the
+  waiting period (typically 2 years for certain dispute types)
+  **WHEN** the handler checks timing
+  **THEN** the system flags the timing issue and the handler verifies whether
+  the waiting period exclusion applies
+
+### Qualifying Dispute Types
+
+| Category               | Examples                                                  | Covered     |
+| ---------------------- | --------------------------------------------------------- | ----------- |
+| Property disputes      | Boundary disputes, dolda fel (hidden defects), renovation | Yes         |
+| Neighbor disputes      | Noise, tree encroachment, shared facilities               | Yes         |
+| Consumer disputes      | Contractor disputes, defective goods above threshold      | Yes         |
+| BRF disputes           | Renovation disputes with BRF board, fee disagreements     | Yes         |
+| Landlord/tenant        | Eviction disputes, deposit disputes                       | Yes         |
+| Employment disputes    | Wrongful termination (if not covered by union)            | Conditional |
+| Family law             | Divorce, custody, inheritance                             | No          |
+| Criminal proceedings   | Defense in criminal cases                                 | No          |
+| Business/commercial    | Disputes arising from business activities                 | No          |
+| Disputes under 25k SEK | Minor disputes below the qualifying threshold             | No          |
+
+### Rättsskydd Waiting Period
+
+| Dispute Category    | Waiting Period |
+| ------------------- | -------------- |
+| Property purchase   | 2 years        |
+| Neighbor disputes   | None           |
+| Consumer disputes   | None           |
+| Employment disputes | 2 years        |
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; eligibility determination must follow
+  published policy terms
+- **FSA-009** — Complaints handling; the customer must be informed of the
+  right to appeal a rättsskydd denial
+- **FSA-003** — Timely claims handling; eligibility review must not be
+  unreasonably delayed
+- **GDPR-007** — Dispute and opposing party data processed under
+  Article 6(1)(b) contract performance
+
+---
+
+## HCL-07: Approve Lawyer and Fee Estimate
+
+**As a** claims handler (skadereglerare),
+**I want to** approve the customer's choice of lawyer (advokat) and the fee
+estimate,
+**so that** legal costs are reasonable and within coverage limits.
+
+### Acceptance Criteria
+
+- **GIVEN** the rättsskydd application has been approved (HCL-06)
+  **WHEN** the customer submits their chosen lawyer and a fee estimate
+  **THEN** the system records the lawyer's name, firm, contact details, and
+  the estimated fees (hourly rate, estimated hours, total estimate)
+
+- **GIVEN** the claims handler reviews the fee estimate
+  **WHEN** the handler evaluates reasonableness
+  **THEN** the handler checks: the hourly rate is within the market range
+  (typically 1,500–3,500 SEK/hour excl. VAT), the estimated hours are
+  proportionate to the dispute complexity, and the total estimate is within
+  the rättsskydd coverage cap
+
+- **GIVEN** the fee estimate is reasonable
+  **WHEN** the handler approves the estimate
+  **THEN** the system records the approval, notifies the customer, and sets
+  the approved budget against which invoices will be checked
+
+- **GIVEN** the fee estimate exceeds the coverage cap or is unreasonably high
+  **WHEN** the handler identifies the issue
+  **THEN** the handler contacts the customer to discuss alternatives: a
+  different lawyer, reduced scope, or partial self-funding for costs exceeding
+  the cap
+
+- **GIVEN** the lawyer submits interim invoices during the dispute
+  **WHEN** the invoices are received
+  **THEN** the system checks each invoice against the approved budget, tracks
+  cumulative costs, and alerts the handler when costs approach 80% of the cap
+
+### Rättsskydd Coverage Terms
+
+| Term                | Value                           |
+| ------------------- | ------------------------------- |
+| Coverage percentage | 75–80% of approved legal costs  |
+| Self-retention      | 20–25% of approved legal costs  |
+| Base deductible     | 1,500 SEK                       |
+| Coverage cap        | Up to 300,000 SEK per dispute   |
+| Hourly rate ceiling | Market rate (assessed per case) |
+
+### Data Requirements
+
+| Data Element       | Source         | Required |
+| ------------------ | -------------- | -------- |
+| Lawyer name        | Customer input | Yes      |
+| Lawyer firm        | Customer input | Yes      |
+| Hourly rate        | Customer input | Yes      |
+| Estimated hours    | Customer input | Yes      |
+| Total fee estimate | Customer input | Yes      |
+| Approval decision  | Claims handler | Yes      |
+| Invoice tracking   | System         | Yes      |
+
+### External Integrations
+
+- **Payment Provider** — Lawyer invoice payments
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; the insurer must assess fee reasonableness
+  but cannot unreasonably restrict the customer's choice of lawyer
+- **FSA-003** — Timely claims handling; fee approval must not delay the
+  customer's access to legal representation
+- **IDD-011** — The customer must understand their self-retention obligation
+  and coverage cap before incurring costs
+- **GDPR-007** — Lawyer and fee data processed under Article 6(1)(b) contract
+  performance
+
+---
+
+## HCL-08: Understand Self-Retention and Coverage Cap
+
+**As a** customer (privatkund),
+**I want to** understand my self-retention (självrisk) and coverage cap for
+legal costs under rättsskydd,
+**so that** I can budget for my share of the expenses.
+
+### Acceptance Criteria
+
+- **GIVEN** the customer has an approved rättsskydd claim (HCL-06)
+  **WHEN** the customer views the claim details
+  **THEN** the system displays: the coverage percentage (75–80%), the
+  self-retention percentage (20–25%), the base deductible (1,500 SEK), and the
+  coverage cap (up to 300,000 SEK)
+
+- **GIVEN** the customer wants to understand their potential out-of-pocket cost
+  **WHEN** the customer accesses the rättsskydd cost calculator
+  **THEN** the system provides an estimated breakdown: total estimated legal
+  costs, insurer's share, customer's self-retention, and base deductible
+
+- **GIVEN** the legal costs are accumulating during the dispute
+  **WHEN** the customer checks the claim status
+  **THEN** the system shows: costs incurred to date, insurer's share paid,
+  remaining coverage before the cap, and the customer's running self-retention
+  balance
+
+- **GIVEN** the estimated legal costs will exceed the coverage cap
+  **WHEN** the system projects costs above the cap
+  **THEN** the system notifies the customer that costs exceeding the cap are
+  the customer's full responsibility and recommends discussing scope with
+  their lawyer
+
+### Cost Example
+
+| Element               | Amount (SEK) |
+| --------------------- | ------------ |
+| Lawyer fees           | 150,000      |
+| Court fees            | 5,000        |
+| **Total legal costs** | **155,000**  |
+| Coverage (80%)        | −124,000     |
+| Self-retention (20%)  | 31,000       |
+| Base deductible       | 1,500        |
+| **Customer pays**     | **32,500**   |
+| **Insurer pays**      | **122,500**  |
+
+### Regulatory
+
+- **FSA-012** — Coverage terms including self-retention and caps must be
+  clearly disclosed to the customer
+- **FSA-005** — Fair settlement; self-retention and cap must be applied per
+  the published policy terms
+- **IDD-011** — Demands-and-needs; the customer must understand cost-sharing
+  before engaging legal representation
+- **FSA-004** — Fair treatment; the customer must not be surprised by
+  unexpected costs
+
+---
+
+## HCL-09: Identify Cross-Insurance Coordination for Liability Claims
+
+**As a** claims handler (skadereglerare),
+**I want to** identify when a liability claim triggers the injured party's own
+insurance,
+**so that** claims are coordinated between insurers and double payment is
+avoided.
+
+### Acceptance Criteria
+
+- **GIVEN** a liability claim has been confirmed (HCL-02)
+  **WHEN** the claims handler assesses the injured party's losses
+  **THEN** the handler determines whether the injured party has their own
+  insurance that covers the same damage (e.g., the injured party's own
+  hemförsäkring)
+
+- **GIVEN** the injured party has own insurance covering the damage
+  **WHEN** the claims handler identifies the overlap
+  **THEN** the system records the injured party's insurer, initiates
+  cross-insurer communication, and determines whether the liability insurer
+  pays the injured party directly or reimburses the injured party's insurer
+  via subrogation
+
+- **GIVEN** both the liability insurer and the injured party's insurer are
+  involved
+  **WHEN** the claims are coordinated
+  **THEN** the system ensures the injured party receives full compensation
+  without double payment and records the inter-insurer settlement
+
+- **GIVEN** the injured party's insurer has already paid the injured party
+  **WHEN** the injured party's insurer exercises subrogation rights
+  **THEN** the system processes the subrogation claim from the other insurer,
+  verifies the amount, and settles under the policyholder's liability coverage
+
+- **GIVEN** the liability claim involves multiple injured parties
+  **WHEN** the claims handler identifies multiple claimants
+  **THEN** the system creates linked sub-claims for each injured party and
+  tracks the aggregate against the policyholder's liability limit
+
+### Data Requirements
+
+| Data Element                | Source                | Required    |
+| --------------------------- | --------------------- | ----------- |
+| Injured party insurer       | Injured party/handler | Conditional |
+| Injured party policy number | Injured party         | Conditional |
+| Subrogation claim amount    | Other insurer         | Conditional |
+| Inter-insurer settlement    | System                | Conditional |
+| Aggregate liability         | System calculation    | Yes         |
+
+### External Integrations
+
+- **Other insurers** — Cross-insurer claim coordination and subrogation
+- **GSR (Gemensamt Skadeanmälningsregister)** — Shared claims register for
+  fraud prevention and claim coordination
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; the injured party must receive full
+  compensation regardless of which insurer ultimately bears the cost
+- **FSA-003** — Timely claims handling; cross-insurer coordination must not
+  unduly delay the injured party's compensation
+- **GDPR-007** — Injured party data shared between insurers must be limited
+  to what is necessary; legal basis is Article 6(1)(f) legitimate interest
+
+---
+
+## HCL-10: Determine BRF Liability vs Individual Liability
+
+**As a** BRF board chair (BRF-styrelseordförande),
+**I want to** understand when BRF liability vs individual member liability
+applies,
+**so that** the correct insurance policy responds to a liability claim.
+
+### Acceptance Criteria
+
+- **GIVEN** a liability incident occurs in a BRF property (e.g., water leak
+  from one apartment damages another)
+  **WHEN** the claims handler assesses the claim
+  **THEN** the system presents the BRF/individual liability boundary tool
+  showing: the BRF's responsibility for common areas and building structure,
+  the individual member's responsibility for their own apartment interior, and
+  the applicable provisions from bostadsrättslagen and the BRF's stadgar
+
+- **GIVEN** the claims handler uses the boundary tool
+  **WHEN** the handler determines responsibility
+  **THEN** the system records: which party is liable (BRF or individual), the
+  legal basis (bostadsrättslagen chapter 7, BRF stadgar), and which insurance
+  policy should respond (BRF's fastighetsförsäkring or member's
+  bostadsrättsförsäkring)
+
+- **GIVEN** the damage is caused by a defect in the BRF building structure
+  (e.g., shared plumbing, roof, foundation)
+  **WHEN** the assessment determines BRF liability
+  **THEN** the system routes the claim to the BRF's property insurer and
+  informs the BRF board chair of the claim status
+
+- **GIVEN** the damage is caused by the individual member's negligence or
+  their apartment's internal installations
+  **WHEN** the assessment determines individual liability
+  **THEN** the system processes the claim under the member's
+  bostadsrättsförsäkring liability coverage
+
+- **GIVEN** the BRF/individual boundary is ambiguous or disputed
+  **WHEN** the claims handler cannot determine responsibility
+  **THEN** the system escalates to a senior claims handler who reviews the
+  BRF stadgar, engages a besiktningsman if needed, and records the
+  determination with documented rationale
+
+### BRF vs Individual Liability Boundaries
+
+| Area                          | BRF Responsibility          | Individual Responsibility  |
+| ----------------------------- | --------------------------- | -------------------------- |
+| Building structure (stomme)   | Yes                         | No                         |
+| Common plumbing (stamledning) | Yes                         | No                         |
+| Apartment interior            | No                          | Yes                        |
+| Apartment plumbing (from tap) | No                          | Yes                        |
+| Balcony/patio                 | Shared (per stadgar)        | Shared (per stadgar)       |
+| Facade windows                | Yes (unless stadgar differ) | No (unless stadgar differ) |
+| White goods (appliances)      | No                          | Yes                        |
+
+### Regulatory
+
+- **FSA-005** — Fair settlement; the correct insurer must respond based on
+  the liability determination
+- **FSA-009** — Complaints handling; the BRF board and individual member must
+  be informed of the complaints process if they disagree with the liability
+  determination
+- **FSA-003** — Timely claims handling; BRF boundary disputes must not unduly
+  delay the injured party's compensation
+- **GDPR-007** — BRF member data shared between the BRF insurer and member's
+  insurer must be limited to what is necessary; legal basis is Article 6(1)(f)
+
+---
+
+## Data Model
+
+### LiabilityClaimRecord
+
+| Attribute               | Type     | Description                                               |
+| ----------------------- | -------- | --------------------------------------------------------- |
+| Claim number            | String   | Unique skadenummer                                        |
+| Policy number           | String   | Reference to the home insurance policy                    |
+| Claim type              | Enum     | Ansvarsskada / Rättsskydd                                 |
+| Incident date/time      | DateTime | When the incident occurred                                |
+| Incident location       | String   | Where the incident occurred                               |
+| Incident description    | String   | Detailed description of the event                         |
+| Injured party name      | String   | Name of the third-party claimant                          |
+| Injured party contact   | String   | Contact details of the injured party                      |
+| Liability determination | Enum     | Confirmed / Denied / Under Investigation                  |
+| Legal basis             | String   | Skadeståndslagen reference or other legal basis           |
+| Damage claim amount     | Decimal  | Amount claimed by the injured party (SEK)                 |
+| Settlement amount       | Decimal  | Agreed settlement amount (SEK)                            |
+| Deductible applied      | Decimal  | Självrisk amount (SEK)                                    |
+| Defense initiated       | Boolean  | Whether defense proceedings have been started             |
+| Cross-insurer flag      | Boolean  | Whether the injured party's insurer is involved           |
+| Status                  | Enum     | Reported / Under Assessment / Settled / Defended / Closed |
+| Claims handler ID       | String   | Assigned handler identity                                 |
+| Created timestamp       | DateTime | When the claim was created                                |
+
+### RättsskyddClaimRecord
+
+| Attribute             | Type     | Description                                             |
+| --------------------- | -------- | ------------------------------------------------------- |
+| Claim number          | String   | Unique skadenummer                                      |
+| Policy number         | String   | Reference to the home insurance policy                  |
+| Dispute description   | String   | Nature of the legal dispute                             |
+| Opposing party        | String   | Identity of the opposing party                          |
+| Dispute category      | Enum     | Property / Neighbor / Consumer / BRF / Employment       |
+| Dispute start date    | Date     | When the dispute arose                                  |
+| Waiting period check  | Boolean  | Whether the waiting period has been verified            |
+| Eligibility status    | Enum     | Approved / Denied / Under Review                        |
+| Lawyer name           | String   | Customer's chosen attorney                              |
+| Lawyer firm           | String   | Attorney's firm                                         |
+| Approved fee estimate | Decimal  | Approved legal cost budget (SEK)                        |
+| Costs incurred        | Decimal  | Cumulative legal costs to date (SEK)                    |
+| Coverage percentage   | Decimal  | Percentage covered by the insurer (75–80%)              |
+| Self-retention amount | Decimal  | Customer's share of costs (SEK)                         |
+| Coverage cap          | Decimal  | Maximum insurer payout (SEK)                            |
+| Base deductible       | Decimal  | Fixed deductible amount (SEK)                           |
+| Status                | Enum     | Applied / Approved / Active / Settled / Denied / Closed |
+| Claims handler ID     | String   | Assigned handler identity                               |
+| Created timestamp     | DateTime | When the claim was created                              |
+
+---
+
+## Regulatory Traceability Matrix
+
+| Requirement | HCL-01 | HCL-02 | HCL-03 | HCL-04 | HCL-05 | HCL-06 | HCL-07 | HCL-08 | HCL-09 | HCL-10 |
+| ----------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| FSA-003     | X      | X      | X      | X      | X      | X      | X      |        | X      | X      |
+| FSA-004     |        |        |        |        |        |        |        | X      |        |        |
+| FSA-005     | X      | X      | X      | X      | X      | X      | X      | X      | X      | X      |
+| FSA-009     |        | X      | X      | X      |        | X      |        |        |        | X      |
+| FSA-012     |        |        |        |        |        |        |        | X      |        |        |
+| GDPR-007    | X      |        | X      | X      | X      | X      | X      |        | X      | X      |
+| IDD-011     |        | X      |        |        | X      |        | X      | X      |        |        |


### PR DESCRIPTION
## Summary

- Added 10 user stories (HCL-01 to HCL-10) covering liability claims (ansvarsskydd) and legal expenses (rättsskydd) under home insurance
- Added UC-HCL-001: Liability Claim Assessment and Settlement lifecycle with alternative/exception flows
- Added UC-HCL-002: Legal Expenses (Rättsskydd) Application and Management lifecycle with alternative/exception flows
- Updated user stories, use cases, and phase-2 index pages with new section entries

## Changes

- `docs/phase-2-home-property/user-stories/liability-and-legal.md` — 10 user stories with acceptance criteria, data models, regulatory traceability matrix
- `docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md` — UC-HCL-001 with mermaid flow, main/alternative/exception flows, validation/business rules
- `docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md` — UC-HCL-002 with mermaid flow, main/alternative/exception flows, validation/business rules
- `docs/phase-2-home-property/user-stories/index.md` — Added liability & legal section
- `docs/phase-2-home-property/use-cases/index.md` — Added liability & legal section
- `docs/phase-2-home-property/index.md` — Added documentation entries

## Testing

- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting check passes
- [x] `npm run build` succeeds (links, frontmatter validated)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)