### PR TITLE
docs(#121): Add state diagrams to Phase 2 Home & Property use cases

### DIFF
--- a/docs/phase-2-home-property/use-cases/burglary-and-theft.md
+++ b/docs/phase-2-home-property/use-cases/burglary-and-theft.md
@@ -151,6 +151,47 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Reported : Customer reports burglary (Inbrott anmält)
+    Reported --> EmergencySecured : Emergency locksmith dispatched (Akutlås)
+    EmergencySecured --> PoliceReportPending : Customer guided to file polisanmälan
+    PoliceReportPending --> Registered : FNOL registered with K-nummer
+    Registered --> FraudScreened : Automated fraud screening completed
+    FraudScreened --> FraudInvestigation : High-risk — escalated to fraud team
+    FraudScreened --> InventorySubmitted : Low/medium risk — inventory requested
+    FraudInvestigation --> InventorySubmitted : Cleared — resume assessment
+    InventorySubmitted --> ItemsVerified : Items verified against declarations (Verifierad)
+    ItemsVerified --> SettlementCalculated : Settlement calculated with åldersavdrag
+    SettlementCalculated --> Settled : Payment processed (Reglerad)
+    Settled --> RepairArranged : Break-in damage repair completed
+    RepairArranged --> CrisisSupport : Krisstöd offered to customer
+    CrisisSupport --> Closed : Claim closed (Stängd)
+    Closed --> [*]
+
+    note right of Reported
+        24/7 emergency reporting.
+        Do not disturb break-in scene.
+    end note
+
+    note right of PoliceReportPending
+        Polisanmälan required before
+        assessment. 7-day grace period.
+    end note
+
+    note right of SettlementCalculated
+        Åldersavdrag per item category.
+        Sub-limits per category apply.
+    end note
+
+    note right of CrisisSupport
+        Licensed counselor within 24 hours.
+        5-10 sessions for household members.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Burglary Report and Emergency Response

--- a/docs/phase-2-home-property/use-cases/cancellations.md
+++ b/docs/phase-2-home-property/use-cases/cancellations.md
@@ -172,6 +172,56 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Requested : Cancellation request received (Uppsägning begärd)
+    Requested --> CoolingOffCheck : Ångerrätt eligibility verified
+    CoolingOffCheck --> FullRefund : Within 14-day ångerrätt period
+    CoolingOffCheck --> Validated : Outside ångerrätt — reason and date determined
+    Validated --> RefundCalculated : Pro-rata refund calculated (Återbetalning beräknad)
+    RefundCalculated --> GapChecked : Coverage gap check for insurer switch
+    GapChecked --> Confirmed : Customer confirms cancellation
+    GapChecked --> Retained : Customer changes mind — policy retained (Behållen)
+    Confirmed --> Processed : Cancellation effective, refund initiated (Genomförd)
+    FullRefund --> Processed : Full refund processed
+    Processed --> [*]
+    Retained --> [*]
+
+    state InsurerInitiated {
+        [*] --> NonPayment : Premium overdue (Obetald premie)
+        [*] --> Misrepresentation : Material misrepresentation discovered
+        NonPayment --> Reminder : First reminder sent (14-day grace)
+        Reminder --> FinalWarning : Second notice sent (14-day final grace)
+        FinalWarning --> AutoCancelled : No payment — policy cancelled
+        FinalWarning --> Reinstated : Payment received — policy reinstated
+        Misrepresentation --> FraudReview : Intent assessment
+        FraudReview --> ImmediateCancel : Intentional — no refund
+        FraudReview --> AdjustOrCancel : Unintentional — offer adjustment
+    }
+
+    note right of Requested
+        Channels: self-service portal, app,
+        phone, EU cancellation button.
+    end note
+
+    note right of CoolingOffCheck
+        14-day ångerrätt applies only to
+        distance/off-premises sales.
+    end note
+
+    note right of GapChecked
+        Mandatory warning if switching insurer
+        and coverage gap detected.
+    end note
+
+    note right of Processed
+        Refund paid within 14 business days.
+        Confirmation sent to customer.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Cancellation Request

--- a/docs/phase-2-home-property/use-cases/home-renewals.md
+++ b/docs/phase-2-home-property/use-cases/home-renewals.md
@@ -138,6 +138,46 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Upcoming : Policy within 60 days of huvudförfallodag
+    Upcoming --> IndexAdjusted : Sums recalculated via byggkostnadsindex/KPI
+    IndexAdjusted --> Recalculated : Premium recalculated with updated factors
+    Recalculated --> UnderwriterReview : Flagged — premium increase >15% or claims
+    Recalculated --> Notified : Standard renewal — förnyelseavisering sent (T-30)
+    UnderwriterReview --> Notified : Underwriter approves renewal
+    UnderwriterReview --> NonRenewal : Underwriter declines renewal (Ej förnyad)
+    Notified --> Modified : Customer requests coverage changes
+    Notified --> Cancelled : Customer cancels before huvudförfallodag (Uppsagd)
+    Notified --> Renewed : No response or explicit acceptance — auto-renewed (T-0)
+    Modified --> Renewed : Updated terms applied at renewal
+    Renewed --> [*]
+    Cancelled --> [*]
+    NonRenewal --> [*]
+
+    note right of Upcoming
+        Batch process identifies eligible policies.
+        Index data retrieved from SCB.
+    end note
+
+    note right of Notified
+        Customer has 30 days to respond.
+        Modification, cancellation, or acceptance.
+    end note
+
+    note right of Renewed
+        New policy period starts at 00:00
+        on huvudförfallodag. No coverage gap.
+    end note
+
+    note right of NonRenewal
+        Non-renewal notice sent at T-30.
+        Customer advised to seek replacement.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Policy Identification (T-60 Days)

--- a/docs/phase-2-home-property/use-cases/policy-administration.md
+++ b/docs/phase-2-home-property/use-cases/policy-administration.md
@@ -35,6 +35,45 @@ record entity provides a complete audit trail of every policy change.
 | `created_at`            | Timestamp | When the amendment was created                                                                                                            |
 | `completed_at`          | Timestamp | When the amendment was finalized                                                                                                          |
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft : Policy created during quote-and-bind (Utkast)
+    Draft --> Active : Policy bound and issued (Aktiv)
+    Active --> Amended : Mid-term modification processed (Ändrad)
+    Amended --> Active : Amendment completed — returns to active
+    Active --> Suspended : Non-payment after grace period (Vilande)
+    Suspended --> Active : Payment received within reinstatement period
+    Suspended --> Lapsed : Reinstatement period expires (Förfallen)
+    Active --> PendingRenewal : Approaching huvudförfallodag
+    PendingRenewal --> Active : Renewed for new period
+    PendingRenewal --> Cancelled : Customer cancels at renewal (Uppsagd)
+    Active --> Cancelled : Mid-term cancellation processed
+    Lapsed --> [*]
+    Cancelled --> [*]
+
+    note right of Active
+        Full policy functions available.
+        Mid-term amendments permitted.
+    end note
+
+    note right of Amended
+        Premium recalculated pro-rata.
+        Updated documents issued.
+    end note
+
+    note right of Suspended
+        Coverage inactive. Reinstatement
+        window open (default 90 days).
+    end note
+
+    note right of Cancelled
+        Refund processed if applicable.
+        No new claims accepted.
+    end note
+```
+
 ---
 
 ## UC-HPA-001: Mid-Term Policy Modification

--- a/docs/phase-2-home-property/use-cases/quote-and-bind.md
+++ b/docs/phase-2-home-property/use-cases/quote-and-bind.md
@@ -127,6 +127,45 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft : Customer initiates quote (Offertförfrågan)
+    Draft --> RiskAssessed : Property data verified and risk scored
+    RiskAssessed --> Presented : Premium calculated and tiers displayed
+    RiskAssessed --> Referred : High-risk property flagged
+    Referred --> Presented : Underwriter approves
+    Referred --> Declined : Underwriter declines
+    Presented --> Accepted : Customer selects coverage and acknowledges IPID
+    Presented --> Expired : 30-day validity timeout (Offertens giltighetstid)
+    Accepted --> Bound : BankID signed and verified (Bunden)
+    Accepted --> Expired : Signing not completed
+    Bound --> [*]
+    Expired --> [*]
+    Declined --> [*]
+
+    note right of Draft
+        Address entered, product type selected.
+        Lantmäteriet property lookup in progress.
+    end note
+
+    note right of RiskAssessed
+        Geographic, construction, and
+        security risk factors evaluated.
+    end note
+
+    note right of Presented
+        Side-by-side tier comparison shown.
+        Demands-and-needs assessment completed.
+    end note
+
+    note right of Bound
+        Policy issued, payment setup initiated.
+        14-day ångerrätt period begins.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Address Entry and Product Selection

--- a/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md
@@ -152,6 +152,70 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> EmergencyReported : Customer reports fire/natural event (Brand/naturhändelse anmäld)
+
+    state "Emergency Response (Räddningsinsats)" as ER {
+        [*] --> EvacuationCheck : Property habitability assessed
+        EvacuationCheck --> HousingArranged : Temporary housing arranged (Tillfälligt boende)
+        EvacuationCheck --> IncidentReport : Property habitable — no housing needed
+        HousingArranged --> IncidentReport : Housing confirmed
+    }
+
+    EmergencyReported --> ER : High-priority claim registered
+    ER --> Investigation : Räddningstjänsten incident report obtained
+
+    state "Investigation (Utredning)" as Investigation {
+        [*] --> StructuralInspection : Besiktningsman inspects property
+        StructuralInspection --> HazardCheck : Structural assessment complete
+        HazardCheck --> Remediation : Environmental hazards found (Sanering)
+        HazardCheck --> LossDetermination : No hazards — proceed to assessment
+        Remediation --> LossDetermination : Remediation certified complete
+    }
+
+    Investigation --> TotalLoss : Total loss determined (Totalskada)
+    Investigation --> PartialLoss : Partial loss determined (Delskada)
+
+    TotalLoss --> RebuildDecision : Settlement calculated with underinsurance check
+    RebuildDecision --> Rebuild : Customer chooses to rebuild (Återuppbyggnad)
+    RebuildDecision --> CashSettlement : Customer takes cash settlement (Kontantreglering)
+    Rebuild --> StagedPayments : Staged payments during reconstruction
+    StagedPayments --> FinalInspection : Rebuild complete
+
+    PartialLoss --> RepairApproved : Repair scope approved
+    RepairApproved --> UnderRepair : Contractor performing repairs
+    UnderRepair --> FinalInspection : Repairs completed
+
+    FinalInspection --> UnderRepair : Restoration unsatisfactory
+    FinalInspection --> Closed : Restoration verified — claim closed (Stängd)
+    CashSettlement --> Closed : Payment processed
+    Closed --> [*]
+
+    note right of ER
+        Temporary housing within 24 hours.
+        Fire cause investigation may run
+        in parallel with assessment.
+    end note
+
+    note right of Investigation
+        Environmental hazards (asbest, PCB)
+        must be remediated before repair.
+    end note
+
+    note right of TotalLoss
+        Settlement based on nybyggnadsvärde.
+        Underinsurance check per FSA-016.
+    end note
+
+    note right of Closed
+        Claims data recorded for catastrophe
+        reserve reporting per FSA-018.
+    end note
+```
+
 ## Main Flow (Fire/Natural Event Claim Lifecycle)
 
 | Step | Actor          | Action                                                                              | System Response                                                                   | Reference                                                             |

--- a/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md
@@ -138,6 +138,56 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Requested : Customer applies for rättsskydd (Ansökan mottagen)
+    Requested --> EligibilityCheck : Application registered with dispute details
+
+    EligibilityCheck --> Approved : Eligible dispute — rättsskydd granted (Godkänd)
+    EligibilityCheck --> WaitingPeriod : Waiting period check required (Karenstid)
+    EligibilityCheck --> Denied : Ineligible dispute type or excluded category (Avslagen)
+    WaitingPeriod --> Approved : Waiting period passed
+    WaitingPeriod --> Denied : Waiting period not met
+
+    Approved --> LawyerReview : Customer submits lawyer and fee estimate
+    LawyerReview --> FeeNegotiation : Fee estimate exceeds reasonable range
+    FeeNegotiation --> LawyerReview : Revised estimate submitted
+    LawyerReview --> Active : Lawyer and fees approved (Aktiv)
+
+    Active --> CostTracking : Legal proceedings in progress
+    CostTracking --> CapWarning : Costs approaching 80% of coverage cap
+    CapWarning --> CostTracking : Customer acknowledges and continues
+    CostTracking --> Resolved : Dispute resolved — judgment, settlement, or withdrawal
+
+    Resolved --> Closed : Final settlement processed, claim archived (Stängd)
+    Denied --> [*]
+    Closed --> [*]
+
+    note right of EligibilityCheck
+        Qualifying disputes only.
+        Excluded: family law, criminal,
+        business disputes.
+    end note
+
+    note right of Approved
+        Coverage: 75-80% of approved costs.
+        Base deductible: 1,500 SEK.
+        Cap: ~300,000 SEK per dispute.
+    end note
+
+    note right of Active
+        Customer chooses own lawyer.
+        Insurer assesses fee reasonableness.
+    end note
+
+    note right of CapWarning
+        Customer informed remaining costs
+        above cap are uninsured.
+    end note
+```
+
 ## Main Flow (Rättsskydd Application and Management)
 
 | Step | Actor          | Action                                                                  | System Response                                                                | Reference                                                                                          |

--- a/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md
@@ -149,6 +149,55 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Reported : Liability incident reported (Ansvarsskada anmäld)
+    Reported --> Registered : FNOL registered, ansvarsskydd verified
+    Registered --> UnderInvestigation : Evidence gathered (Utredning pågår)
+    UnderInvestigation --> ExpertReview : Uncertain — expert investigation commissioned
+    ExpertReview --> UnderInvestigation : Expert report received
+    UnderInvestigation --> LiabilityDetermined : Liability assessed
+
+    LiabilityDetermined --> Negotiation : Policyholder liable — negotiating with injured party (Förhandling)
+    LiabilityDetermined --> Defense : Policyholder not liable — defending claim (Bestridande)
+
+    Negotiation --> Settled : Settlement agreed and paid (Reglerad)
+    Negotiation --> LegalProceedings : No agreement — escalated to mediation/court
+    LegalProceedings --> Settled : Court judgment or mediated settlement
+
+    Defense --> Closed : Injured party accepts denial
+    Defense --> LegalDefense : Injured party disputes — legal counsel engaged (Rättsligt försvar)
+    LegalDefense --> Closed : Defense resolved
+
+    Settled --> CrossInsurer : Cross-insurer coordination needed
+    Settled --> Closed : No coordination needed — claim closed (Stängd)
+    CrossInsurer --> Closed : Inter-insurer settlement completed
+    Closed --> [*]
+
+    note right of UnderInvestigation
+        Besiktningsman may be commissioned
+        for site inspection and expert report.
+    end note
+
+    note right of LiabilityDetermined
+        Insurer has dual obligation:
+        compensate justified claims AND
+        defend against unfounded claims.
+    end note
+
+    note right of Negotiation
+        Settlement limit: up to 5,000,000 SEK.
+        Amounts >500,000 SEK need senior approval.
+    end note
+
+    note right of Defense
+        Defense costs covered in addition
+        to settlement limit.
+    end note
+```
+
 ## Main Flow (Liability Claim Assessment and Settlement)
 
 | Step | Actor          | Action                                                                         | System Response                                                              | Reference                                                                                                          |

--- a/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
+++ b/docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md
@@ -144,6 +144,55 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> EmergencyReported : Customer reports water damage (Vattenskada anmäld)
+
+    state "Emergency Response (Akutåtgärder)" as ER {
+        [*] --> LeakDetection : Saneringsfirma dispatched
+        LeakDetection --> WaterStopped : Leak source identified and stopped
+        WaterStopped --> StandingWaterRemoved : Standing water extracted
+    }
+
+    EmergencyReported --> ER : Saneringsfirma dispatched within 2 hours
+    ER --> Drying : Drying equipment installed (Torkning pågår)
+
+    state "Drying Phase (Torkfas)" as Drying {
+        [*] --> ActiveDrying : Equipment running
+        ActiveDrying --> MoistureCheck : Torkprotokoll submitted
+        MoistureCheck --> ActiveDrying : Moisture above acceptable limits
+        MoistureCheck --> DryingComplete : Moisture within limits
+    }
+
+    Drying --> Inspection : Drying verified complete
+    Inspection --> RepairApproved : Repair scope and contractor approved
+    RepairApproved --> UnderRepair : Contractor performing repairs (Reparation pågår)
+    UnderRepair --> FinalInspection : Repairs completed
+    FinalInspection --> UnderRepair : Restoration unsatisfactory
+    FinalInspection --> Settlement : Restoration verified — settlement calculated (Reglering)
+    Settlement --> Closed : Payment processed, claim archived (Stängd)
+    Closed --> [*]
+
+    note right of ER
+        24/7 emergency dispatch.
+        Temporary housing arranged
+        if property uninhabitable.
+    end note
+
+    note right of Drying
+        Periodic torkprotokoll with
+        moisture readings required.
+        Drying must complete before repair.
+    end note
+
+    note right of Settlement
+        Åldersavdrag applied per material.
+        BRF/individual split if applicable.
+    end note
+```
+
 ## Main Flow (Water Damage Claim Lifecycle)
 
 | Step | Actor          | Action                                                                       | System Response                                                       | Reference                                                        |

--- a/docs/phase-2-home-property/use-cases/underwriting-rules.md
+++ b/docs/phase-2-home-property/use-cases/underwriting-rules.md
@@ -132,6 +132,49 @@ sequenceDiagram
     end
 ```
 
+## State Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : Quote request received (Offertförfrågan mottagen)
+    Pending --> DataCollected : Property and external data retrieved
+    DataCollected --> Scored : Risk score calculated (Riskpoäng beräknad)
+    Scored --> Approved : Within auto-accept criteria (Automatiskt godkänd)
+    Scored --> Referred : Borderline risk — underwriter review (Hänvisad)
+    Scored --> Declined : Outside risk appetite (Avböjd)
+    Referred --> Approved : Underwriter accepts
+    Referred --> ApprovedWithConditions : Underwriter accepts with conditions (Godkänd med villkor)
+    Referred --> Declined : Underwriter declines
+    ApprovedWithConditions --> Approved : Customer accepts conditions
+    Approved --> [*]
+    Declined --> [*]
+
+    note right of Pending
+        Customer has provided address
+        and selected product type.
+    end note
+
+    note right of DataCollected
+        Lantmäteriet, SMHI, MSB, BRÅ
+        data retrieved and validated.
+    end note
+
+    note right of Scored
+        Composite risk score assigned.
+        Rating factor breakdown recorded.
+    end note
+
+    note right of Referred
+        Underwriter review SLA: 2 business days.
+        Escalation on SLA breach.
+    end note
+
+    note right of Declined
+        Declination reason documented.
+        Retained for FSA-014 audit.
+    end note
+```
+
 ## Main Success Scenario
 
 ### 1. Property Data Collection


### PR DESCRIPTION
## Summary
- Add Mermaid `stateDiagram-v2` blocks to all 10 Phase 2 Home & Property use cases
- Each diagram models the lifecycle states of the primary entity with Swedish terms, labeled transitions, and business rule notes
- Water damage and fire claims use composite states for multi-phase lifecycles (drying, emergency response, investigation)

## Changes
- `docs/phase-2-home-property/use-cases/quote-and-bind.md` — Quote: Draft → Risk Assessed → Presented → Accepted → Bound
- `docs/phase-2-home-property/use-cases/underwriting-rules.md` — Risk assessment: Pending → Data Collected → Scored → Approved/Referred/Declined
- `docs/phase-2-home-property/use-cases/home-renewals.md` — Renewal: Upcoming → Index Adjusted → Notified → Renewed/Cancelled/Non-Renewal
- `docs/phase-2-home-property/use-cases/cancellations.md` — Cancellation: Requested → Cooling-off Check → Processed (with composite insurer-initiated states)
- `docs/phase-2-home-property/use-cases/policy-administration.md` — Policy: Draft → Active → Amended → Suspended → Cancelled/Lapsed
- `docs/phase-2-home-property/use-cases/uc-water-damage-lifecycle.md` — Water claim: Emergency → Drying (composite) → Repair → Settlement → Closed
- `docs/phase-2-home-property/use-cases/uc-fire-natural-event-lifecycle.md` — Fire claim: Emergency (composite) → Investigation (composite) → Repair/Rebuild → Closed
- `docs/phase-2-home-property/use-cases/burglary-and-theft.md` — Burglary claim: Reported → Registered → Verified → Settled → Closed
- `docs/phase-2-home-property/use-cases/uc-liability-claim-lifecycle.md` — Liability claim: Reported → Investigation → Liability Determined → Negotiation/Defense → Closed
- `docs/phase-2-home-property/use-cases/uc-legal-expenses-lifecycle.md` — Legal expenses: Requested → Eligibility Check → Approved → Active → Closed

## Testing
- [x] `npx markdownlint docs/phase-2-home-property/use-cases/` — zero warnings
- [x] `npx prettier --check docs/phase-2-home-property/use-cases/` — all files pass
- [x] `npm run build` — successful build, all links valid

Closes #121

🤖 Generated with Claude Code