### PR TITLE
docs(#103): Add cross-reference and sync validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
           node scripts/validate-use-cases.mjs
           node scripts/validate-user-stories.mjs
 
+      - name: Validate cross-references and sync
+        run: |
+          node scripts/validate-links.mjs
+          node scripts/validate-glossary.mjs
+          node scripts/validate-version-sync.mjs
+
   deploy:
     name: Deploy to GitHub Pages
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/scripts/validate-glossary.mjs
+++ b/scripts/validate-glossary.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * Glossary Coverage Check
+ * Checks that Swedish insurance terms used in documentation are defined in the glossary.
+ * Warning only (exit code 0) — new terms should be reviewed, not auto-blocked.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { join, resolve } from "path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const GLOSSARY_PATHS = [
+  join(ROOT, "versioned_docs/version-phase-1/glossary.md"),
+  join(ROOT, "docs/glossary.md"),
+];
+const SCAN_DIRS = [
+  "docs/phase-1-motor/user-stories",
+  "docs/phase-1-motor/use-cases",
+  "docs/phase-2-home-property/user-stories",
+  "docs/phase-2-home-property/use-cases",
+  "versioned_docs/version-phase-1/phase-1-motor/user-stories",
+  "versioned_docs/version-phase-1/phase-1-motor/use-cases",
+];
+
+// Pattern to extract bold terms from glossary table rows: | **Term** |
+const GLOSSARY_TERM_PATTERN = /\|\s*\*\*([^*]+)\*\*/g;
+
+// Patterns to find Swedish terms in documentation files (single-line only)
+const BOLD_TERM_PATTERN = /\*\*([A-ZÅÄÖ][a-zåäöéA-ZÅÄÖ /-]+)\*\*/g;
+const PAREN_TERM_PATTERN = /\(([a-zåäöé][a-zåäöéA-ZÅÄÖ /-]+)\)/g;
+
+function parseGlossaryTerms() {
+  const terms = new Set();
+
+  for (const glossaryPath of GLOSSARY_PATHS) {
+    if (!existsSync(glossaryPath)) continue;
+    const content = readFileSync(glossaryPath, "utf-8");
+    let match;
+
+    GLOSSARY_TERM_PATTERN.lastIndex = 0;
+    while ((match = GLOSSARY_TERM_PATTERN.exec(content)) !== null) {
+      // Glossary may have "Term1 / Term2" format — split and add both
+      const raw = match[1];
+      for (const part of raw.split("/")) {
+        terms.add(part.trim().toLowerCase());
+      }
+    }
+  }
+
+  return terms;
+}
+
+function collectMarkdownFiles(dir) {
+  const files = [];
+  const absDir = join(ROOT, dir);
+  if (!existsSync(absDir)) return files;
+
+  function walk(current) {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (entry.endsWith(".md") && entry !== "index.md") {
+        files.push(full);
+      }
+    }
+  }
+
+  walk(absDir);
+  return files;
+}
+
+/**
+ * Checks if a term looks like a Swedish insurance term.
+ * Filters out common English words and generic phrases.
+ */
+function isSwedishInsuranceTerm(term) {
+  // Skip very long phrases (likely sentences, not terms)
+  if (term.split(/\s+/).length > 4) return false;
+
+  // Must contain Swedish characters OR be a known Swedish term pattern
+  const hasSwedishChars = /[åäöÅÄÖ]/.test(term);
+  const looksSwedish =
+    /försäkring|skade|bonus|premie|självrisk|ånger|klass|förfallo/i.test(term);
+  return hasSwedishChars || looksSwedish;
+}
+
+// Main
+console.log("Checking glossary coverage...\n");
+
+const glossaryTerms = parseGlossaryTerms();
+console.log(`Found ${glossaryTerms.size} terms defined in glossary.\n`);
+
+const allFiles = SCAN_DIRS.flatMap(collectMarkdownFiles);
+let warningCount = 0;
+const missingTerms = new Map(); // term -> [files]
+
+for (const file of allFiles) {
+  const content = readFileSync(file, "utf-8");
+  const relPath = file.replace(ROOT + "/", "");
+
+  // Check bold terms
+  let match;
+  BOLD_TERM_PATTERN.lastIndex = 0;
+  while ((match = BOLD_TERM_PATTERN.exec(content)) !== null) {
+    const term = match[1].trim();
+    if (!isSwedishInsuranceTerm(term)) continue;
+    if (!glossaryTerms.has(term.toLowerCase())) {
+      const arr = missingTerms.get(term.toLowerCase()) || [];
+      arr.push(relPath);
+      missingTerms.set(term.toLowerCase(), arr);
+    }
+  }
+
+  // Check parenthesized terms (Swedish equivalents)
+  PAREN_TERM_PATTERN.lastIndex = 0;
+  while ((match = PAREN_TERM_PATTERN.exec(content)) !== null) {
+    const term = match[1].trim();
+    if (!isSwedishInsuranceTerm(term)) continue;
+    if (!glossaryTerms.has(term.toLowerCase())) {
+      const arr = missingTerms.get(term.toLowerCase()) || [];
+      arr.push(relPath);
+      missingTerms.set(term.toLowerCase(), arr);
+    }
+  }
+}
+
+for (const [term, files] of missingTerms) {
+  const uniqueFiles = [...new Set(files)];
+  for (const f of uniqueFiles) {
+    console.warn(
+      `\u26a0 Term "${term}" used in ${f} but not found in glossary`,
+    );
+    warningCount++;
+  }
+}
+
+console.log(`\nScanned ${allFiles.length} files.`);
+if (warningCount > 0) {
+  console.warn(
+    `\n${warningCount} warning(s): terms used but not defined in glossary.`,
+  );
+  console.warn("Consider adding missing terms to glossary.md.");
+} else {
+  console.log("All Swedish insurance terms are defined in the glossary.");
+}
+
+// Always exit 0 — warnings only, never block the build
+process.exit(0);

--- a/scripts/validate-links.mjs
+++ b/scripts/validate-links.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Internal Link Validator
+ * Checks all relative markdown links across docs/ and versioned_docs/.
+ * Complements Docusaurus's built-in broken link detection with faster feedback.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { join, dirname, resolve } from "path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const DIRS = ["docs", "versioned_docs"];
+const LINK_PATTERN = /\[([^\]]*)\]\(([^)]+\.md[^)]*)\)/g;
+
+let brokenCount = 0;
+let checkedCount = 0;
+
+function collectMarkdownFiles(dir) {
+  const files = [];
+  const absDir = join(ROOT, dir);
+  if (!existsSync(absDir)) return files;
+
+  function walk(current) {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (entry.endsWith(".md")) {
+        files.push(full);
+      }
+    }
+  }
+
+  walk(absDir);
+  return files;
+}
+
+function validateFile(filePath) {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let match;
+    LINK_PATTERN.lastIndex = 0;
+
+    while ((match = LINK_PATTERN.exec(line)) !== null) {
+      const linkTarget = match[2];
+
+      // Skip external links, anchors-only, and http(s) URLs
+      if (
+        linkTarget.startsWith("http://") ||
+        linkTarget.startsWith("https://") ||
+        linkTarget.startsWith("#")
+      ) {
+        continue;
+      }
+
+      // Strip anchor fragment from target
+      const targetPath = linkTarget.split("#")[0];
+      if (!targetPath) continue;
+
+      checkedCount++;
+      const resolvedPath = resolve(dirname(filePath), targetPath);
+
+      if (!existsSync(resolvedPath)) {
+        const relSource = filePath.replace(ROOT + "/", "");
+        console.error(
+          `BROKEN LINK: ${relSource}:${i + 1} -> ${linkTarget} (resolved: ${resolvedPath.replace(ROOT + "/", "")})`,
+        );
+        brokenCount++;
+      }
+    }
+  }
+}
+
+// Main
+console.log("Validating internal markdown links...\n");
+
+const allFiles = DIRS.flatMap(collectMarkdownFiles);
+
+for (const file of allFiles) {
+  validateFile(file);
+}
+
+console.log(`\nChecked ${checkedCount} links across ${allFiles.length} files.`);
+
+if (brokenCount > 0) {
+  console.error(`\nFOUND ${brokenCount} broken link(s).`);
+  process.exit(1);
+} else {
+  console.log("All internal links are valid.");
+}

--- a/scripts/validate-version-sync.mjs
+++ b/scripts/validate-version-sync.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+ * Version Sync Check
+ * Verifies that versioned_docs structure matches expected Phase 1 baseline.
+ * Catches scenarios where a PR accidentally deletes versioned content.
+ */
+
+import { existsSync, readdirSync, statSync } from "fs";
+import { join, resolve } from "path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const VERSION_DIR = join(ROOT, "versioned_docs/version-phase-1");
+
+const EXPECTED_STRUCTURE = {
+  "actors/": { minFiles: 2, description: "actor definitions" },
+  "personas/": { minFiles: 5, description: "persona definitions" },
+  "phase-1-motor/user-stories/": {
+    minFiles: 10,
+    description: "motor user stories",
+  },
+  "phase-1-motor/use-cases/": { minFiles: 5, description: "motor use cases" },
+  "regulatory/": { exactFiles: 3, description: "regulatory documents" },
+};
+
+const EXPECTED_FILES = ["glossary.md", "intro.md"];
+
+let errorCount = 0;
+
+function countMarkdownFiles(dir) {
+  let count = 0;
+  if (!existsSync(dir)) return 0;
+
+  function walk(current) {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (entry.endsWith(".md")) {
+        count++;
+      }
+    }
+  }
+
+  walk(dir);
+  return count;
+}
+
+// Main
+console.log("Checking version-phase-1 structure...\n");
+
+if (!existsSync(VERSION_DIR)) {
+  console.error("MISSING: versioned_docs/version-phase-1/ directory not found");
+  process.exit(1);
+}
+
+// Check required directories
+for (const [dirPath, spec] of Object.entries(EXPECTED_STRUCTURE)) {
+  const fullPath = join(VERSION_DIR, dirPath);
+
+  if (!existsSync(fullPath)) {
+    console.error(
+      `MISSING: expected directory version-phase-1/${dirPath} (${spec.description})`,
+    );
+    errorCount++;
+    continue;
+  }
+
+  const fileCount = countMarkdownFiles(fullPath);
+
+  if (spec.exactFiles !== undefined && fileCount !== spec.exactFiles) {
+    console.error(
+      `MISMATCH: version-phase-1/${dirPath} has ${fileCount} markdown files, expected exactly ${spec.exactFiles} (${spec.description})`,
+    );
+    errorCount++;
+  } else if (spec.minFiles !== undefined && fileCount < spec.minFiles) {
+    console.error(
+      `MISMATCH: version-phase-1/${dirPath} has ${fileCount} markdown files, expected at least ${spec.minFiles} (${spec.description})`,
+    );
+    errorCount++;
+  } else {
+    console.log(`  OK: version-phase-1/${dirPath} — ${fileCount} files`);
+  }
+}
+
+// Check required individual files
+for (const fileName of EXPECTED_FILES) {
+  const fullPath = join(VERSION_DIR, fileName);
+
+  if (!existsSync(fullPath)) {
+    console.error(`Missing expected file in version-phase-1: ${fileName}`);
+    errorCount++;
+  } else {
+    console.log(`  OK: version-phase-1/${fileName}`);
+  }
+}
+
+console.log("");
+
+if (errorCount > 0) {
+  console.error(
+    `FAILED: ${errorCount} structure issue(s) found in version-phase-1.`,
+  );
+  process.exit(1);
+} else {
+  console.log("Version-phase-1 structure is intact.");
+}


### PR DESCRIPTION
## Summary
- Adds three Node.js validation scripts to catch cross-reference gaps and structural drift
- Integrates validation into CI pipeline after lint/format checks
- All scripts use only Node.js built-in modules (no extra dependencies)

## Changes
- `scripts/validate-links.mjs` — Checks all relative markdown links across `docs/` and `versioned_docs/` resolve to existing files. Reports broken links with source file, line number, and target path. Fails CI on broken links.
- `scripts/validate-glossary.mjs` — Checks Swedish insurance terms (bold and parenthesized) against glossary.md definitions. Warning only (exit 0) — suggests additions without blocking.
- `scripts/validate-version-sync.mjs` — Verifies versioned_docs/version-phase-1/ structure is intact (expected directories, minimum file counts, required files). Fails CI if structure is degraded.
- `.github/workflows/ci.yml` — Added "Validate cross-references and sync" step after formatting checks.

## Testing
- [x] Link validator: checked 1145 links across 229 files — all valid
- [x] Glossary checker: found 57 defined terms, reports warnings for undefined Swedish terms, exits 0
- [x] Version sync: verified Phase 1 structure (actors, personas, user-stories, use-cases, regulatory, glossary, intro)
- [x] Markdownlint passes with zero warnings
- [x] Prettier passes with zero warnings
- [x] Docusaurus build succeeds

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)