### PR TITLE
docs(#119): Add sequence diagrams to Phase 2 Home & Property use cases

### DIFF
--- a/docs/phase-2-home-property/use-cases/burglary-and-theft.md
+++ b/docs/phase-2-home-property/use-cases/burglary-and-theft.md
@@ -72,6 +72,85 @@ flowchart TD
     style O fill:#fff3e0
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant CH as Claims Handler (Skadereglerare)
+    participant LS as Låssmed (Locksmith)
+    participant PO as Polisen (Police)
+    participant FI as Fraud Investigator
+    participant RP as Repair Partner
+
+    rect rgb(230, 245, 255)
+        Note over C, LS: Emergency Response
+        C->>S: Report burglary (web/app/phone/24h emergency line)
+        S->>S: Create preliminary claim record
+        opt Locks or entry compromised
+            S->>LS: Dispatch emergency locksmith
+            S->>C: Confirm locksmith ETA
+            LS->>S: Arrive and secure property
+        end
+        S->>C: Guidance — do not disturb scene, file polisanmälan
+    end
+
+    rect rgb(255, 243, 224)
+        Note over C, CH: FNOL Registration
+        C->>PO: File polisanmälan
+        PO-->>C: Police report number (K-nummer)
+        C->>S: Provide police report number
+        CH->>S: Register FNOL, link police report, verify coverage
+        S->>C: Confirm claim number and next steps
+    end
+
+    rect rgb(252, 228, 236)
+        Note over S, FI: Fraud Screening
+        S->>S: Automated fraud screening (forced entry, timing, history)
+        S->>S: Assign fraud risk score
+        alt High fraud risk
+            CH->>FI: Escalate to fraud investigation
+            FI->>FI: Conduct detailed investigation
+            FI-->>CH: Cleared or confirmed fraud
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over C, CH: Inventory and Verification
+        S->>C: Send structured property inventory form
+        C->>S: Submit stolen items with descriptions and receipts
+        opt Total claimed > 100,000 SEK
+            CH->>S: Assign field investigator for on-site verification
+        end
+        CH->>S: Verify items against prior declarations
+        CH->>S: Record verification per item (Verified/Partial/Unverified)
+    end
+
+    rect rgb(243, 229, 245)
+        Note over CH, RP: Settlement and Repair
+        S->>S: Calculate replacement value per item
+        S->>S: Apply åldersavdrag (age deduction) per category
+        S->>S: Apply sub-limits where applicable
+        S->>S: Subtract deductible (självrisk)
+        S->>C: Present settlement breakdown
+        CH->>S: Approve and initiate payment
+        S->>C: Process settlement payment
+        CH->>RP: Create repair authorization (locks, windows, doors)
+        RP->>RP: Complete break-in damage repair
+        S->>RP: Process repair payment
+    end
+
+    rect rgb(255, 253, 231)
+        Note over S, C: Crisis Support and Closure
+        S->>C: Offer krisstöd (crisis counseling)
+        opt Customer requests support
+            S->>C: Connect to licensed crisis counselor
+        end
+        CH->>S: Close claim
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Burglary Report and Emergency Response

--- a/docs/phase-2-home-property/use-cases/cancellations.md
+++ b/docs/phase-2-home-property/use-cases/cancellations.md
@@ -89,6 +89,89 @@ flowchart TD
     style X fill:#ffebee
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant BID as BankID
+    participant A as Customer Service Agent
+    participant PP as Payment Provider
+    participant NI as New Insurer
+    participant UW as Underwriter (Försäkringsgivare)
+
+    rect rgb(230, 245, 255)
+        Note over C, BID: Cancellation Request
+        C->>S: Request cancellation (portal/app/phone)
+        S->>BID: Authenticate customer
+        BID-->>S: Identity verified
+        S->>S: Identify policy and cancellation type
+    end
+
+    alt Ångerrätt (within 14 days)
+        rect rgb(232, 245, 233)
+            Note over C, PP: Cooling-Off Cancellation
+            S->>S: Verify within 14-day ångerrätt period
+            S->>S: Calculate full refund (minus any claims costs)
+            S->>C: Present refund amount
+            C->>S: Confirm cancellation
+            S->>PP: Process full refund
+            PP-->>S: Refund initiated
+            S->>C: Send cancellation confirmation
+        end
+    else Customer-initiated cancellation
+        rect rgb(255, 243, 224)
+            Note over C, NI: Standard Cancellation
+            C->>S: Select reason (sale/move/switch insurer/other)
+            S->>S: Determine effective date
+            S->>S: Calculate pro-rata refund
+            S->>C: Preview refund and effective date
+            opt Switching insurer
+                C->>S: Provide new insurer details and start date
+                S->>S: Check for coverage gap
+                alt Gap detected
+                    S->>C: Warn about coverage gap risk
+                    C->>S: Acknowledge gap or adjust dates
+                end
+            end
+            C->>S: Confirm cancellation
+            S->>PP: Process pro-rata refund
+            PP-->>S: Refund initiated
+            S->>C: Send cancellation confirmation
+        end
+    else Insurer-initiated (non-payment)
+        rect rgb(255, 235, 238)
+            Note over S, C: Non-Payment Cancellation
+            S->>C: Send betalningspåminnelse (14-day grace)
+            alt Payment received
+                C->>S: Pay overdue premium
+                S->>S: Reinstate policy
+            else Still unpaid
+                S->>C: Send uppsägningsvarning (14-day final grace)
+                alt Payment received
+                    C->>S: Pay overdue premium
+                    S->>S: Reinstate policy
+                else Still unpaid
+                    S->>S: Cancel policy automatically
+                    S->>C: Send cancellation notice
+                end
+            end
+        end
+    else Insurer-initiated (misrepresentation)
+        rect rgb(252, 228, 236)
+            Note over UW, C: Misrepresentation Cancellation
+            UW->>S: Document misrepresentation and evidence
+            alt Intentional (fraud)
+                S->>S: Immediate cancellation, no refund
+                S->>C: Send formal notice with denial and ARN rights
+            else Unintentional
+                S->>C: Offer adjustment or cancellation with refund
+            end
+        end
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Cancellation Request

--- a/docs/phase-2-home-property/use-cases/home-renewals.md
+++ b/docs/phase-2-home-property/use-cases/home-renewals.md
@@ -69,6 +69,75 @@ flowchart TD
     style O fill:#ffebee
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant S as System
+    participant SCB as SCB (Statistiska centralbyrån)
+    participant UW as Underwriter (Försäkringsgivare)
+    participant C as Customer (Privatkund)
+    participant A as Customer Service Agent
+    participant PP as Payment Provider
+
+    rect rgb(230, 245, 255)
+        Note over S, SCB: T-60: Index Adjustment and Recalculation
+        S->>S: Identify policies approaching huvudförfallodag
+        S->>SCB: Retrieve byggkostnadsindex
+        SCB-->>S: Current building cost index
+        S->>SCB: Retrieve konsumentprisindex (KPI)
+        SCB-->>S: Current consumer price index
+        S->>S: Recalculate building sum (villa/fritidshus)
+        S->>S: Recalculate contents sum (all policies)
+        S->>S: Recalculate premium with updated risk factors
+    end
+
+    rect rgb(255, 243, 224)
+        Note over S, UW: T-45: Underwriter Review (If Flagged)
+        alt Premium increase > 15% or 2+ claims or index > 10%
+            S->>UW: Route to underwriter review queue
+            UW->>UW: Review claims history and risk factors
+            alt Approve
+                UW-->>S: Renewal approved
+            else Conditional
+                UW-->>S: Approve with conditions (increased deductible, exclusions)
+            else Non-renewal
+                UW-->>S: Non-renewal decision
+            end
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over S, C: T-30: Renewal Notice
+        S->>S: Generate förnyelseavisering
+        S->>C: Dispatch renewal notice (postal/digital/Mina Sidor)
+    end
+
+    rect rgb(243, 229, 245)
+        Note over C, PP: T-30 to T-0: Customer Response Window
+        alt Customer modifies coverage
+            C->>S: Request coverage/tier/deductible change
+            S->>S: Recalculate premium with new terms
+            S->>C: Present updated terms
+            C->>S: Confirm modified terms
+        else Customer cancels
+            C->>S: Submit cancellation
+            S->>C: Cancellation confirmation
+        else No response or accept
+            Note over C: Automatic renewal proceeds
+        end
+    end
+
+    rect rgb(255, 253, 231)
+        Note over S, PP: T-0: Automatic Renewal
+        S->>S: Create new policy period with updated terms
+        S->>S: Generate updated policy document
+        S->>PP: Update payment schedule with new premium
+        PP-->>S: Payment schedule confirmed
+        S->>C: Send renewal confirmation
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Identification (T-60 Days)

--- a/docs/phase-2-home-property/use-cases/policy-administration.md
+++ b/docs/phase-2-home-property/use-cases/policy-administration.md
@@ -116,6 +116,73 @@ flowchart TD
     style I fill:#fff3e0
 ```
 
+### Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant BID as BankID
+    participant LM as Lantmäteriet
+    participant UW as Underwriter (Försäkringsgivare)
+    participant PP as Payment Provider
+
+    rect rgb(230, 245, 255)
+        Note over C, BID: Authentication
+        C->>S: Select "Make a change" on policy page
+        S->>BID: Authenticate customer
+        BID-->>S: Identity verified
+        C->>S: Select change type
+    end
+
+    alt Address change
+        rect rgb(255, 243, 224)
+            Note over C, LM: Address Change
+            C->>S: Enter new address
+            S->>LM: Property lookup
+            LM-->>S: Property data (type, year, area)
+            alt Different property type
+                S->>C: Redirect to new quote flow
+            else Same property type
+                S->>S: Recalculate premium for new address
+            end
+        end
+    else Coverage tier change
+        rect rgb(232, 245, 233)
+            Note over C, S: Coverage Change
+            S->>C: Show tier comparison (bas/standard/premium)
+            C->>S: Select new tier
+            opt Significant change
+                S->>C: Request updated demands-and-needs (IDD-011)
+                C->>S: Complete updated assessment
+            end
+            S->>S: Recalculate premium
+        end
+    else Add-on or deductible change
+        rect rgb(243, 229, 245)
+            Note over C, S: Add-on / Deductible Change
+            S->>C: Show options with pricing
+            C->>S: Select new add-on or deductible level
+            S->>S: Recalculate premium
+        end
+    end
+
+    rect rgb(255, 253, 231)
+        Note over S, PP: Approval and Processing
+        alt Underwriter review needed
+            S->>UW: Route amendment for review
+            UW-->>S: Approve / decline
+        end
+        S->>C: Display old vs new premium + pro-rata adjustment
+        C->>S: Confirm change
+        S->>S: Process amendment and update policy record
+        S->>PP: Trigger premium adjustment
+        PP-->>S: Payment processed
+        S->>S: Generate updated policy documents
+        S->>C: Send confirmation with updated documents
+    end
+```
+
 ### Main Success Scenario
 
 1. **Initiate** — Customer selects "Make a change" from their policy
@@ -309,6 +376,56 @@ flowchart TD
     style N fill:#ffebee
 ```
 
+### Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant BC as BRF Board Chair (Ordförande)
+    participant S as System
+    participant BV as Building Valuation Tool
+    participant UW as Underwriter (Försäkringsgivare)
+    participant PP as Payment Provider
+
+    rect rgb(230, 245, 255)
+        Note over BC, S: Authentication and Change Request
+        BC->>S: Log in and select BRF building policy
+        S->>S: Verify BRF authorization via Bolagsverket
+        BC->>S: Select change type (renovation/facility/valuation)
+    end
+
+    alt Renovation completed
+        BC->>S: Enter renovation details (type, scope, cost, date)
+        S->>BV: Recalculate building sum insured
+        BV-->>S: Updated rebuilding cost estimate
+    else Facility change
+        BC->>S: Add/remove facility (sauna, pool, workshop)
+        S->>S: Update facility list and assess risk
+    else Valuation review
+        BC->>S: Request revaluation
+        S->>BV: Fresh rebuilding cost estimate
+        BV-->>S: Updated valuation
+    end
+
+    rect rgb(255, 243, 224)
+        Note over S, UW: Review and Approval
+        alt Valuation anomaly or high-risk facility
+            S->>UW: Route for underwriter review
+            UW-->>S: Approve / approve with conditions / decline
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over BC, PP: Confirmation and Processing
+        S->>BC: Show updated sum insured and premium change
+        BC->>S: Confirm change
+        S->>S: Process amendment and update policy
+        S->>PP: Adjust premium
+        PP-->>S: Payment processed
+        S->>S: Reissue building insurance certificate
+        S->>BC: Send confirmation to board
+    end
+```
+
 ### Main Success Scenario
 
 1. **Authenticate** — BRF board chair logs in and selects the BRF building
@@ -459,6 +576,53 @@ flowchart TD
     style A fill:#e1f5fe
     style O fill:#e8f5e9
     style J fill:#fff3e0
+```
+
+### Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant PH as Policyholder (Privatkund)
+    participant S as System
+    participant BID as BankID
+
+    rect rgb(230, 245, 255)
+        Note over PH, BID: Authentication
+        PH->>S: Select "Manage household members"
+        S->>BID: Authenticate policyholder
+        BID-->>S: Identity verified
+    end
+
+    alt Add family member
+        rect rgb(232, 245, 233)
+            Note over PH, S: Add Member
+            PH->>S: Enter member details (name, personnummer/DOB, relationship)
+            S->>S: Validate personnummer format
+            S->>S: Check for duplicate coverage at same address
+            opt Duplicate found
+                S->>PH: Warning — person listed on another policy
+            end
+        end
+    else Remove family member
+        rect rgb(255, 243, 224)
+            Note over PH, S: Remove Member
+            PH->>S: Select member to remove
+            S->>PH: Confirm removal and impact on coverage
+        end
+    end
+
+    rect rgb(243, 229, 245)
+        Note over PH, S: Review and Confirmation
+        S->>S: Review household size vs contents sum insured
+        opt Sum insured inadequate for household size
+            S->>PH: Suggest updated sum insured (lösöresumma)
+        end
+        S->>PH: Show updated member list and premium impact
+        PH->>S: Confirm change
+        S->>S: Process amendment and update policy
+        S->>S: Generate updated policy document
+        S->>PH: Send confirmation with updated household list
+    end
 ```
 
 ### Main Success Scenario

--- a/docs/phase-2-home-property/use-cases/quote-and-bind.md
+++ b/docs/phase-2-home-property/use-cases/quote-and-bind.md
@@ -69,6 +69,64 @@ flowchart TD
     style R fill:#fff3e0
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant LM as Lantmäteriet
+    participant BID as BankID
+    participant UW as Underwriter (Försäkringsgivare)
+    participant PP as Payment Provider
+
+    rect rgb(230, 245, 255)
+        Note over C, LM: Property Verification
+        C->>S: Enter address + product type + personnummer
+        S->>LM: Query property registry
+        LM-->>S: Property data (type, year, area, coordinates)
+        S->>S: Validate building type matches product
+    end
+
+    rect rgb(255, 243, 224)
+        Note over S, UW: Risk Assessment
+        S->>S: Automated risk assessment (flood, subsidence, crime)
+        alt High-risk property
+            S->>UW: Route to underwriter review
+            UW-->>S: Accept / accept with conditions / decline
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over C, S: Demands-and-Needs & Quote
+        S->>C: Present demands-and-needs assessment (krav- och behovsanalys)
+        C->>S: Complete assessment (household, belongings, deductible)
+        S->>S: Generate coverage recommendation
+        opt BRF product (bostadsrättsförsäkring)
+            S->>C: Present BRF coverage gap analysis
+            C->>S: Confirm understanding of coverage boundary
+        end
+        S->>S: Calculate premiums for all tiers
+        S->>C: Present tier comparison with add-ons and IPID links
+        C->>S: Select coverage tier, deductible, and add-ons
+    end
+
+    rect rgb(243, 229, 245)
+        Note over C, PP: Binding and Issuance
+        S->>C: Present binding summary + pre-contractual info (IDD-003)
+        C->>BID: Initiate BankID signing
+        BID-->>S: Verification result + transaction reference
+        alt BankID verified
+            S->>S: Generate policy number and documents
+            S->>PP: Initiate payment setup (autogiro/invoice)
+            PP-->>S: Payment confirmation
+            S->>C: Send confirmation (policy, IPID, payment instructions)
+        else BankID failed
+            S->>C: Offer retry or save quote for later
+        end
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Address Entry and Product Selection

--- a/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
@@ -74,6 +74,84 @@ flowchart TD
     style N fill:#fce4ec
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant CH as Claims Handler (Skadereglerare)
+    participant FD as Räddningstjänsten (Brandkår)
+    participant BI as Besiktningsman
+    participant RC as Remediation Contractor
+    participant CO as Contractor
+    participant BRF as BRF Board (BRF-styrelse)
+
+    rect rgb(230, 245, 255)
+        Note over C, CH: FNOL and Emergency
+        C->>S: Report fire/natural event (web/app/phone 24/7)
+        S->>C: Confirm FNOL, flag as high-priority
+        CH->>S: Register FNOL with event type and habitability status
+        opt Property uninhabitable
+            CH->>S: Arrange temporary housing within 24 hours
+            S->>C: Confirm accommodation details
+        end
+    end
+
+    rect rgb(255, 243, 224)
+        Note over CH, BI: Investigation and Inspection
+        CH->>FD: Request räddningstjänsten incident report
+        FD-->>CH: Incident report with cause determination
+        alt Suspected arson (brandorsaksutredning pending)
+            CH->>S: Flag claim as "Pending Cause Investigation"
+            Note over CH: Continue assessment, defer final settlement
+        end
+        CH->>BI: Schedule structural inspection (within 48 hours)
+        BI->>BI: Inspect structural integrity and safety
+        BI->>S: Submit inspection report + hazard findings
+    end
+
+    rect rgb(252, 228, 236)
+        Note over CH, RC: Environmental Hazard Check
+        opt Environmental hazards (asbestos, PCB, lead)
+            CH->>RC: Order specialized remediation
+            RC->>RC: Perform remediation
+            RC->>S: Submit remediation certification
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over CH, CO: Loss Determination and Repair/Rebuild
+        CH->>S: Determine total loss or partial loss
+        alt Total loss (totalskada)
+            CH->>S: Calculate total loss settlement (nybyggnadsvärde)
+            S->>S: Check for underinsurance
+            alt Customer rebuilds
+                CH->>CO: Coordinate rebuild
+                S->>C: Process staged payments during rebuild
+            else Cash settlement
+                S->>C: Process lump-sum settlement payment
+            end
+        else Partial loss (delskada)
+            CH->>S: Approve repair scope and contractors
+            CO->>CO: Perform repairs per approved scope
+        end
+    end
+
+    rect rgb(243, 229, 245)
+        Note over CH, C: Final Inspection and Closure
+        CH->>S: Final inspection or customer sign-off
+        alt Restoration unsatisfactory
+            CH->>CO: Request rework
+        end
+        opt Subrogation applicable
+            CH->>S: Pursue subrogation against responsible third party
+        end
+        S->>S: Close claim and record data for risk assessment
+        S->>C: Confirm claim closure
+    end
+```
+
 ## Main Flow (Fire/Natural Event Claim Lifecycle)
 
 | Step | Actor          | Action                                                                              | System Response                                                                   | Reference                                                             |

--- a/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
@@ -72,6 +72,72 @@ flowchart TD
     style L fill:#fff3e0
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant CH as Claims Handler (Skadereglerare)
+    participant L as Lawyer (Advokat)
+    participant CT as Court/Arbitration Body
+    participant PP as Payment Provider
+
+    rect rgb(230, 245, 255)
+        Note over C, CH: Application and Eligibility
+        C->>S: Apply for rättsskydd (web/app/phone)
+        S->>C: Confirm application received
+        CH->>S: Register application with dispute details
+        CH->>S: Verify eligibility (dispute type, timing, waiting period)
+        alt Eligible
+            S->>C: Confirm rättsskydd approved
+        else Not eligible
+            S->>C: Deny with explanation + right to appeal (FSA-009)
+        end
+    end
+
+    rect rgb(255, 243, 224)
+        Note over C, CH: Lawyer Approval
+        C->>S: Submit chosen lawyer, firm, and fee estimate
+        S->>CH: Present fee reasonableness guidelines
+        alt Fees within range
+            CH->>S: Approve lawyer and set budget
+            S->>C: Confirm lawyer approval and approved budget
+        else Fees too high
+            CH->>C: Discuss alternatives, request revised estimate
+            C->>S: Submit revised fee estimate
+            CH->>S: Approve revised budget
+        end
+    end
+
+    rect rgb(232, 245, 233)
+        Note over L, CT: Active Legal Proceedings
+        L->>CT: Conduct proceedings on behalf of customer
+        loop Invoice cycle
+            L->>S: Submit invoice for legal work
+            CH->>S: Review and approve invoice against budget
+            S->>PP: Process payment (75-80% of invoice)
+            PP->>L: Pay approved amount
+            S->>C: Invoice customer self-retention share
+        end
+        opt Costs near coverage cap
+            S->>C: Warn — approaching 300,000 SEK cap
+            S->>CH: Alert handler of cap approach
+            C->>S: Decide to continue at own cost or settle
+        end
+    end
+
+    rect rgb(243, 229, 245)
+        Note over L, S: Resolution and Closure
+        L->>S: Report dispute outcome (judgment/settlement/withdrawal)
+        CH->>S: Calculate final settlement and remaining payments
+        S->>PP: Process final lawyer payment
+        PP->>L: Final payment
+        S->>C: Final cost summary (total costs, coverage share, self-retention)
+        CH->>S: Close claim and archive documentation
+    end
+```
+
 ## Main Flow (Rättsskydd Application and Management)
 
 | Step | Actor          | Action                                                                  | System Response                                                                | Reference                                                                                          |

--- a/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
@@ -80,6 +80,75 @@ flowchart TD
     style M fill:#fce4ec
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant CH as Claims Handler (Skadereglerare)
+    participant BI as Besiktningsman
+    participant IP as Injured Party (Skadelidande)
+    participant OI as Opposing Insurer
+    participant LC as Legal Counsel
+
+    rect rgb(230, 245, 255)
+        Note over C, CH: Report and Registration
+        C->>S: Report accidental damage to third party
+        S->>C: Confirm liability claim with claim number
+        CH->>S: Register FNOL, verify ansvarsskydd coverage
+        S->>C: Confirm coverage status
+    end
+
+    rect rgb(255, 243, 224)
+        Note over CH, BI: Evidence and Liability Assessment
+        CH->>CH: Gather evidence (photos, witness statements, damage reports)
+        opt Expert investigation needed
+            CH->>BI: Commission property inspection
+            BI->>S: Submit expert report
+        end
+        CH->>S: Assess liability (negligence, causation, legal basis)
+    end
+
+    alt Policyholder liable
+        rect rgb(232, 245, 233)
+            Note over CH, IP: Settlement Negotiation
+            CH->>IP: Present liability acceptance and settlement offer
+            alt Settlement agreed
+                IP-->>CH: Accept settlement amount
+                S->>IP: Process settlement payment
+                S->>C: Deduct deductible from policyholder
+            else Settlement disputed
+                CH->>IP: Escalate to mediation or legal proceedings
+                S->>IP: Process final settlement payment
+            end
+        end
+    else Policyholder not liable
+        rect rgb(243, 229, 245)
+            Note over CH, LC: Defense
+            CH->>IP: Send written denial with rationale
+            CH->>C: Inform policyholder of defense
+            alt Injured party disputes denial
+                IP->>CH: Dispute the denial
+                CH->>LC: Engage legal counsel for defense
+                LC->>LC: Defend in mediation/arbitration/court
+                LC-->>S: Report outcome (judgment/settlement/withdrawal)
+            else Injured party accepts
+                Note over IP: Claim closed
+            end
+        end
+    end
+
+    rect rgb(255, 253, 231)
+        Note over CH, OI: Cross-Insurer Coordination and Closure
+        opt Cross-insurer coordination needed
+            CH->>OI: Coordinate subrogation or split settlement
+            OI-->>CH: Confirm inter-insurer settlement
+        end
+        CH->>S: Close claim and archive documentation
+    end
+```
+
 ## Main Flow (Liability Claim Assessment and Settlement)
 
 | Step | Actor          | Action                                                                         | System Response                                                              | Reference                                                                                                          |

--- a/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
@@ -73,6 +73,77 @@ flowchart TD
     style L fill:#fff3e0
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant CH as Claims Handler (Skadereglerare)
+    participant SF as Saneringsfirma
+    participant BI as Besiktningsman
+    participant BRF as BRF Board (BRF-styrelse)
+    participant CO as Contractor
+
+    rect rgb(230, 245, 255)
+        Note over C, CH: FNOL and Emergency Response
+        C->>S: Report water damage (web/app/phone 24/7)
+        S->>C: Confirm FNOL with claim number
+        CH->>S: Register FNOL with damage type and cause
+        S->>SF: Dispatch nearest saneringsfirma
+        S->>C: Notify expected arrival time
+    end
+
+    rect rgb(255, 243, 224)
+        Note over SF, SF: Emergency and Drying
+        SF->>SF: Leak detection and water source stop
+        SF->>S: Update status to "Emergency Response"
+        opt Property uninhabitable
+            CH->>S: Arrange temporary housing
+            S->>C: Confirm accommodation details
+        end
+        SF->>S: Install drying equipment, start torkprotokoll
+    end
+
+    rect rgb(232, 245, 233)
+        Note over CH, BRF: Assessment and Responsibility
+        CH->>S: Assess damage scope from moisture report
+        opt Complex damage
+            CH->>BI: Request property inspection
+            BI->>S: Submit inspection report
+        end
+        opt BRF property (bostadsrätt)
+            CH->>S: Determine BRF vs individual responsibility
+            CH->>BRF: Coordinate cross-claim if split responsibility
+            BRF-->>CH: Confirm responsibility boundary
+        end
+    end
+
+    rect rgb(243, 229, 245)
+        Note over SF, CO: Drying and Repair
+        loop Until drying complete
+            SF->>S: Submit torkprotokoll with moisture measurements
+            S->>CH: Update drying progress
+            S->>C: Notify drying status
+        end
+        CH->>S: Approve repair scope and select contractor
+        S->>C: Notify approved scope and budget
+        CO->>CO: Perform repairs per approved scope
+        CH->>S: Final inspection or customer sign-off
+        alt Restoration unsatisfactory
+            CH->>CO: Request rework
+        end
+    end
+
+    rect rgb(255, 253, 231)
+        Note over CH, C: Settlement and Closure
+        CH->>S: Calculate settlement (replacement cost − age deduction − deductible)
+        S->>C: Present settlement breakdown for review
+        S->>C: Process payment (customer/contractor/saneringsfirma)
+        S->>S: Close claim and record data for risk assessment
+    end
+```
+
 ## Main Flow (Water Damage Claim Lifecycle)
 
 | Step | Actor          | Action                                                                       | System Response                                                       | Reference                                                        |

--- a/docs/phase-2-home-property/use-cases/underwriting-rules.md
+++ b/docs/phase-2-home-property/use-cases/underwriting-rules.md
@@ -69,6 +69,69 @@ flowchart TD
     style J fill:#ffebee
 ```
 
+## Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (Privatkund)
+    participant S as System
+    participant LM as Lantmäteriet
+    participant SMHI as SMHI
+    participant MSB as MSB
+    participant BRA as BRÅ
+    participant UW as Underwriter (Försäkringsgivare)
+
+    rect rgb(230, 245, 255)
+        Note over S, LM: Property Data Collection
+        S->>LM: Query property registry (address, type, material, year)
+        LM-->>S: Property data + geocoordinates
+    end
+
+    rect rgb(255, 243, 224)
+        Note over S, BRA: Geographic Risk Zone Determination
+        S->>SMHI: Query flood risk zone
+        SMHI-->>S: Flood risk classification
+        S->>MSB: Query subsidence risk + flood data
+        MSB-->>S: Geological risk data
+        S->>BRA: Query area crime rate
+        BRA-->>S: Crime rate classification
+        S->>S: Assign composite geographic risk score
+    end
+
+    rect rgb(232, 245, 233)
+        Note over S, S: Construction and Security Assessment
+        S->>S: Evaluate fire risk (trä/sten/betong)
+        S->>S: Evaluate building age risk (age bands)
+        S->>S: Apply security feature discounts (alarm, water shutoff, sprinkler)
+        S->>S: Check claims history (past 5 years)
+    end
+
+    rect rgb(243, 229, 245)
+        Note over S, UW: Risk Acceptance Evaluation
+        S->>S: Evaluate combined risk against acceptance criteria
+        alt Auto-accept
+            S->>S: Proceed to coverage selection
+        else Borderline risk
+            S->>UW: Route to underwriter review queue
+            UW->>UW: Review risk factors and claims history
+            UW-->>S: Accept / accept with conditions / decline
+        else Decline
+            S->>S: Record declination with documented reason
+            S->>C: Notify with decline reason
+        end
+    end
+
+    rect rgb(255, 253, 231)
+        Note over C, S: Premium Calculation
+        S->>C: Present coverage tiers (bas/standard/premium)
+        C->>S: Select coverage tier
+        S->>C: Present deductible options (låg/standard/hög/mycket hög)
+        C->>S: Select deductible level
+        S->>S: Calculate final premium (all rating factors)
+        S->>C: Present quote with premium breakdown
+    end
+```
+
 ## Main Success Scenario
 
 ### 1. Property Data Collection


### PR DESCRIPTION
## Summary
- Add Mermaid `sequenceDiagram` blocks to all 10 Phase 2 Home & Property use cases
- Each diagram shows actor-to-actor message flow with Swedish terms for domain-specific actors (Saneringsfirma, Besiktningsman, Räddningstjänsten, Låssmed, etc.)
- Diagrams use `rect rgb(...)` blocks to highlight lifecycle phases and `alt`/`opt` blocks for alternative/error paths

## Changes
- `quote-and-bind.md` — Quote flow: Customer ↔ System ↔ Lantmäteriet ↔ BankID
- `underwriting-rules.md` — Risk assessment: System ↔ SMHI/MSB/BRÅ ↔ Lantmäteriet ↔ Underwriter
- `home-renewals.md` — Renewal: System → SCB → Customer → Payment Provider
- `cancellations.md` — All cancellation types: ångerrätt, customer-initiated, non-payment, misrepresentation
- `policy-administration.md` — 3 sequence diagrams for MTA, BRF building admin, family member management
- `uc-water-damage-lifecycle.md` — Water claim: Customer → Claims Handler → Saneringsfirma → Besiktningsman → BRF
- `uc-fire-natural-event-lifecycle.md` — Fire/natural event: Customer → Räddningstjänsten → Besiktningsman → Contractor
- `burglary-and-theft.md` — Burglary: Customer → Polisen → Claims Handler → Låssmed
- `uc-liability-claim-lifecycle.md` — Liability: Customer → Claims Handler → Besiktningsman → Injured Party
- `uc-legal-expenses-lifecycle.md` — Legal expenses: Customer → Claims Handler → Lawyer → Court

## Testing
- [x] `npx markdownlint docs/` passes with zero warnings
- [x] `npx prettier --check .` passes
- [x] `npm run build` completes successfully

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)