### PR TITLE
docs(#219): Add persona Maja Andersson — Dödsboförvaltare (estate executor)

### DIFF
--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -28,6 +28,7 @@ TryggFörsäkring platform must support.
 | [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver   |
 | [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
 | [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
+| [Maja Andersson](maja-andersson)                 | 52    | Estate Executor       | Empathetic estate settlement after death       |
 
 ## How Personas Are Used
 

--- a/versioned_docs/version-phase-1/personas/maja-andersson.md
+++ b/versioned_docs/version-phase-1/personas/maja-andersson.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 11
+---
+
+# Maja Andersson, 52 — Dödsboförvaltare (Estate Executor)
+
+> _"My father just passed away, and between the grief and the paperwork, I need
+> the insurance company to guide me — not make me guess what documents I need or
+> how long the car stays covered."_
+
+## Avatar Description
+
+A woman in her early fifties, looking composed but tired, sitting at a kitchen
+table surrounded by folders of documents — estate inventory papers, a death
+certificate, vehicle registration printouts. A half-empty coffee cup sits
+nearby. Her expression is determined but emotionally drained.
+
+## Demographics
+
+| Field      | Details                            |
+| ---------- | ---------------------------------- |
+| Age        | 52                                 |
+| Location   | Karlstad, Sweden                   |
+| Occupation | Nurse at Centralsjukhuset Karlstad |
+| Income     | Mid-range, salaried employee       |
+
+## Insurance Situation
+
+Maja is not a TryggFörsäkring customer herself — she is insured with
+Länsförsäkringar. She interacts with TryggFörsäkring solely as the estate
+executor (boutredningsman) for her deceased father Sven Andersson (78), who was
+a customer for over 30 years.
+
+| Field                 | Details                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| Relationship          | Estate executor (dödsboförvaltare/boutredningsman) for deceased policyholder          |
+| Deceased policyholder | Sven Andersson, 78, TryggFörsäkring customer for 30+ years                            |
+| Estate policy         | Helförsäkring on a 2016 Volvo V70 — policy must be cancelled or transferred           |
+| Bonus class           | Class 7 (Sven had 30+ years claim-free)                                               |
+| Immediate need        | Cancel policy, obtain premium refund to estate, maintain trafikförsäkring temporarily |
+| Vehicle disposition   | Transfer car to Maja's brother, who will sell it                                      |
+
+## Goals
+
+- Understand exactly which documents are required (death certificate, estate
+  inventory, power of attorney) so she can gather everything in one go
+- Cancel her father's motor insurance and receive a fair refund of prepaid
+  premium to the estate's bank account
+- Ensure the Volvo remains covered by trafikförsäkring during the estate
+  settlement period until the vehicle is transferred or deregistered
+- Transfer the policy or vehicle registration to her brother before sale, with
+  minimal administrative burden
+- Complete the entire process through digital channels where possible, avoiding
+  repeated phone calls while managing work and grief
+
+## Frustrations / Pain Points
+
+- **Unclear documentation requirements** — no upfront checklist of what the
+  estate executor needs to provide; each phone call reveals a new document
+  requirement
+- **Emotional insensitivity in process design** — automated messages addressed
+  to her deceased father, renewal reminders sent to a dead person's email, and
+  generic hold-queue experiences during an already difficult time
+- **Temporary coverage uncertainty** — the car is parked at her father's house
+  but still needs trafikförsäkring; Maja is unsure if coverage continues
+  automatically or if she needs to take action to avoid a gap
+- **Refund opacity** — no clear explanation of how the unused premium is
+  calculated, when the refund will be paid, or to which account
+- **Multiple touchpoints** — cancellation, refund, vehicle transfer, and
+  trafikförsäkring continuation all seem to involve different departments with
+  no coordinated estate-handling process
+
+## Tech Comfort Level
+
+**Medium.** Maja is comfortable with BankID, internet banking, and digital
+health services through her work. She prefers handling administrative tasks
+online during evenings after work, rather than calling during office hours. She
+uses a laptop and smartphone but is not interested in installing dedicated apps
+for a one-time interaction. A clear web-based self-service flow with status
+tracking would suit her needs best.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring must remain active on the Volvo until the vehicle is deregistered with Transportstyrelsen or transferred to a new owner (FSA-007).                                               |
+| **FSA**    | Fair refund calculation for the unused premium period after cancellation; the estate is entitled to a pro-rata refund (FSA-004).                                                                  |
+| **GDPR**   | The deceased person's personal data is subject to retention rules; the estate representative has a right to access policy and claims data relevant to estate administration (GDPR-001, GDPR-003). |
+| **GDPR**   | The death certificate and estate inventory documents are sensitive personal data requiring appropriate handling and storage (GDPR-004).                                                           |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — represents the
+  deceased policyholder Sven, whose policy Maja is administering on behalf of
+  the estate.
+- [Transportstyrelsen](../actors/external/transportstyrelsen.md) — vehicle
+  ownership transfer and deregistration during estate settlement.


### PR DESCRIPTION
## Summary
- Adds new persona **Maja Andersson, 52** — an estate executor (dödsboförvaltare) handling insurance matters after her father's death
- Covers the sensitive customer journey of policy cancellation, premium refund, temporary coverage, and vehicle transfer during estate settlement
- Updates the personas index page with the new entry

## Changes
- `versioned_docs/version-phase-1/personas/maja-andersson.md` — new persona file with all required sections (frontmatter, quote, avatar, demographics, insurance situation, goals, frustrations, tech comfort, regulatory touchpoints, related actors)
- `versioned_docs/version-phase-1/personas/index.md` — added Maja to the persona summary table

## Testing
- [x] markdownlint passes with zero warnings
- [x] Prettier formatting verified
- [x] Docusaurus build succeeds
- [x] All relative actor links verified (customer.md, transportstyrelsen.md)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)