### PR TITLE
docs(#102): Add document structure validators to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Validate regulatory traceability
         run: node scripts/validate-regulatory.mjs
 
+      - name: Validate document structure
+        run: |
+          node scripts/validate-frontmatter.mjs
+          node scripts/validate-use-cases.mjs
+          node scripts/validate-user-stories.mjs
+
   deploy:
     name: Deploy to GitHub Pages
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/scripts/validate-frontmatter.mjs
+++ b/scripts/validate-frontmatter.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Frontmatter Validator
+ *
+ * Checks all .md files in docs/ and versioned_docs/ for:
+ * - YAML frontmatter delimited by ---
+ * - sidebar_position field with a numeric value
+ *
+ * Skips: LESSON-TEMPLATE.md, ADR-TEMPLATE.md, _category_.json, node_modules
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, basename, extname } from "node:path";
+
+const SKIP_FILES = new Set(["LESSON-TEMPLATE.md", "ADR-TEMPLATE.md"]);
+const SEARCH_DIRS = ["docs", "versioned_docs"];
+
+function collectMarkdownFiles(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isDirectory()) {
+      if (entry === "node_modules") continue;
+      files.push(...collectMarkdownFiles(fullPath));
+    } else if (extname(entry) === ".md" && !SKIP_FILES.has(basename(entry))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  return match[1];
+}
+
+function hasSidebarPosition(frontmatterText) {
+  const match = frontmatterText.match(/^sidebar_position:\s*(\S+)/m);
+  if (!match) return false;
+  const val = Number(match[1]);
+  return !Number.isNaN(val);
+}
+
+const violations = [];
+let fileCount = 0;
+
+for (const dir of SEARCH_DIRS) {
+  const files = collectMarkdownFiles(dir);
+  for (const file of files) {
+    fileCount++;
+    const content = readFileSync(file, "utf-8");
+    const issues = [];
+
+    const fm = parseFrontmatter(content);
+    if (fm === null) {
+      issues.push("missing YAML frontmatter (--- delimiters)");
+    } else if (!hasSidebarPosition(fm)) {
+      issues.push("missing or non-numeric sidebar_position in frontmatter");
+    }
+
+    if (issues.length > 0) {
+      violations.push({ file, issues });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Frontmatter validation failed:\n");
+  for (const { file, issues } of violations) {
+    for (const issue of issues) {
+      console.error(`  ${file}: ${issue}`);
+    }
+  }
+  console.error(
+    `\n${violations.length} file(s) with issues out of ${fileCount} checked.`,
+  );
+  process.exit(1);
+} else {
+  console.log(`\u2713 ${fileCount} files checked, all valid`);
+}

--- a/scripts/validate-use-cases.mjs
+++ b/scripts/validate-use-cases.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * Use Case Structure Validator
+ *
+ * Checks all files in use-cases directories (excluding index.md) for:
+ * - Summary: ## Summary heading or a summary table (| Use Case ID |)
+ * - Main scenario: ## Main Success Scenario, ## Main Scenario, ## Main Flow, or numbered step list
+ * - Alternative flows: ## Alternative Flows, ## Alternative, ## Extensions
+ * - Regulatory: ## Regulatory heading or regulatory reference pattern
+ *
+ * Skips: index.md files
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, basename, extname, sep } from "node:path";
+
+const SEARCH_DIRS = ["docs", "versioned_docs"];
+
+function collectUseCaseFiles(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isDirectory()) {
+      if (entry === "node_modules") continue;
+      files.push(...collectUseCaseFiles(fullPath));
+    } else if (
+      extname(entry) === ".md" &&
+      basename(entry) !== "index.md" &&
+      fullPath.includes(`${sep}use-cases${sep}`)
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function checkSummary(content) {
+  // Check for ## Summary or ## Overview heading, or summary table with | Use Case ID |
+  if (/^#{2,3}\s+.*summary/im.test(content)) return true;
+  if (/^#{2,3}\s+overview/im.test(content)) return true;
+  if (/\|\s*\*?\*?Use Case ID\*?\*?\s*\|/i.test(content)) return true;
+  // Aggregated multi-use-case files: introductory section before UC headings counts
+  // (e.g., "## Renewal Timeline" followed by "## UC-RN-001: ...")
+  const ucHeadings = content.match(/^##\s+UC-\w+-\d+/gm);
+  if (ucHeadings && ucHeadings.length >= 2) return true;
+  return false;
+}
+
+function checkMainScenario(content) {
+  // Check for main scenario headings or numbered step list
+  if (/^##\s+main\s+(success\s+)?scenario/im.test(content)) return true;
+  if (/^##\s+main\s+flow/im.test(content)) return true;
+  // Check for numbered step list (at least 3 numbered steps as a proxy for a scenario)
+  const numberedSteps = content.match(/^\d+\.\s+/gm);
+  if (numberedSteps && numberedSteps.length >= 3) return true;
+  return false;
+}
+
+function checkAlternativeFlows(content) {
+  // Grouped heading: ## Alternative Flows / ### Alternative Flows
+  if (/^#{2,3}\s+alternative\s*(flows|scenarios)?/im.test(content)) return true;
+  // Inline heading: ## Alternative Flow A: ... / ## Alternative Flow: ...
+  if (/^#{2,3}\s+alternative\s+flow\b/im.test(content)) return true;
+  // Exception flows count as alternative paths
+  if (/^#{2,3}\s+exception\s+flow/im.test(content)) return true;
+  if (/^#{2,3}\s+extensions/im.test(content)) return true;
+  return false;
+}
+
+function checkRegulatory(content) {
+  if (/^##\s+regulatory/im.test(content)) return true;
+  // Check for inline regulatory references like FSA-xxx, GDPR-xxx, IDD-xxx
+  if (/\b(FSA|GDPR|IDD)-\d{3}\b/.test(content)) return true;
+  return false;
+}
+
+const violations = [];
+let fileCount = 0;
+
+for (const dir of SEARCH_DIRS) {
+  const files = collectUseCaseFiles(dir);
+  for (const file of files) {
+    fileCount++;
+    const content = readFileSync(file, "utf-8");
+    const issues = [];
+
+    if (!checkSummary(content)) {
+      issues.push(
+        'missing Summary section (## Summary or "| Use Case ID |" table)',
+      );
+    }
+    if (!checkMainScenario(content)) {
+      issues.push(
+        "missing Main Scenario section (## Main Success Scenario / ## Main Flow / numbered steps)",
+      );
+    }
+    if (!checkAlternativeFlows(content)) {
+      issues.push(
+        "missing Alternative Flows section (## Alternative Flows / ## Extensions)",
+      );
+    }
+    if (!checkRegulatory(content)) {
+      issues.push(
+        "missing Regulatory section (## Regulatory or FSA/GDPR/IDD references)",
+      );
+    }
+
+    if (issues.length > 0) {
+      violations.push({ file, issues });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Use case structure validation failed:\n");
+  for (const { file, issues } of violations) {
+    for (const issue of issues) {
+      console.error(`  ${file}: ${issue}`);
+    }
+  }
+  console.error(
+    `\n${violations.length} file(s) with issues out of ${fileCount} checked.`,
+  );
+  process.exit(1);
+} else {
+  console.log(`\u2713 ${fileCount} files checked, all valid`);
+}

--- a/scripts/validate-user-stories.mjs
+++ b/scripts/validate-user-stories.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+/**
+ * User Story Format Validator
+ *
+ * Checks all files in user-stories directories (excluding index.md and cross-reference docs) for:
+ * - User story statement: "As a" ... "I want" ... "so that" pattern (case-insensitive)
+ * - Acceptance criteria section: ## Acceptance Criteria heading
+ * - Actors section: ## Actors, **Primary Actor**, or **Actors**
+ *
+ * Aggregated files (containing multiple stories) need at least one "As a" statement.
+ * Skips: index.md, *cross-reference* files
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, basename, extname, sep } from "node:path";
+
+const SEARCH_DIRS = ["docs", "versioned_docs"];
+const SKIP_PATTERNS = [/^index\.md$/, /cross-reference/i];
+
+function shouldSkip(filename) {
+  return SKIP_PATTERNS.some((p) => p.test(filename));
+}
+
+function collectUserStoryFiles(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isDirectory()) {
+      if (entry === "node_modules") continue;
+      files.push(...collectUserStoryFiles(fullPath));
+    } else if (
+      extname(entry) === ".md" &&
+      !shouldSkip(basename(entry)) &&
+      fullPath.includes(`${sep}user-stories${sep}`)
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function checkUserStoryStatement(content) {
+  // Strip bold markers for matching (content uses **As a** / **I want to** / **so that**)
+  const plain = content.replace(/\*\*/g, "");
+  if (
+    /as (a|an|the)\s/i.test(plain) &&
+    /i want/i.test(plain) &&
+    /so that/i.test(plain)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function checkAcceptanceCriteria(content) {
+  // ## Acceptance Criteria or ### Acceptance Criteria
+  if (/^#{2,3}\s+acceptance\s+criteria/im.test(content)) return true;
+  return false;
+}
+
+function checkActors(content) {
+  if (/^#{2,3}\s+actors/im.test(content)) return true;
+  if (/\*\*primary\s+actor\*\*/i.test(content)) return true;
+  if (/\*\*actors\*\*/i.test(content)) return true;
+  // Summary table with Primary Actor
+  if (/\|\s*\*?\*?Primary Actor\*?\*?\s*\|/i.test(content)) return true;
+  // Overview table with Actor column (aggregated files)
+  if (/\|\s*Actor\s*\|/i.test(content)) return true;
+  // Primary: actor reference (inline in ## Actors section)
+  if (/\*\*Primary:\*\*/i.test(content)) return true;
+  // Aggregated files: actors embedded in "As a [role]" statements are acceptable
+  // Detect aggregated format: multiple story headings (## US- or ## ID-NNN)
+  const storyHeadings = content.match(/^##\s+(US-|\w+-\d+)/gm);
+  if (storyHeadings && storyHeadings.length >= 2) return true;
+  return false;
+}
+
+const violations = [];
+let fileCount = 0;
+
+for (const dir of SEARCH_DIRS) {
+  const files = collectUserStoryFiles(dir);
+  for (const file of files) {
+    fileCount++;
+    const content = readFileSync(file, "utf-8");
+    const issues = [];
+
+    if (!checkUserStoryStatement(content)) {
+      issues.push(
+        'missing user story statement ("As a ... I want ... so that ...")',
+      );
+    }
+    if (!checkAcceptanceCriteria(content)) {
+      issues.push(
+        "missing Acceptance Criteria section (## Acceptance Criteria)",
+      );
+    }
+    if (!checkActors(content)) {
+      issues.push(
+        "missing Actors section (## Actors / **Primary Actor** / **Actors**)",
+      );
+    }
+
+    if (issues.length > 0) {
+      violations.push({ file, issues });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("User story format validation failed:\n");
+  for (const { file, issues } of violations) {
+    for (const issue of issues) {
+      console.error(`  ${file}: ${issue}`);
+    }
+  }
+  console.error(
+    `\n${violations.length} file(s) with issues out of ${fileCount} checked.`,
+  );
+  process.exit(1);
+} else {
+  console.log(`\u2713 ${fileCount} files checked, all valid`);
+}


### PR DESCRIPTION
## Summary
- Add 3 validation scripts to CI that catch structural inconsistencies in documentation
- **Frontmatter validator**: checks all .md files for YAML frontmatter and `sidebar_position`
- **Use case validator**: checks for summary/overview, main scenario, alternative flows, regulatory sections
- **User story validator**: checks for story statement (As a.../I want.../so that...), acceptance criteria, actors

## Changes
- `scripts/validate-frontmatter.mjs` — new validator (Node.js built-in modules only)
- `scripts/validate-use-cases.mjs` — new validator (Node.js built-in modules only)
- `scripts/validate-user-stories.mjs` — new validator (Node.js built-in modules only)
- `.github/workflows/ci.yml` — added "Validate document structure" step after formatting check

## Testing
- [x] All 3 validators pass locally (223 frontmatter, 38 use cases, 98 user stories)
- [x] Validators handle both `docs/` and `versioned_docs/` directories
- [x] Index files, templates, and cross-reference docs are excluded
- [x] Markdownlint passes with zero warnings
- [x] Prettier check passes
- [x] Build succeeds

Closes #102

🤖 Generated with Claude Code