### PR TITLE
docs(#113): Add sequence diagrams to Phase 1 Motor use cases

### DIFF
--- a/docs/phase-1-motor/use-cases/policy-administration.md
+++ b/docs/phase-1-motor/use-cases/policy-administration.md
@@ -35,6 +35,61 @@ record entity provides a complete audit trail of every policy change.
 
 ---
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant S as System
+    participant TS as Transportstyrelsen
+    participant UW as Underwriter
+    participant PP as Payment Provider
+
+    Note over C,PP: UC-PA-001: Vehicle Change
+    C->>S: Request vehicle change
+    S->>TS: Lookup new vehicle (reg.nr)
+    TS-->>S: Vehicle data (make, model, year)
+    S-->>C: Display vehicle details for confirmation
+    C->>S: Confirm vehicle
+    S->>S: Assess risk of new vehicle
+    alt High-risk vehicle
+        S->>UW: Route for underwriter review
+        UW-->>S: Approve / decline
+    end
+    S->>S: Recalculate premium
+    S-->>C: Show premium change and pro-rata adjustment
+    C->>S: Accept premium adjustment
+    S->>TS: De-register old vehicle
+    S->>TS: Register new vehicle
+    S->>PP: Trigger payment adjustment
+    S-->>C: Updated policy document and certificate
+
+    Note over C,PP: UC-PA-002: Coverage Tier Change
+    C->>S: Request coverage change
+    S-->>C: Display tier comparison (trafik/halv/hel)
+    C->>S: Select new coverage tier
+    S-->>C: Provide updated IPID (IDD-002)
+    S->>S: Recalculate premium
+    S-->>C: Show premium change and pro-rata adjustment
+    C->>S: Acknowledge IPID and confirm change
+    S->>PP: Trigger payment adjustment
+    S-->>C: Updated policy document
+
+    Note over C,UW: UC-PA-003: Named Driver Change
+    C->>S: Add driver (enter personnummer)
+    S->>S: Validate personnummer and driving license
+    S->>S: Assess risk (age, experience)
+    alt High-risk driver
+        S->>UW: Route for underwriter review
+        UW-->>S: Approve / decline
+    end
+    S->>S: Recalculate premium with driver surcharges
+    S-->>C: Show premium impact
+    C->>S: Confirm driver addition
+    S->>PP: Trigger payment adjustment
+    S-->>C: Updated policy document
+```
+
 ## UC-PA-001: Process Mid-Term Vehicle Change
 
 ### Use Case Summary

--- a/docs/phase-1-motor/use-cases/quote-and-bind.md
+++ b/docs/phase-1-motor/use-cases/quote-and-bind.md
@@ -90,6 +90,53 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant S as System
+    participant TS as Transportstyrelsen
+    participant BID as BankID
+    participant PP as Payment Provider
+
+    C->>S: Enter reg.nr + personnummer
+    activate S
+    S->>TS: Vehicle lookup request
+    TS-->>S: Vehicle data (make, model, year, VIN)
+    S-->>C: Display vehicle details
+    deactivate S
+
+    S->>S: Retrieve bonus class from claims DB
+    S-->>C: Present demands-and-needs assessment form
+    C->>S: Complete assessment (usage, mileage, parking)
+    activate S
+    S-->>C: Coverage recommendation with rationale
+    deactivate S
+
+    S->>S: Calculate premiums for all three tiers
+    S-->>C: Side-by-side tier comparison with IPID links
+
+    C->>S: Select coverage tier, deductible, add-ons
+    S-->>C: Binding summary with pre-contractual info
+    Note over S,C: IDD-001/002/003 disclosures included
+
+    C->>BID: Initiate BankID signing
+    activate BID
+    S->>BID: Send policy document hash
+    BID-->>S: Authentication and signature confirmed
+    deactivate BID
+
+    activate S
+    S->>S: Generate policy number and certificate
+    S->>PP: Initiate payment setup (autogiro/invoice)
+    PP-->>S: Payment setup confirmed
+    S->>TS: Insurance notification (policy bound)
+    TS-->>S: Acknowledgement reference
+    S-->>C: Confirmation + certificate + policy documents
+    deactivate S
+```
+
 ## Main Success Scenario
 
 ### 1. Customer Identification

--- a/docs/phase-1-motor/use-cases/renewals.md
+++ b/docs/phase-1-motor/use-cases/renewals.md
@@ -71,6 +71,59 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as System
+    participant UW as Underwriter
+    participant Cust as Customer
+    participant PP as Payment Provider
+    participant TS as Transportstyrelsen
+    participant CI as Competitor Insurer
+
+    Note over S,Cust: UC-RN-001: Annual Renewal
+    S->>S: Batch: identify policies within renewal window
+    S->>S: Evaluate claims history and update bonus class
+    S->>S: Recalculate premium with new tariff
+    alt Premium increase above threshold
+        S->>UW: Route renewal for review
+        UW-->>S: Approve / adjust / retention offer
+    end
+    S-->>Cust: Send renewal notice (T-30 days)
+    alt Customer takes no action
+        S->>S: Auto-renew at huvudforfallodag
+        S->>PP: Update payment schedule
+        S-->>Cust: Renewal confirmation
+    else Customer cancels
+        Cust->>S: Submit cancellation request
+        S->>TS: Notify coverage end date
+        S-->>Cust: Cancellation confirmation + bonus certificate
+    else Customer requests changes
+        Cust->>S: Request coverage modifications
+        S->>S: Recalculate premium with changes
+        S->>S: Renew with modified terms
+    end
+
+    Note over S,CI: UC-RN-002: Flyttanmalan (Insurer Switch)
+    CI->>S: Flyttanmalan request (personnummer, reg.nr)
+    S->>S: Validate policy match and huvudforfallodag
+    S->>S: Suppress auto-renewal
+    S-->>CI: Confirmation + forsakringsbesked (bonus class)
+    S->>TS: Notify coverage end date
+    S-->>Cust: Cancellation confirmation + bonus certificate
+
+    Note over S,UW: UC-RN-003: Bonus Class Progression
+    S->>S: Retrieve claims history for expiring period
+    S->>S: Apply bonus progression rules
+    alt Customer disputes bonus
+        Cust->>S: Dispute bonus class
+        S->>UW: Route dispute for review
+        UW-->>S: Correct or confirm bonus class
+        S-->>Cust: Dispute resolution
+    end
+```
+
 ## UC-RN-001: Process Annual Policy Renewal
 
 Handles the end-to-end renewal flow from pre-renewal premium recalculation through automatic renewal or customer cancellation.

--- a/docs/phase-1-motor/use-cases/trafikforsakring.md
+++ b/docs/phase-1-motor/use-cases/trafikforsakring.md
@@ -98,6 +98,50 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as System
+    participant TS as Transportstyrelsen
+    participant CH as Claims Handler
+    participant CO as Compliance Officer
+    participant TFF as TFF
+    participant Cust as Customer
+
+    Note over S,TS: Policy Issuance - Registration
+    S->>S: Validate trafikforsakring included
+    S->>TS: Registration notification (reg.nr, policy, start date)
+    TS-->>S: Acknowledgement reference
+
+    Note over S,TS: Cancellation - Coverage Gap Prevention
+    Cust->>S: Request cancellation
+    S->>TS: Query replacement coverage status
+    alt Replacement confirmed
+        TS-->>S: Replacement coverage found
+        S->>S: Process cancellation
+        S->>TS: Notify coverage end date
+    else No replacement and vehicle registered
+        TS-->>S: No replacement coverage
+        S-->>Cust: Warn about TFF penalty (trafikforsakringsavgift)
+    end
+
+    Note over S,CH: Personal Injury Claim
+    Cust->>S: Report traffic accident
+    S->>CH: Assign claim (personal injury flagged)
+    CH->>CH: Apply strict liability (Trafikskadelagen)
+    CH->>S: Record compensation (medical, income, disability)
+    S->>TFF: Report claims data
+
+    Note over CO,TFF: TFF Reporting
+    S->>CO: Generate statutory reports
+    CO->>TFF: Review and submit reports
+
+    Note over S,Cust: Green Card Issuance
+    Cust->>S: Request Green Card for EU travel
+    S-->>Cust: Issue Green Card document
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Issuance — Mandatory Coverage Check and Registration

--- a/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-cancellation-processing.md
@@ -126,6 +126,68 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant S as System
+    participant TS as Transportstyrelsen
+    participant TFF as TFF
+    participant PP as Payment Provider
+    participant Ops as Operations Staff
+
+    Note over C,PP: Customer-Initiated Cancellation
+    C->>S: Log in and select policy to cancel
+    C->>S: Select cancellation reason
+    S->>S: Determine cancellation type and rules
+
+    alt Cooling-off (angerratt) within 14 days
+        S->>S: Calculate full refund
+    else Huvudforfallodag
+        S->>S: No refund - coverage runs to end
+    else Mid-term (vehicle sold/scrapped/emigration)
+        S->>S: Calculate pro-rata refund
+    end
+
+    S->>S: Check if policy includes trafikforsakring
+    opt Trafikforsakring policy
+        S->>TS: Query replacement coverage
+        alt Replacement confirmed
+            TS-->>S: Replacement coverage found
+        else No replacement
+            TS-->>S: No replacement coverage
+            S-->>C: Block cancellation - coverage required
+        end
+    end
+
+    S-->>C: Display refund breakdown and effective date
+    C->>S: Confirm cancellation
+    S->>TS: Notify policy termination
+    TS-->>S: Acknowledgement
+    S->>PP: Process refund (if applicable)
+    PP-->>S: Refund confirmed
+    S-->>C: Cancellation confirmation
+
+    Note over S,Ops: Insurer-Initiated Cancellation
+    S->>C: Payment reminder (overdue premium)
+    S->>S: Grace period (14 days)
+    alt Payment received
+        S->>S: Policy remains active
+    else No payment
+        S->>C: Cancellation warning (14-day notice)
+        alt Payment received within notice period
+            S->>S: Policy remains active
+        else No payment after notice
+            Ops->>S: Approve insurer-initiated cancellation
+            S->>TS: Notify coverage termination
+            opt Trafikforsakring
+                S->>TFF: Notify uninsured vehicle
+            end
+        end
+    end
+```
+
 ## Main Flow (Customer-Initiated Online Cancellation)
 
 | Step | Actor    | Action                                                                          | System Response                                                                                |

--- a/docs/phase-1-motor/use-cases/uc-claims-closure.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-closure.md
@@ -117,6 +117,52 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant CH as Claims Handler
+    participant S as System
+    participant Acct as Accounting
+    participant Act as Actuary
+    participant C as Customer
+
+    CH->>S: Initiate claim closure
+    activate S
+    S->>S: Validate all payments confirmed
+    S->>S: Validate subrogation cases resolved
+    S->>S: Validate bonus class impact applied
+    S->>S: Validate all documents attached
+    S->>S: Validate no pending disputes
+    deactivate S
+
+    alt Checklist item fails
+        S-->>CH: Display blocking items
+        CH->>S: Resolve outstanding items
+        CH->>S: Retry closure
+    end
+
+    S-->>CH: Present closure summary (total paid, recovered, net cost)
+    CH->>S: Confirm closure
+    S->>S: Set claim status to Closed
+
+    S->>Acct: Release outstanding reserves
+    S->>Act: Update actuarial reporting data (frequency, severity, KPIs)
+    S-->>C: Closure notification with final summary
+
+    Note over S: Claim record retained for 10 years (FSA-014)
+
+    opt Claim reopening (new evidence or dispute)
+        CH->>S: Request reopening with reason
+        alt Claim less than 1 year old
+            S->>S: Reopen with standard authorization
+        else Claim more than 1 year old
+            CH->>S: Senior handler approval required
+        end
+        S->>Acct: Re-establish reserves
+    end
+```
+
 ## Main Success Scenario: Standard Closure
 
 | Step | Actor          | Action                                           | System Response                                                     |

--- a/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
+++ b/docs/phase-1-motor/use-cases/uc-claims-lifecycle.md
@@ -62,6 +62,60 @@ flowchart TD
     E --> T[Record denial and close]
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant CH as Claims Handler
+    participant S as System
+    participant CA as Claims Adjuster
+    participant RS as Repair Shop
+    participant PP as Payment Provider
+
+    C->>S: Report incident (FNOL via web/app/phone)
+    S->>S: Create claim record and assign claim number
+    S->>CH: Assign claim to handler
+
+    CH->>S: Verify coverage against policy
+    alt Coverage denied
+        S-->>C: Denial notification + complaints procedure
+    end
+
+    S->>S: Run automated fraud screening
+    alt High fraud risk
+        CH->>CH: Full investigation
+        alt Fraud confirmed
+            S-->>C: Claim denied
+        end
+    end
+
+    CH->>CH: Determine liability based on evidence
+    CH->>S: Record liability split
+
+    S->>CA: Assign damage assessment
+    CA->>CA: Inspect vehicle and document damage
+    CA-->>CH: Submit assessment report (repair estimate or total loss)
+
+    CH->>S: Approve or deny claim
+    alt Approved
+        S->>S: Calculate settlement (damage - deductible)
+        alt Direct billing
+            S->>RS: Send repair authorization
+        else Payment to customer
+            S->>PP: Initiate bank transfer
+        end
+        PP-->>S: Payment confirmed
+        S->>S: Update bonus class
+        opt Subrogation eligible
+            CH->>S: Initiate subrogation against third party
+        end
+    end
+
+    CH->>S: Final review and close claim
+    S-->>C: Closure notification with final summary
+```
+
 ### Step-by-Step
 
 | Step | Action                                                        | Actor           | System Response                                             | Reference                                                                                                        |

--- a/docs/phase-1-motor/use-cases/uc-damage-assessment.md
+++ b/docs/phase-1-motor/use-cases/uc-damage-assessment.md
@@ -112,6 +112,61 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant CH as Claims Handler
+    participant CA as Claims Adjuster
+    participant C as Customer
+    participant RS as Repair Shop
+    participant S as System
+
+    CH->>CA: Assign damage assessment
+    CA->>C: Contact to schedule inspection
+
+    alt On-site inspection
+        CA->>CA: Inspect vehicle at location
+        CA->>S: Document damage with photos (min 4)
+        CA->>S: Record affected components
+        CA->>S: Prepare repair estimate (parts, labor, paint)
+    else Remote assessment (minor damage)
+        S-->>C: Request photos (min 6)
+        C->>S: Upload damage photos
+        CA->>S: Review photos
+        alt Photos sufficient
+            CA->>S: Complete remote assessment
+        else Photos insufficient
+            CA->>C: Schedule on-site inspection
+        end
+    else Repair shop estimate
+        CH-->>C: Direct to authorized repair shop
+        RS->>S: Submit repair estimate
+        CA->>S: Review shop estimate vs market rates
+        alt Within acceptable range
+            CA->>S: Approve estimate
+        else Rates above market
+            CA->>S: Adjust estimate with justification
+        end
+    end
+
+    CA->>CA: Consistency check (damage vs reported incident)
+    alt Inconsistency detected
+        CA->>CH: Flag for fraud review
+    end
+
+    alt Repair cost > 75% of market value
+        S->>S: Calculate vehicle market value
+        CA->>S: Confirm market value and salvage value
+        CA->>S: Submit total loss report
+    else Repair feasible
+        CA->>S: Submit repair estimate
+    end
+
+    CA->>CH: Submit completed assessment report
+    CH->>S: Review and accept assessment
+```
+
 ## Main Success Scenario: On-Site Inspection
 
 | Step | Actor           | Action                                                                   | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-fnol-processing.md
+++ b/docs/phase-1-motor/use-cases/uc-fnol-processing.md
@@ -92,6 +92,45 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant BID as BankID
+    participant S as System
+    participant CH as Claims Handler
+
+    Note over C,CH: Online Self-Service FNOL
+    C->>S: Open claims reporting page
+    C->>BID: Authenticate via BankID
+    BID-->>S: Identity verified
+    S-->>C: Display active policies
+    C->>S: Select policy and vehicle
+    S-->>C: Show eligible claim types for coverage tier
+    C->>S: Select claim type (collision, theft, glass, etc.)
+    S-->>C: Adapted FNOL form
+    C->>S: Enter incident details (date, time, location)
+    S->>S: Validate incident date against coverage period
+    C->>S: Enter other party information (if applicable)
+    C->>S: Upload damage photos and documents
+    S-->>C: Display FNOL summary for review
+    C->>S: Submit claim report
+    activate S
+    S->>S: Generate claim number (skadenummer)
+    S->>CH: Auto-assign claims handler
+    S-->>C: Confirmation with claim number
+    deactivate S
+
+    Note over C,CH: Phone-Reported FNOL
+    C->>CH: Call claims phone line
+    CH->>S: Search policy (personnummer or policy number)
+    S-->>CH: Display matching policies
+    CH->>S: Create claim and enter incident details
+    S->>S: Generate claim number
+    CH-->>C: Provide claim number
+```
+
 ## Main Flow (Online Self-Service)
 
 | Step | Actor    | Action                                                          | System Response                                                                                   |

--- a/docs/phase-1-motor/use-cases/uc-fraud-screening.md
+++ b/docs/phase-1-motor/use-cases/uc-fraud-screening.md
@@ -102,6 +102,54 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as System
+    participant GSR as GSR (Fraud DB)
+    participant CH as Claims Handler
+    participant CA as Claims Adjuster
+    participant Police as Police
+
+    S->>S: New claim registered - trigger fraud screening
+    S->>S: Evaluate fraud indicators and calculate risk score
+    S->>GSR: Query for matching patterns
+    GSR-->>S: Match results
+
+    alt Low risk
+        S->>S: Auto-clear - proceed to normal processing
+    else Medium risk
+        S->>CH: Flag claim for handler review
+        CH->>S: Review flagged indicators
+        CH->>CH: Gather additional evidence
+        CH->>GSR: Check for additional pattern matches
+        alt Cleared
+            CH->>S: Clear fraud flag
+            S->>S: Resume normal claims processing
+        else Suspicious
+            CH->>S: Escalate to senior handler
+        end
+    else High risk
+        S->>S: Hold claim - pause settlement
+        S->>CH: Assign for full investigation
+        activate CH
+        CH->>CA: Request re-inspection for consistency
+        CA-->>CH: Assessment consistency report
+        CH->>CH: Complete investigation
+        alt Fraud confirmed
+            CH->>S: Deny claim with fraud determination
+            opt Criminal referral warranted
+                CH->>Police: Submit criminal referral
+                Police-->>CH: Police reference number
+            end
+        else No fraud found
+            CH->>S: Clear flag and resume processing
+        end
+        deactivate CH
+    end
+```
+
 ## Main Flow: Automated Screening
 
 | Step | Actor  | Action                     | System Response                                                          |

--- a/docs/phase-1-motor/use-cases/uc-liability-determination.md
+++ b/docs/phase-1-motor/use-cases/uc-liability-determination.md
@@ -110,6 +110,58 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant CH as Claims Handler
+    participant S as System
+    participant Police as Police
+    participant TPI as Third-Party Insurer
+    participant TFF as TFF
+
+    CH->>S: Open claim for liability assessment
+    S-->>CH: Display incident details and evidence
+
+    alt Single-vehicle incident
+        CH->>S: Set 100% policyholder liability
+        CH->>S: Check coverage tier (halv/hel required)
+    else Multi-vehicle collision
+        CH->>Police: Request police report
+        Police-->>CH: Police report with findings
+        CH->>CH: Review witness statements and photos
+        CH->>S: Identify all parties involved
+        S-->>CH: Suggest default liability split
+        CH->>S: Adjust and confirm liability percentages
+        Note over CH,S: VR-LIA-001: percentages must total 100%
+        opt Third-party insurer coordination
+            CH->>TPI: Contact to agree on liability split
+            alt Agreement reached
+                TPI-->>CH: Agreed split
+            else Disagreement
+                CH->>TFF: Escalate to inter-company arbitration
+                TFF-->>CH: Arbitrated liability decision
+            end
+        end
+    else Animal collision (viltskada)
+        CH->>S: Record no-fault determination
+        Note over CH,S: Bonus-neutral - no impact on bonus class
+    else Hit-and-run (smitning)
+        CH->>Police: Verify police report (mandatory)
+        Police-->>CH: Police report confirmed
+        CH->>S: Determine TFF eligibility
+        S->>TFF: Refer for unidentified vehicle claim
+    else Personal injury (trafikforsakring)
+        CH->>S: Apply strict liability (Trafikskadelagen)
+    end
+
+    CH->>S: Record liability rationale and evidence
+    opt Subrogation eligible
+        CH->>S: Identify recovery target
+    end
+    S->>S: Advance claim to damage assessment
+```
+
 ## Main Success Scenario: Multi-Party Collision
 
 | Step | Actor          | Action                                          | System Response                                                                 |

--- a/docs/phase-1-motor/use-cases/uc-refund-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-refund-calculation.md
@@ -91,6 +91,53 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as System
+    participant C as Customer
+    participant PP as Payment Provider
+    participant Ops as Operations Staff
+
+    S->>S: Retrieve annual premium and payment history
+    S->>S: Determine cancellation effective date
+
+    alt Cooling-off (angerratt)
+        S->>S: Calculate full refund
+        opt Early coverage start requested
+            S->>S: Deduct proportional days of coverage used
+        end
+    else Huvudforfallodag
+        S-->>C: No refund - coverage runs to period end
+    else Mid-term (vehicle sold/scrapped/emigration)
+        S->>S: Calculate pro-rata refund
+        Note over S: (remaining days / total days) x premium
+    end
+
+    S->>S: Check for outstanding balance
+    opt Outstanding premium balance
+        S->>S: Offset: net refund = gross refund - outstanding
+    end
+
+    alt Net refund is positive
+        S-->>C: Display refund breakdown before confirmation
+        C->>S: Confirm cancellation and refund
+        S->>PP: Send refund instruction (original payment method)
+        alt Payment successful
+            PP-->>S: Refund processed
+            S-->>C: Refund confirmation with expected payment date
+        else Payment rejected
+            PP-->>S: Rejection (e.g., closed bank account)
+            S->>Ops: Alert for manual processing
+            Ops->>C: Arrange alternative refund method
+            Ops->>PP: Reprocess refund
+        end
+    else Net refund is zero or negative
+        S-->>C: Inform of remaining balance (no refund)
+    end
+```
+
 ## Main Flow (Pro-Rata Refund Calculation)
 
 | Step | Actor    | Action                                                                                                | System Response                                                   |

--- a/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
+++ b/docs/phase-1-motor/use-cases/uc-settlement-calculation.md
@@ -92,6 +92,56 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant CH as Claims Handler
+    participant S as System
+    participant CA as Claims Adjuster
+    participant PP as Payment Provider
+    participant RS as Repair Shop
+    participant C as Customer
+
+    CH->>S: Open approved claim for settlement
+    S-->>CH: Display damage assessment and repair estimate
+
+    alt Vehicle repair
+        S->>S: Calculate: repair cost - deductible
+        S-->>CH: Settlement amount with breakdown
+    else Total loss
+        CA->>S: Market value and salvage value
+        S->>S: Calculate: market value - salvage - deductible
+        S-->>CH: Total loss settlement breakdown
+    else Liability split (multi-party)
+        S->>S: Apply liability % to damage amount
+        S->>S: Subtract deductible from adjusted amount
+        S-->>CH: Liability-adjusted settlement
+    else Personal injury (trafikforsakring)
+        CH->>S: Enter compensation components
+        S->>S: Calculate: medical + income loss + pain + disability
+        Note over S,CH: No deductible for personal injury claims
+        S-->>CH: Total compensation amount
+    end
+
+    alt Amount exceeds handler authority (> SEK 100k)
+        CH->>S: Request senior approval
+        S-->>CH: Senior approval granted
+    end
+
+    CH->>S: Confirm settlement and select payment method
+    alt Direct billing to repair shop
+        S->>RS: Send repair authorization
+        Note over RS,C: Customer pays deductible to shop
+    else Bank transfer to customer
+        S->>PP: Initiate bank transfer
+        PP-->>S: Payment confirmed
+    end
+
+    S-->>C: Settlement breakdown notification
+    S->>S: Update claim status to Settled
+```
+
 ## Main Flow: Vehicle Repair Settlement
 
 | Step | Actor          | Action                                              | System Response                                                                      |

--- a/docs/phase-1-motor/use-cases/underwriting-bonus.md
+++ b/docs/phase-1-motor/use-cases/underwriting-bonus.md
@@ -103,6 +103,57 @@ stateDiagram-v2
     end note
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer
+    participant S as System
+    participant RE as Rating Engine
+    participant TFF as TFF
+    participant UW as Underwriter
+
+    C->>S: Request motor insurance quote
+    activate S
+    S->>S: Retrieve bonus class from internal DB
+    alt New customer
+        S->>S: Assign default starting class (class 7)
+    else Transfer from another insurer
+        S->>TFF: Verify transferred bonus class
+        TFF-->>S: Verification result
+    end
+    deactivate S
+
+    S->>RE: Submit rating factors (vehicle, customer, usage)
+    activate RE
+    RE->>RE: Apply rating model (multiplicative factors)
+    RE->>RE: Apply bonus class discount
+    RE->>RE: Enforce min/max premium limits
+    RE-->>S: Premium for all three tiers
+    deactivate RE
+
+    S->>S: Evaluate acceptance criteria
+    alt Auto-accept
+        S-->>C: Present quote with premium breakdown
+    else Referral triggered
+        S->>UW: Route to underwriter queue
+        activate UW
+        UW->>UW: Review risk assessment
+        alt Approve
+            UW-->>S: Approved (standard terms)
+        else Approve with conditions
+            UW-->>S: Approved with premium loading/exclusions
+        else Decline
+            UW-->>S: Declined with reason
+        end
+        deactivate UW
+        S-->>C: Present decision to customer
+    else Decline rule triggered
+        S-->>C: Notify decline with reason
+        Note over S,C: Trafikforsakring still offered (FSA-007)
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Bonus Class Determination


### PR DESCRIPTION
## Summary
- Add Mermaid `sequenceDiagram` blocks to all 14 Phase 1 Motor use cases
- Each diagram shows actor-to-actor message flows for the main success scenario
- Alternative/error paths shown using `alt`/`opt` blocks where appropriate
- New `## Interaction Sequence` section placed after existing process flow diagrams

## Changes
- 14 use case files modified in `docs/phase-1-motor/use-cases/`
- No changes to `versioned_docs/` (per issue scope)
- Zero new files created

## Testing
- [x] `npx markdownlint docs/` passes with zero warnings
- [x] `npx prettier --check .` passes
- [x] `npm run build` succeeds — all diagrams render correctly

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)