### PR TITLE
docs(#216): Add persona Niklas Bergman — Skadeanmälare (claims reporter)

### DIFF
--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -23,6 +23,7 @@ support across all product lines.
 | [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
 | [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
+| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 
 ## Phase 2 — Home & Property
 

--- a/docs/personas/niklas-bergman.md
+++ b/docs/personas/niklas-bergman.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 8
+---
+
+# Niklas Bergman, 35 — Claims Reporter (Skadeanmälare)
+
+> _"I've never filed a claim before. I just want to know what happens next and
+> when I can get my car back — I need it for work."_
+
+## Avatar Description
+
+A man in his mid-thirties wearing a work jacket with an electrician's tool belt,
+standing next to a damaged dark grey Skoda Octavia at a roundabout. He is holding
+his phone in one hand and rubbing his neck with the other, looking stressed and
+uncertain.
+
+## Demographics
+
+| Field      | Details                                       |
+| ---------- | --------------------------------------------- |
+| Age        | 35                                            |
+| Location   | Uppsala, Sweden                               |
+| Occupation | Electrician, self-employed (enskild firma)    |
+| Income     | Mid-range, variable (self-employed invoicing) |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| Current coverage | Halvförsäkring on a 2020 Skoda Octavia Combi (work and family use)                                      |
+| Vehicle          | 2020 Skoda Octavia Combi                                                                                |
+| Bonus class      | 4 (eight years claim-free)                                                                              |
+| Claim situation  | Rear-ended at a roundabout; not at fault. Minor whiplash, significant vehicle damage. First claim ever. |
+
+## Goals
+
+- Get his vehicle repaired or replaced as quickly as possible so he can continue
+  working — every day without a car means lost income
+- Understand the full claims process from start to finish, including timelines
+  and what he needs to provide
+- Confirm that his bonus class will not drop since the accident was not his fault
+- Secure a rental car or replacement vehicle while his Skoda is being repaired
+- Ensure his whiplash injury is properly documented and any medical costs are
+  covered through the at-fault driver's trafikförsäkring
+
+## Frustrations / Pain Points
+
+- **First-time anxiety** — Niklas has never filed a claim and does not know what
+  to expect; he worries about making mistakes that could delay or reduce his
+  settlement
+- **Work dependency on the car** — as a self-employed electrician, he drives to
+  customer sites daily; being without a car directly impacts his livelihood
+- **Liability confusion** — he was clearly not at fault but does not understand
+  how liability determination and subrogation between insurers work
+- **Medical documentation complexity** — the whiplash injury requires medical
+  records, and he is unsure what documentation the insurer needs and how
+  sensitive health data will be handled
+- **Bonus class worry** — despite not causing the accident, he fears his bonus
+  class will be affected, increasing future premiums
+
+## Tech Comfort Level
+
+**Medium-high.** Niklas uses his smartphone daily for work scheduling, invoicing
+(via an accounting app), and communication. He prefers handling administrative
+tasks on his phone when possible but is comfortable using a laptop for more
+complex forms. He expects to be able to file his claim digitally, upload photos
+of the damage, and track the progress online. He would find it frustrating to
+have to call or visit an office during working hours.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Niklas's claim must be settled fairly and within a reasonable timeframe in accordance with FSA consumer protection requirements (FSA-010).                                |
+| **FSA**    | If Niklas disagrees with the claims decision, he must be informed of the complaints procedure and his right to escalate (FSA-011).                                        |
+| **GDPR**   | Niklas's whiplash medical records constitute special-category personal data; processing requires explicit purpose limitation and data minimization (GDPR-001).            |
+| **GDPR**   | Medical data collected for the claim must not be used for other purposes such as underwriting future policies without separate lawful basis (GDPR-004).                   |
+| **IDD**    | The quality of claims handling — including timeliness, communication, and fairness — is part of TryggFörsäkring's product oversight and governance obligations (IDD-004). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Niklas is a private
+  customer filing his first claim.
+- [Claims Handler (Skadereglerare)](../actors/internal/claims-handler.md) —
+  the internal handler who will manage Niklas's claim from FNOL to settlement.
+- [Claims Adjuster (Värderare)](../actors/internal/claims-adjuster.md) —
+  assesses the vehicle damage and determines repair vs. total loss.
+- [Repair Shop (Verkstad)](../actors/external/repair-shop.md) — the authorized
+  workshop that will repair Niklas's Skoda Octavia.
+- [Medical Provider (Vårdgivare)](../actors/external/medical-provider.md) —
+  provides the whiplash medical documentation needed for the personal injury
+  component of the claim.
+- [Police (Polisen)](../actors/external/police.md) — Niklas may need a police
+  report reference for the traffic accident.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -23,6 +23,7 @@ TryggFörsäkring platform must support.
 | [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
 | [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
+| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 
 ## How Personas Are Used
 

--- a/versioned_docs/version-phase-1/personas/niklas-bergman.md
+++ b/versioned_docs/version-phase-1/personas/niklas-bergman.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 8
+---
+
+# Niklas Bergman, 35 — Claims Reporter (Skadeanmälare)
+
+> _"I've never filed a claim before. I just want to know what happens next and
+> when I can get my car back — I need it for work."_
+
+## Avatar Description
+
+A man in his mid-thirties wearing a work jacket with an electrician's tool belt,
+standing next to a damaged dark grey Skoda Octavia at a roundabout. He is holding
+his phone in one hand and rubbing his neck with the other, looking stressed and
+uncertain.
+
+## Demographics
+
+| Field      | Details                                       |
+| ---------- | --------------------------------------------- |
+| Age        | 35                                            |
+| Location   | Uppsala, Sweden                               |
+| Occupation | Electrician, self-employed (enskild firma)    |
+| Income     | Mid-range, variable (self-employed invoicing) |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| Current coverage | Halvförsäkring on a 2020 Skoda Octavia Combi (work and family use)                                      |
+| Vehicle          | 2020 Skoda Octavia Combi                                                                                |
+| Bonus class      | 4 (eight years claim-free)                                                                              |
+| Claim situation  | Rear-ended at a roundabout; not at fault. Minor whiplash, significant vehicle damage. First claim ever. |
+
+## Goals
+
+- Get his vehicle repaired or replaced as quickly as possible so he can continue
+  working — every day without a car means lost income
+- Understand the full claims process from start to finish, including timelines
+  and what he needs to provide
+- Confirm that his bonus class will not drop since the accident was not his fault
+- Secure a rental car or replacement vehicle while his Skoda is being repaired
+- Ensure his whiplash injury is properly documented and any medical costs are
+  covered through the at-fault driver's trafikförsäkring
+
+## Frustrations / Pain Points
+
+- **First-time anxiety** — Niklas has never filed a claim and does not know what
+  to expect; he worries about making mistakes that could delay or reduce his
+  settlement
+- **Work dependency on the car** — as a self-employed electrician, he drives to
+  customer sites daily; being without a car directly impacts his livelihood
+- **Liability confusion** — he was clearly not at fault but does not understand
+  how liability determination and subrogation between insurers work
+- **Medical documentation complexity** — the whiplash injury requires medical
+  records, and he is unsure what documentation the insurer needs and how
+  sensitive health data will be handled
+- **Bonus class worry** — despite not causing the accident, he fears his bonus
+  class will be affected, increasing future premiums
+
+## Tech Comfort Level
+
+**Medium-high.** Niklas uses his smartphone daily for work scheduling, invoicing
+(via an accounting app), and communication. He prefers handling administrative
+tasks on his phone when possible but is comfortable using a laptop for more
+complex forms. He expects to be able to file his claim digitally, upload photos
+of the damage, and track the progress online. He would find it frustrating to
+have to call or visit an office during working hours.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Niklas's claim must be settled fairly and within a reasonable timeframe in accordance with FSA consumer protection requirements (FSA-010).                                |
+| **FSA**    | If Niklas disagrees with the claims decision, he must be informed of the complaints procedure and his right to escalate (FSA-011).                                        |
+| **GDPR**   | Niklas's whiplash medical records constitute special-category personal data; processing requires explicit purpose limitation and data minimization (GDPR-001).            |
+| **GDPR**   | Medical data collected for the claim must not be used for other purposes such as underwriting future policies without separate lawful basis (GDPR-004).                   |
+| **IDD**    | The quality of claims handling — including timeliness, communication, and fairness — is part of TryggFörsäkring's product oversight and governance obligations (IDD-004). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Niklas is a private
+  customer filing his first claim.
+- [Claims Handler (Skadereglerare)](../actors/internal/claims-handler.md) —
+  the internal handler who will manage Niklas's claim from FNOL to settlement.
+- [Claims Adjuster (Värderare)](../actors/internal/claims-adjuster.md) —
+  assesses the vehicle damage and determines repair vs. total loss.
+- [Repair Shop (Verkstad)](../actors/external/repair-shop.md) — the authorized
+  workshop that will repair Niklas's Skoda Octavia.
+- [Medical Provider (Vårdgivare)](../actors/external/medical-provider.md) —
+  provides the whiplash medical documentation needed for the personal injury
+  component of the claim.
+- [Police (Polisen)](../actors/external/police.md) — Niklas may need a police
+  report reference for the traffic accident.


### PR DESCRIPTION
## Summary

- Adds new persona **Niklas Bergman, 35** — a self-employed electrician in Uppsala filing his first-ever insurance claim after being rear-ended at a roundabout
- Fills the key persona gap: no existing Phase 1 persona represents the **claims reporter journey** (first-time claimant perspective)
- Covers first-time anxiety, work dependency on vehicle, liability/subrogation confusion, medical documentation complexity, and bonus class concerns

## Changes

- `versioned_docs/version-phase-1/personas/niklas-bergman.md` — New persona file (sidebar_position: 8)
- `versioned_docs/version-phase-1/personas/index.md` — Added Niklas to persona summary table
- `docs/personas/niklas-bergman.md` — Mirror copy for current docs version
- `docs/personas/index.md` — Added Niklas to Phase 1 persona summary table

## Regulatory Touchpoints

- **FSA-010** — Fair and timely claims settlement
- **FSA-011** — Complaints procedure
- **GDPR-001** — Purpose limitation (medical data)
- **GDPR-004** — Medical data not reused for other purposes
- **IDD-004** — Claims handling as product oversight

## Testing

- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files formatted
- [x] `npm run build` — successful, no broken links

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)