### PR TITLE
docs(#217): Add persona Lina Eriksson, 28 — Elbilsägare (EV owner)

### DIFF
--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -24,6 +24,7 @@ support across all product lines.
 | [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
+| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
 
 ## Phase 2 — Home & Property
 

--- a/docs/personas/lina-eriksson.md
+++ b/docs/personas/lina-eriksson.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 9
+---
+
+# Lina Eriksson, 28 — Elbilsägare (EV Owner)
+
+> _"I love my Tesla, but I'm paying a fortune in insurance and I still don't
+> know if the battery is actually covered if something goes wrong. What am I
+> paying for?"_
+
+## Avatar Description
+
+A young woman in her late twenties wearing a winter jacket, standing next to a
+white Tesla Model 3 at a charging station in a snowy parking lot. She is
+checking the charging app on her phone while glancing at the wallbox display,
+breath visible in the cold northern Swedish air.
+
+## Demographics
+
+| Field      | Details                                  |
+| ---------- | ---------------------------------------- |
+| Age        | 28                                       |
+| Location   | Umeå, Sweden (Norrland)                  |
+| Occupation | Physiotherapist at the regional hospital |
+| Income     | Mid-range, stable public-sector salary   |
+
+## Insurance Situation
+
+| Field            | Details                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| Current coverage | Helförsäkring (required by financing agreement with Santander)                         |
+| Vehicle          | 2024 Tesla Model 3 Long Range (purchased new, financed)                                |
+| Bonus class      | 2 (four years driving, no claims)                                                      |
+| Coverage goal    | Understand what her helförsäkring actually covers for EV-specific components and risks |
+
+## Goals
+
+- Confirm that her policy covers battery damage and degradation — the battery
+  is the most expensive single component and she wants explicit clarity on what
+  scenarios are included
+- Understand whether her home wallbox (charging station) and charging cable are
+  covered under her motor policy or require separate home insurance
+- Get transparency on what drives her premium — she suspects the high vehicle
+  value is the main factor and wants to know if there are ways to reduce cost
+- Find out which repair shops in Norrland are authorized to work on EVs, since
+  high-voltage vehicle repairs require specialist certification
+- Ensure she has adequate roadside assistance that understands EV-specific
+  issues such as flatbed towing requirements (EVs should not be towed on driven
+  wheels)
+
+## Frustrations / Pain Points
+
+- **Battery coverage ambiguity** — her policy documents do not clearly state
+  whether battery degradation, thermal runaway, or charging-related damage are
+  covered; she has to call customer service to get vague answers
+- **Premium sticker shock** — as a 28-year-old with a high-value new vehicle,
+  her premium is significantly higher than colleagues with comparable ICE cars,
+  and she does not understand the breakdown
+- **Limited EV repair network** — very few workshops in northern Sweden have
+  the high-voltage certification required for EV repairs, which could mean long
+  wait times or transporting the car hundreds of kilometres
+- **Winter range anxiety and insurance implications** — she worries about
+  getting stranded in extreme cold when battery range drops, and whether
+  roadside assistance covers EV-specific recovery
+- **Telematics uncertainty** — her Tesla collects extensive driving data; she is
+  unsure whether TryggFörsäkring uses or could request this data and what that
+  means for her privacy
+
+## Tech Comfort Level
+
+**High.** Lina is a digital native who manages most of her life through apps.
+She monitors her Tesla through the manufacturer's app, uses BankID for all
+banking and government services, and expects to manage her insurance policy
+entirely online. She would prefer a chat or in-app support channel over calling
+a phone number.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring is mandatory regardless of propulsion type; EV owners have the same obligation as ICE vehicle owners (FSA-007).                                                  |
+| **FSA**    | Premium transparency — Lina must be able to understand the factors driving her premium, including any EV-specific rating factors (FSA-004).                                       |
+| **IDD**    | Demands-and-needs assessment must consider EV-specific coverage needs such as battery protection, charging equipment, and specialist repair requirements (IDD-001).               |
+| **IDD**    | The Insurance Product Information Document (IPID) must clearly state whether battery damage, charging infrastructure, and EV-specific roadside assistance are included (IDD-002). |
+| **GDPR**   | Vehicle telematics data collected by the manufacturer or insurer constitutes personal data; processing requires explicit consent and transparent information (GDPR-001).          |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Lina is a private
+  customer with an EV-specific insurance profile.
+- [Repair Shop (Verkstad)](../actors/external/repair-shop.md) — authorized EV
+  workshops with high-voltage certification are critical for Lina's claims
+  experience.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -24,6 +24,7 @@ TryggFörsäkring platform must support.
 | [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
+| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
 
 ## How Personas Are Used
 

--- a/versioned_docs/version-phase-1/personas/lina-eriksson.md
+++ b/versioned_docs/version-phase-1/personas/lina-eriksson.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 9
+---
+
+# Lina Eriksson, 28 — Elbilsägare (EV Owner)
+
+> _"I love my Tesla, but I'm paying a fortune in insurance and I still don't
+> know if the battery is actually covered if something goes wrong. What am I
+> paying for?"_
+
+## Avatar Description
+
+A young woman in her late twenties wearing a winter jacket, standing next to a
+white Tesla Model 3 at a charging station in a snowy parking lot. She is
+checking the charging app on her phone while glancing at the wallbox display,
+breath visible in the cold northern Swedish air.
+
+## Demographics
+
+| Field      | Details                                  |
+| ---------- | ---------------------------------------- |
+| Age        | 28                                       |
+| Location   | Umeå, Sweden (Norrland)                  |
+| Occupation | Physiotherapist at the regional hospital |
+| Income     | Mid-range, stable public-sector salary   |
+
+## Insurance Situation
+
+| Field            | Details                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| Current coverage | Helförsäkring (required by financing agreement with Santander)                         |
+| Vehicle          | 2024 Tesla Model 3 Long Range (purchased new, financed)                                |
+| Bonus class      | 2 (four years driving, no claims)                                                      |
+| Coverage goal    | Understand what her helförsäkring actually covers for EV-specific components and risks |
+
+## Goals
+
+- Confirm that her policy covers battery damage and degradation — the battery
+  is the most expensive single component and she wants explicit clarity on what
+  scenarios are included
+- Understand whether her home wallbox (charging station) and charging cable are
+  covered under her motor policy or require separate home insurance
+- Get transparency on what drives her premium — she suspects the high vehicle
+  value is the main factor and wants to know if there are ways to reduce cost
+- Find out which repair shops in Norrland are authorized to work on EVs, since
+  high-voltage vehicle repairs require specialist certification
+- Ensure she has adequate roadside assistance that understands EV-specific
+  issues such as flatbed towing requirements (EVs should not be towed on driven
+  wheels)
+
+## Frustrations / Pain Points
+
+- **Battery coverage ambiguity** — her policy documents do not clearly state
+  whether battery degradation, thermal runaway, or charging-related damage are
+  covered; she has to call customer service to get vague answers
+- **Premium sticker shock** — as a 28-year-old with a high-value new vehicle,
+  her premium is significantly higher than colleagues with comparable ICE cars,
+  and she does not understand the breakdown
+- **Limited EV repair network** — very few workshops in northern Sweden have
+  the high-voltage certification required for EV repairs, which could mean long
+  wait times or transporting the car hundreds of kilometres
+- **Winter range anxiety and insurance implications** — she worries about
+  getting stranded in extreme cold when battery range drops, and whether
+  roadside assistance covers EV-specific recovery
+- **Telematics uncertainty** — her Tesla collects extensive driving data; she is
+  unsure whether TryggFörsäkring uses or could request this data and what that
+  means for her privacy
+
+## Tech Comfort Level
+
+**High.** Lina is a digital native who manages most of her life through apps.
+She monitors her Tesla through the manufacturer's app, uses BankID for all
+banking and government services, and expects to manage her insurance policy
+entirely online. She would prefer a chat or in-app support channel over calling
+a phone number.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring is mandatory regardless of propulsion type; EV owners have the same obligation as ICE vehicle owners (FSA-007).                                                  |
+| **FSA**    | Premium transparency — Lina must be able to understand the factors driving her premium, including any EV-specific rating factors (FSA-004).                                       |
+| **IDD**    | Demands-and-needs assessment must consider EV-specific coverage needs such as battery protection, charging equipment, and specialist repair requirements (IDD-001).               |
+| **IDD**    | The Insurance Product Information Document (IPID) must clearly state whether battery damage, charging infrastructure, and EV-specific roadside assistance are included (IDD-002). |
+| **GDPR**   | Vehicle telematics data collected by the manufacturer or insurer constitutes personal data; processing requires explicit consent and transparent information (GDPR-001).          |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Lina is a private
+  customer with an EV-specific insurance profile.
+- [Repair Shop (Verkstad)](../actors/external/repair-shop.md) — authorized EV
+  workshops with high-voltage certification are critical for Lina's claims
+  experience.


### PR DESCRIPTION
## Summary
- Adds new EV owner persona (Lina Eriksson, 28) representing Sweden's growing electric vehicle segment
- Covers EV-specific insurance needs: battery coverage, charging infrastructure, specialist repair network, premium transparency
- Includes regulatory touchpoints for FSA-007, FSA-004, IDD-001, IDD-002, GDPR-001

## Changes
- `versioned_docs/version-phase-1/personas/lina-eriksson.md` — new persona file
- `versioned_docs/version-phase-1/personas/index.md` — added to persona summary table
- `docs/personas/lina-eriksson.md` — mirrored persona file
- `docs/personas/index.md` — added to Phase 1 persona table

## Testing
- [x] markdownlint passes with zero warnings
- [x] Prettier formatting passes
- [x] `npm run build` succeeds (all links valid)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)