### PR TITLE
docs(#114): Add state diagrams to Phase 1 Motor use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/policy-administration.md
+++ b/docs/phase-1-motor/use-cases/policy-administration.md
@@ -616,21 +616,32 @@ flowchart TD
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Active
+    [*] --> Active : Policy issued or renewed
     Active --> Suspended : Non-payment after grace period
+    Active --> PendingCancellation : Cancellation requested
     Suspended --> Active : Payment received within reinstatement period
     Suspended --> Lapsed : Reinstatement period expires without payment
+    PendingCancellation --> Cancelled : Effective date reached
+    Cancelled --> [*]
     Lapsed --> [*]
 
     note right of Active
         Coverage in force.
         All policy functions available.
+        Mid-term amendments permitted.
     end note
 
     note right of Suspended
         Coverage inactive.
-        Reinstatement window open.
+        Reinstatement window open (90 days).
         Customer notified of consequences.
+        Transportstyrelsen notified.
+    end note
+
+    note right of PendingCancellation
+        Cancellation confirmed.
+        Awaiting effective date.
+        Refund calculated.
     end note
 
     note right of Lapsed

--- a/docs/phase-1-motor/use-cases/quote-and-bind.md
+++ b/docs/phase-1-motor/use-cases/quote-and-bind.md
@@ -61,6 +61,35 @@ flowchart TD
     style E fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft : Customer initiates quote
+    Draft --> Presented : Premium calculated
+    Presented --> Accepted : Customer selects coverage
+    Presented --> Expired : 30-day validity timeout
+    Accepted --> Bound : BankID signed and verified
+    Accepted --> Expired : Signing not completed
+    Bound --> [*]
+    Expired --> [*]
+
+    note right of Draft
+        Vehicle and customer data collected.
+        Demands-and-needs assessment in progress.
+    end note
+
+    note right of Presented
+        Quote valid for 30 days.
+        Customer may compare tiers.
+    end note
+
+    note right of Bound
+        Policy issued. Transportstyrelsen notified.
+        Payment setup initiated.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Customer Identification

--- a/docs/phase-1-motor/use-cases/renewals.md
+++ b/docs/phase-1-motor/use-cases/renewals.md
@@ -37,6 +37,40 @@ flowchart LR
     style D fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Upcoming : T-60 days before huvudforfallodag
+    Upcoming --> Notified : Renewal notice sent (T-30)
+    Notified --> Reviewed : Customer reviews terms
+    Notified --> Renewed : No action — auto-renewal at T-0
+    Reviewed --> Renewed : Customer accepts or modifies
+    Reviewed --> Lapsed : Customer cancels before T-0
+    Renewed --> [*]
+    Lapsed --> [*]
+
+    note right of Upcoming
+        Premium recalculated.
+        Bonus class updated.
+    end note
+
+    note right of Notified
+        Customer response window open.
+        30-day notice period per FAL.
+    end note
+
+    note right of Renewed
+        New policy period begins.
+        Payment schedule updated.
+    end note
+
+    note right of Lapsed
+        Coverage ends at huvudforfallodag.
+        Transportstyrelsen notified.
+    end note
+```
+
 ## UC-RN-001: Process Annual Policy Renewal
 
 Handles the end-to-end renewal flow from pre-renewal premium recalculation through automatic renewal or customer cancellation.

--- a/docs/phase-1-motor/use-cases/trafikforsakring.md
+++ b/docs/phase-1-motor/use-cases/trafikforsakring.md
@@ -67,6 +67,37 @@ flowchart TD
     style H fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Uninsured : Vehicle registered without coverage
+    [*] --> Pending : Policy binding initiated
+    Pending --> Active : Transportstyrelsen notified
+    Active --> Active : Coverage change or renewal
+    Active --> Lapsed : Non-payment after grace period
+    Active --> Cancelled : Replacement coverage confirmed
+    Lapsed --> Active : Payment received and reinstated
+    Lapsed --> Uninsured : Reinstatement period expires
+    Uninsured --> Pending : New policy bound
+    Cancelled --> [*]
+
+    note right of Active
+        Continuous mandatory coverage in force.
+        TFF reporting obligations apply.
+    end note
+
+    note right of Lapsed
+        Coverage suspended.
+        TFF trafikforsakringsavgift risk.
+    end note
+
+    note right of Uninsured
+        Vehicle registered but no coverage.
+        TFF default coverage and penalty fees apply.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Issuance — Mandatory Coverage Check and Registration

--- a/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -93,6 +93,39 @@ flowchart TD
     style I fill:#ffebee
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Requested : Customer or system initiates cancellation
+    Requested --> Validated : Cancellation type and rules determined
+    Validated --> Blocked : Trafikforsakring replacement missing
+    Blocked --> Validated : Replacement coverage provided
+    Validated --> Processed : Cancellation confirmed by customer
+    Processed --> Confirmed : Transportstyrelsen notified, refund issued
+    Confirmed --> [*]
+
+    note right of Requested
+        Reason determined: angerratt,
+        huvudforfallodag, vehicle sold, etc.
+    end note
+
+    note right of Validated
+        Effective date calculated.
+        Refund amount displayed.
+    end note
+
+    note right of Blocked
+        Vehicle still registered.
+        Replacement coverage required.
+    end note
+
+    note right of Confirmed
+        Policy terminated. Customer
+        receives cancellation confirmation.
+    end note
+```
+
 ## Main Flow (Customer-Initiated Online Cancellation)
 
 | Step | Actor    | Action                                                                          | System Response                                                                                |

--- a/docs/phase-1-motor/use-cases/uc-claims-closure.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-closure.md
@@ -83,6 +83,40 @@ flowchart TD
     style K fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Review : Closure initiated by handler
+    Review --> FinalCheck : All checklist items pass
+    Review --> Blocked : Checklist item(s) failed
+    Blocked --> Review : Blocking items resolved
+    FinalCheck --> Closed : Handler confirms closure
+    Closed --> Reopened : New evidence or worsened condition
+    Reopened --> Review : Re-investigation begins
+    Closed --> [*]
+
+    note right of Review
+        Payments, subrogation, bonus,
+        documents, and disputes validated.
+    end note
+
+    note right of FinalCheck
+        Closure summary reviewed.
+        Total claim cost calculated.
+    end note
+
+    note right of Closed
+        Reserves released. Records
+        archived for 10-year retention.
+    end note
+
+    note right of Reopened
+        Reserves re-established.
+        Senior approval required if > 1 year.
+    end note
+```
+
 ## Main Success Scenario: Standard Closure
 
 | Step | Actor          | Action                                           | System Response                                                     |

--- a/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
@@ -79,6 +79,43 @@ flowchart TD
 | 11   | Subrogation initiated if third party at fault                 | Claims Handler  | Records recovery target and tracks recovery                 | [US-CLM-009](../user-stories/claims-subrogation.md)                                                              |
 | 12   | Claims handler performs final review and closes claim         | Claims Handler  | Sets status to "Closed", updates statistics                 | [US-CLM-015](../user-stories/claims-closure.md)                                                                  |
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> FNOL : Customer reports incident
+    FNOL --> Registered : Claim created and handler assigned
+    Registered --> UnderInvestigation : Coverage verified, screening complete
+    UnderInvestigation --> Decided : Liability and damage assessed
+    Decided --> Settled : Payment issued or repair authorized
+    Decided --> Denied : Claim rejected
+    Settled --> Closed : All payments confirmed, closure checklist passed
+    Denied --> Closed : Complaint window elapsed
+    Closed --> Reopened : New evidence or disputed settlement
+    Reopened --> UnderInvestigation : Re-investigation begins
+    Closed --> [*]
+
+    note right of FNOL
+        Initial report received.
+        Claim number generated.
+    end note
+
+    note right of UnderInvestigation
+        Fraud screening, liability,
+        and damage assessment in progress.
+    end note
+
+    note right of Settled
+        Settlement paid. Bonus class
+        updated. Subrogation initiated if applicable.
+    end note
+
+    note right of Denied
+        Customer notified with reason.
+        Complaints procedure available.
+    end note
+```
+
 ## Alternative Flows
 
 ### A1: Phone-Reported Claim

--- a/docs/phase-1-motor/use-cases/uc-damage-assessment.md
+++ b/docs/phase-1-motor/use-cases/uc-damage-assessment.md
@@ -80,6 +80,38 @@ flowchart TD
     style T fill:#ffebee
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : Claim assigned for assessment
+    Pending --> Inspected : Vehicle inspected (on-site, remote, or shop)
+    Inspected --> Estimated : Repair estimate prepared
+    Estimated --> Approved : Handler accepts assessment
+    Estimated --> TotalLoss : Repair cost > 75% market value
+    TotalLoss --> Approved : Total loss valuation confirmed
+    Inspected --> FraudReview : Damage inconsistent with incident
+    Pending --> OnHold : Vehicle inaccessible
+    OnHold --> Pending : Access arranged
+    Approved --> [*]
+    FraudReview --> [*]
+
+    note right of Inspected
+        Damage documented with photos.
+        Components and costs recorded.
+    end note
+
+    note right of TotalLoss
+        Market value and salvage
+        value assessed.
+    end note
+
+    note right of Approved
+        Assessment accepted.
+        Claim ready for settlement.
+    end note
+```
+
 ## Main Success Scenario: On-Site Inspection
 
 | Step | Actor           | Action                                                                   | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -63,6 +63,35 @@ flowchart TD
     style K fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Received : Customer initiates claim report
+    Received --> Validated : Identity verified, policy matched
+    Validated --> Registered : Claim submitted with all details
+    Received --> Rejected : No active policy found
+    Validated --> Rejected : Incident not covered by tier
+    Registered --> [*]
+    Rejected --> [*]
+
+    note right of Received
+        FNOL initiated via web, app, or phone.
+        BankID authentication in progress.
+    end note
+
+    note right of Validated
+        Policy and coverage tier confirmed.
+        Incident details captured.
+    end note
+
+    note right of Registered
+        Claim number generated.
+        Claims handler assigned.
+        Customer confirmation sent.
+    end note
+```
+
 ## Main Flow (Online Self-Service)
 
 | Step | Actor    | Action                                                          | System Response                                                                                   |

--- a/docs/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/docs/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -65,6 +65,43 @@ flowchart TD
     style K fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : Claim registered
+    Pending --> Screened : Automated indicators evaluated
+    Screened --> Cleared : Low risk — no fraud indicators
+    Screened --> Flagged : Medium/high risk — indicators triggered
+    Flagged --> Investigated : Handler reviews evidence
+    Investigated --> Cleared : No fraud found
+    Investigated --> Confirmed : Fraud determined
+    Confirmed --> CriminalReferral : Referred to police
+    Confirmed --> [*]
+    CriminalReferral --> [*]
+    Cleared --> [*]
+
+    note right of Screened
+        Automated fraud risk score assigned.
+        GSR database checked.
+    end note
+
+    note right of Flagged
+        Settlement paused for high risk.
+        Specific indicators highlighted.
+    end note
+
+    note right of Investigated
+        Evidence gathered. GSR queried.
+        Damage consistency reviewed.
+    end note
+
+    note right of Confirmed
+        Claim denied. Fraud recorded
+        for future pattern detection.
+    end note
+```
+
 ## Main Flow: Automated Screening
 
 | Step | Actor  | Action                     | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-liability-determination.md
+++ b/docs/phase-1-motor/use-cases/uc-liability-determination.md
@@ -80,6 +80,36 @@ flowchart TD
     style L fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Undetermined : Claim registered and coverage verified
+    Undetermined --> UnderReview : Evidence collection begins
+    UnderReview --> Determined : Liability percentages assigned
+    UnderReview --> OnHold : Insufficient evidence
+    OnHold --> UnderReview : Additional evidence received
+    Determined --> Disputed : Party contests liability split
+    Disputed --> Arbitrated : TFF inter-company arbitration
+    Arbitrated --> Determined : Final liability confirmed
+    Determined --> [*]
+
+    note right of UnderReview
+        Police report, witness statements,
+        and photos under assessment.
+    end note
+
+    note right of Determined
+        Liability split recorded.
+        Subrogation target identified if applicable.
+    end note
+
+    note right of Disputed
+        Insurer or policyholder
+        contests the determination.
+    end note
+```
+
 ## Main Success Scenario: Multi-Party Collision
 
 | Step | Actor          | Action                                          | System Response                                                                 |

--- a/docs/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -62,6 +62,35 @@ flowchart TD
     style O fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Calculated : Refund amount determined
+    Calculated --> Approved : Customer confirms cancellation
+    Calculated --> NotApplicable : No refund due (huvudforfallodag)
+    Approved --> Disbursed : Payment provider processes refund
+    Approved --> Failed : Payment provider rejects refund
+    Failed --> Disbursed : Alternative payment method used
+    Disbursed --> [*]
+    NotApplicable --> [*]
+
+    note right of Calculated
+        Pro-rata or full refund computed.
+        Outstanding balance offset applied.
+    end note
+
+    note right of Approved
+        Refund breakdown shown to customer.
+        Confirmation received.
+    end note
+
+    note right of Disbursed
+        Refund issued within 30 days.
+        Confirmation sent to customer.
+    end note
+```
+
 ## Main Flow (Pro-Rata Refund Calculation)
 
 | Step | Actor    | Action                                                                                                | System Response                                                   |

--- a/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -63,6 +63,35 @@ flowchart TD
     style M fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Calculated : Settlement amount determined
+    Calculated --> Approved : Handler confirms (or senior approves)
+    Calculated --> SeniorReview : Amount exceeds handler authority
+    SeniorReview --> Approved : Senior handler approves
+    Approved --> Paid : Payment confirmed by provider
+    Approved --> RepairAuthorized : Direct billing to repair shop
+    RepairAuthorized --> Paid : Shop invoice settled
+    Paid --> [*]
+
+    note right of Calculated
+        Damage, liability, and deductible
+        applied to compute net amount.
+    end note
+
+    note right of Approved
+        Settlement breakdown sent
+        to customer before payment.
+    end note
+
+    note right of Paid
+        Claim status updated to Settled.
+        Payment records stored for audit.
+    end note
+```
+
 ## Main Flow: Vehicle Repair Settlement
 
 | Step | Actor          | Action                                              | System Response                                                                      |

--- a/docs/phase-1-motor/use-cases/underwriting-bonus.md
+++ b/docs/phase-1-motor/use-cases/underwriting-bonus.md
@@ -61,6 +61,48 @@ flowchart TD
     style I fill:#fff3e0
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Class7 : New customer default
+    Class7 --> Class8 : Claim-free year (+1)
+    Class8 --> Class9 : Claim-free year (+1)
+    Class9 --> Class10 : Claim-free year (+1)
+    Class10 --> Class11 : Claim-free year (+1)
+    Class11 --> Class12 : Claim-free year (+1)
+    Class12 --> Class13 : Claim-free year (+1)
+    Class13 --> Class14 : Claim-free year (+1)
+    Class14 --> Class15 : Claim-free year (+1)
+    Class15 --> Class15 : Claim-free year (max)
+    Class15 --> Class12 : One at-fault claim (-3)
+    Class12 --> Class9 : One at-fault claim (-3)
+    Class9 --> Class4 : Two+ at-fault claims (-5 each)
+    Class7 --> Class4 : One at-fault claim (-3)
+    Class4 --> Class1 : At-fault claim(s)
+    Class1 --> Class2 : Claim-free year (+1)
+    Class2 --> Class3 : Claim-free year (+1)
+    Class3 --> Class4 : Claim-free year (+1)
+    Class4 --> Class5 : Claim-free year (+1)
+    Class5 --> Class6 : Claim-free year (+1)
+    Class6 --> Class7 : Claim-free year (+1)
+
+    note right of Class1
+        Minimum class.
+        Highest premium.
+    end note
+
+    note right of Class15
+        Maximum class.
+        Highest discount.
+    end note
+
+    note right of Class7
+        Default starting class
+        for new customers.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Bonus Class Determination


### PR DESCRIPTION
## Summary
- Added Mermaid `stateDiagram-v2` blocks to all 14 Phase 1 Motor use cases showing entity lifecycle states, transitions, and business rule notes
- Enhanced the existing state diagram in `policy-administration.md` (UC-PA-004) with `PendingCancellation` and `Cancelled` states
- Each diagram uses `[*]` notation for initial/terminal states, labeled transitions with triggering events, and `note right of` for business rules

## Changes
- `quote-and-bind.md` — Quote lifecycle: Draft → Presented → Accepted → Bound → Expired
- `trafikforsakring.md` — Coverage status: Uninsured → Pending → Active → Lapsed → Cancelled
- `renewals.md` — Renewal lifecycle: Upcoming → Notified → Reviewed → Renewed / Lapsed
- `underwriting-bonus.md` — Bonus class transitions: Class 1–15 with upgrade/downgrade rules
- `policy-administration.md` — Enhanced existing diagram with PendingCancellation and Cancelled states
- `uc-claims-lifecycle.md` — Claim lifecycle: FNOL → Registered → Under Investigation → Decided → Settled/Denied → Closed → Reopened
- `uc-fnol-processing.md` — FNOL status: Received → Validated → Registered → Rejected
- `uc-fraud-screening.md` — Fraud screening: Pending → Screened → Flagged → Investigated → Cleared/Confirmed
- `uc-liability-determination.md` — Liability: Undetermined → Under Review → Determined → Disputed → Arbitrated
- `uc-damage-assessment.md` — Assessment: Pending → Inspected → Estimated → Approved / Total Loss
- `uc-settlement-calculation.md` — Settlement: Calculated → Approved → Paid
- `uc-cancellation-processing.md` — Cancellation: Requested → Validated → Processed → Confirmed
- `uc-refund-calculation.md` — Refund: Calculated → Approved → Disbursed
- `uc-claims-closure.md` — Closure: Review → Final Check → Closed / Reopened

## Testing
- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files pass
- [x] `npm run build` — builds successfully

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)