### PR TITLE
docs(#101): Add regulatory traceability CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Check formatting
         run: npx prettier --check .
 
+      - name: Validate regulatory traceability
+        run: node scripts/validate-regulatory.mjs
+
   deploy:
     name: Deploy to GitHub Pages
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/scripts/validate-regulatory.mjs
+++ b/scripts/validate-regulatory.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that all user story and use case markdown files
+ * contain regulatory traceability (FSA, GDPR, or IDD references).
+ *
+ * Exit 0 = all files pass
+ * Exit 1 = one or more violations found
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, basename } from "node:path";
+
+const SKIP_FILENAMES = new Set(["index.md", "_category_.json"]);
+const SKIP_PREFIXES = ["LESSON-", "ADR-"];
+
+const REGULATORY_HEADING_RE = /^#{2,3}\s+regulatory/im;
+const REGULATORY_ID_RE = /(?:FSA|GDPR|IDD)-\d{3}/;
+
+/**
+ * Recursively find markdown files in user-stories/ and use-cases/ directories.
+ */
+function findTargetFiles(root) {
+  const results = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (stat.isFile() && entry.endsWith(".md")) {
+        const dirName = basename(dir);
+        if (dirName === "user-stories" || dirName === "use-cases") {
+          if (shouldCheck(entry)) {
+            results.push(fullPath);
+          }
+        }
+      }
+    }
+  }
+
+  walk(root);
+  return results;
+}
+
+function shouldCheck(filename) {
+  if (SKIP_FILENAMES.has(filename)) return false;
+  for (const prefix of SKIP_PREFIXES) {
+    if (filename.startsWith(prefix)) return false;
+  }
+  return true;
+}
+
+function validate(filePath) {
+  const content = readFileSync(filePath, "utf8");
+  const errors = [];
+
+  if (!REGULATORY_HEADING_RE.test(content)) {
+    errors.push("missing '## Regulatory' section");
+  }
+
+  if (!REGULATORY_ID_RE.test(content)) {
+    errors.push(
+      "no regulatory IDs found (expected FSA-nnn, GDPR-nnn, or IDD-nnn)",
+    );
+  }
+
+  return errors;
+}
+
+// --- main ---
+
+const roots = ["docs", "versioned_docs"];
+const allFiles = roots.flatMap((root) => findTargetFiles(root));
+
+let violations = 0;
+
+for (const file of allFiles) {
+  const errors = validate(file);
+  if (errors.length > 0) {
+    for (const err of errors) {
+      console.error(`ERROR: ${file} — ${err}`);
+    }
+    violations++;
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `\n✗ ${violations} file(s) with regulatory traceability violations`,
+  );
+  process.exit(1);
+} else {
+  console.log(
+    `✓ ${allFiles.length} files checked, all have regulatory traceability`,
+  );
+}


### PR DESCRIPTION
## Summary
- Add `scripts/validate-regulatory.mjs` that scans all user-stories/ and use-cases/ markdown files for regulatory traceability
- Add CI step to `.github/workflows/ci.yml` that runs the validator after lint checks
- Validates 138 files across `docs/` and `versioned_docs/`, all currently passing

## Changes
- **New**: `scripts/validate-regulatory.mjs` — Node.js validation script (zero dependencies)
- **Modified**: `.github/workflows/ci.yml` — added "Validate regulatory traceability" step

## How it works
The script:
1. Recursively scans `docs/**/user-stories/*.md`, `docs/**/use-cases/*.md`, `versioned_docs/**/user-stories/*.md`, `versioned_docs/**/use-cases/*.md`
2. Skips `index.md`, `_category_.json`, `LESSON-*`, `ADR-*` files
3. Checks each file for a `## Regulatory` heading (accepts variants: Regulatory Compliance Summary, Regulatory Traceability Matrix, Regulatory Requirements)
4. Checks each file for at least one regulatory ID matching `FSA-\d{3}`, `GDPR-\d{3}`, or `IDD-\d{3}`
5. Reports violations with clear error messages and exits non-zero if any found

## Testing
- [x] Script correctly detects missing `## Regulatory` section
- [x] Script correctly detects missing regulatory IDs (heading present, no IDs)
- [x] Script skips index.md files
- [x] All 138 existing files pass validation
- [x] `npm run build` passes
- [x] `npx markdownlint docs/ versioned_docs/` passes (zero warnings)
- [x] `npx prettier --check .` passes

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)