### PR TITLE
docs(#218): Add persona Mohammed Hassan, 42 — Bytare (insurer switcher)

### DIFF
--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -15,18 +15,19 @@ support across all product lines.
 
 ## Phase 1 — Motor Insurance
 
-| Persona                                          | Age   | Role                  | Key Need                                      |
-| ------------------------------------------------ | ----- | --------------------- | --------------------------------------------- |
-| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance         |
-| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies       |
-| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                |
-| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
-| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
-| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
-| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
-| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
-| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
-| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints         |
+| Persona                                          | Age   | Role                  | Key Need                                       |
+| ------------------------------------------------ | ----- | --------------------- | ---------------------------------------------- |
+| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance          |
+| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies        |
+| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                 |
+| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service    |
+| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history  |
+| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds     |
+| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience            |
+| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing    |
+| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver   |
+| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
+| [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
 
 ## Phase 2 — Home & Property
 

--- a/docs/personas/mohammed-hassan.md
+++ b/docs/personas/mohammed-hassan.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 10
+---
+
+# Mohammed Hassan, 42 — Insurer Switcher (Bytare)
+
+> _"I've been with If for eight years with a clean record. Now they want 15%
+> more? I should be able to move my bonus to another insurer without starting
+> over — and without a single day without coverage."_
+
+## Avatar Description
+
+A man in his early forties wearing a casual blazer over a polo shirt, standing
+outside a restaurant entrance. His 2021 Volvo XC60 is parked nearby. He is
+holding a renewal letter in one hand and scrolling through insurance comparison
+sites on his phone with the other, looking focused and slightly irritated.
+
+## Demographics
+
+| Field      | Details                                    |
+| ---------- | ------------------------------------------ |
+| Age        | 42                                         |
+| Location   | Jönköping, Sweden                          |
+| Occupation | Restaurant owner (two locations)           |
+| Income     | Upper-middle, self-employed business owner |
+
+## Insurance Situation
+
+| Field            | Details                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| Current coverage | Helförsäkring with If P&C on a 2021 Volvo XC60 (personal use)                                    |
+| Vehicle          | 2021 Volvo XC60                                                                                  |
+| Bonus class      | 6 (eight years claim-free)                                                                       |
+| Switch trigger   | Received renewal quote with 15% premium increase; shopping for better pricing at TryggFörsäkring |
+
+## Goals
+
+- Transfer his bonus class 6 seamlessly from If to TryggFörsäkring via the
+  TFF-managed bonus transfer process, ensuring no loss of earned discount
+- Time the switch correctly — either at huvudförfallodag (main renewal date) or
+  mid-term — without any gap in trafikförsäkring coverage
+- Compare coverage tiers accurately between If and TryggFörsäkring, since
+  helförsäkring terms differ between insurers despite the same name
+- Bundle his personal Volvo XC60 insurance with fleet coverage for the two
+  restaurant delivery vehicles, getting a cross-sell discount
+- Receive a clear, written confirmation that his claims history is recognized
+  and his bonus class is correctly registered from day one
+
+## Frustrations / Pain Points
+
+- **Premium shock at renewal** — after eight claim-free years Mohammed expected
+  loyalty to be rewarded, not penalized with a 15% increase; the lack of
+  transparency about why the premium increased erodes trust
+- **Bonus portability anxiety** — he has heard conflicting information about
+  whether bonus class transfers are guaranteed or discretionary, and fears
+  losing years of earned discount in the switch
+- **Coverage gap risk** — the timing of cancellation with If and start of
+  coverage with TryggFörsäkring must be exact; any gap means driving without
+  mandatory trafikförsäkring, which is illegal
+- **Coverage comparison difficulty** — comparing what is actually covered under
+  helförsäkring between two different insurers is nearly impossible from
+  marketing materials alone; he wants a side-by-side IPID comparison
+- **Trust in the new insurer** — Mohammed needs assurance that TryggFörsäkring
+  will genuinely honor his claims history and not find reasons to downgrade
+  his bonus class after onboarding
+
+## Tech Comfort Level
+
+**Medium.** Mohammed uses digital tools daily for his restaurant business —
+point-of-sale systems, online accounting, staff scheduling apps — and is
+comfortable with online self-service. However, for significant financial
+decisions like insurance he prefers speaking to an advisor who can walk him
+through the details. He would start the comparison process online but wants to
+complete the switch with a human advisor, either by phone or at a local office.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                           |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring must be continuous with no coverage gap during the switch between insurers (FSA-007).                                                                              |
+| **FSA**    | TFF manages the bonus class transfer process between Swedish insurers, ensuring Mohammed's class 6 is correctly transferred (FSA-008).                                              |
+| **FSA**    | Mohammed has the right to cancel his If policy at huvudförfallodag with one month's written notice (FSA-013).                                                                       |
+| **IDD**    | TryggFörsäkring must perform a demands-and-needs assessment for Mohammed as a new customer, even though he is an experienced policyholder switching from another insurer (IDD-001). |
+| **IDD**    | Mohammed must receive an IPID for each TryggFörsäkring product tier so he can compare coverage with his existing If policy on a like-for-like basis (IDD-002).                      |
+| **GDPR**   | Mohammed has the right to data portability — he can request his claims history and bonus documentation from If to facilitate the switch to TryggFörsäkring (GDPR-002).              |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Mohammed is a
+  private customer switching from a competing insurer.
+- [TFF](../actors/external/tff.md) — manages the bonus class transfer between
+  If and TryggFörsäkring.
+- [Insurance Agent (Försäkringsrådgivare)](../actors/internal/insurance-agent.md)
+  — Mohammed prefers completing the switch with an advisor who can explain
+  coverage differences and confirm bonus transfer.
+- [Corporate Customer (Företagskund)](../actors/internal/corporate-customer.md)
+  — Mohammed is also a potential corporate customer for fleet insurance covering
+  his two restaurant delivery vehicles.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -15,18 +15,19 @@ TryggFörsäkring platform must support.
 
 ## Persona Summary
 
-| Persona                                          | Age   | Role                  | Key Need                                      |
-| ------------------------------------------------ | ----- | --------------------- | --------------------------------------------- |
-| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance         |
-| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies       |
-| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                |
-| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service   |
-| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history |
-| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
-| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
-| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
-| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
-| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints         |
+| Persona                                          | Age   | Role                  | Key Need                                       |
+| ------------------------------------------------ | ----- | --------------------- | ---------------------------------------------- |
+| [Erik Lindström](erik-lindstrom)                 | 19    | New Young Driver      | Affordable first-time motor insurance          |
+| [Anna & Marcus Johansson](anna-marcus-johansson) | 38/40 | Family, Multiple Cars | Unified management of multiple policies        |
+| [Fatima Al-Rashid](fatima-al-rashid)             | 45    | Small Business Fleet  | Efficient fleet administration                 |
+| [Gunnar Pettersson](gunnar-pettersson)           | 72    | Senior Policyholder   | Transparent renewals and accessible service    |
+| [Sofia Chen](sofia-chen)                         | 32    | Recent Immigrant      | Smooth onboarding with foreign claims history  |
+| [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds     |
+| [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience            |
+| [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing    |
+| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver   |
+| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
+| [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
 
 ## How Personas Are Used
 

--- a/versioned_docs/version-phase-1/personas/mohammed-hassan.md
+++ b/versioned_docs/version-phase-1/personas/mohammed-hassan.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 10
+---
+
+# Mohammed Hassan, 42 — Insurer Switcher (Bytare)
+
+> _"I've been with If for eight years with a clean record. Now they want 15%
+> more? I should be able to move my bonus to another insurer without starting
+> over — and without a single day without coverage."_
+
+## Avatar Description
+
+A man in his early forties wearing a casual blazer over a polo shirt, standing
+outside a restaurant entrance. His 2021 Volvo XC60 is parked nearby. He is
+holding a renewal letter in one hand and scrolling through insurance comparison
+sites on his phone with the other, looking focused and slightly irritated.
+
+## Demographics
+
+| Field      | Details                                    |
+| ---------- | ------------------------------------------ |
+| Age        | 42                                         |
+| Location   | Jönköping, Sweden                          |
+| Occupation | Restaurant owner (two locations)           |
+| Income     | Upper-middle, self-employed business owner |
+
+## Insurance Situation
+
+| Field            | Details                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| Current coverage | Helförsäkring with If P&C on a 2021 Volvo XC60 (personal use)                                    |
+| Vehicle          | 2021 Volvo XC60                                                                                  |
+| Bonus class      | 6 (eight years claim-free)                                                                       |
+| Switch trigger   | Received renewal quote with 15% premium increase; shopping for better pricing at TryggFörsäkring |
+
+## Goals
+
+- Transfer his bonus class 6 seamlessly from If to TryggFörsäkring via the
+  TFF-managed bonus transfer process, ensuring no loss of earned discount
+- Time the switch correctly — either at huvudförfallodag (main renewal date) or
+  mid-term — without any gap in trafikförsäkring coverage
+- Compare coverage tiers accurately between If and TryggFörsäkring, since
+  helförsäkring terms differ between insurers despite the same name
+- Bundle his personal Volvo XC60 insurance with fleet coverage for the two
+  restaurant delivery vehicles, getting a cross-sell discount
+- Receive a clear, written confirmation that his claims history is recognized
+  and his bonus class is correctly registered from day one
+
+## Frustrations / Pain Points
+
+- **Premium shock at renewal** — after eight claim-free years Mohammed expected
+  loyalty to be rewarded, not penalized with a 15% increase; the lack of
+  transparency about why the premium increased erodes trust
+- **Bonus portability anxiety** — he has heard conflicting information about
+  whether bonus class transfers are guaranteed or discretionary, and fears
+  losing years of earned discount in the switch
+- **Coverage gap risk** — the timing of cancellation with If and start of
+  coverage with TryggFörsäkring must be exact; any gap means driving without
+  mandatory trafikförsäkring, which is illegal
+- **Coverage comparison difficulty** — comparing what is actually covered under
+  helförsäkring between two different insurers is nearly impossible from
+  marketing materials alone; he wants a side-by-side IPID comparison
+- **Trust in the new insurer** — Mohammed needs assurance that TryggFörsäkring
+  will genuinely honor his claims history and not find reasons to downgrade
+  his bonus class after onboarding
+
+## Tech Comfort Level
+
+**Medium.** Mohammed uses digital tools daily for his restaurant business —
+point-of-sale systems, online accounting, staff scheduling apps — and is
+comfortable with online self-service. However, for significant financial
+decisions like insurance he prefers speaking to an advisor who can walk him
+through the details. He would start the comparison process online but wants to
+complete the switch with a human advisor, either by phone or at a local office.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                           |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring must be continuous with no coverage gap during the switch between insurers (FSA-007).                                                                              |
+| **FSA**    | TFF manages the bonus class transfer process between Swedish insurers, ensuring Mohammed's class 6 is correctly transferred (FSA-008).                                              |
+| **FSA**    | Mohammed has the right to cancel his If policy at huvudförfallodag with one month's written notice (FSA-013).                                                                       |
+| **IDD**    | TryggFörsäkring must perform a demands-and-needs assessment for Mohammed as a new customer, even though he is an experienced policyholder switching from another insurer (IDD-001). |
+| **IDD**    | Mohammed must receive an IPID for each TryggFörsäkring product tier so he can compare coverage with his existing If policy on a like-for-like basis (IDD-002).                      |
+| **GDPR**   | Mohammed has the right to data portability — he can request his claims history and bonus documentation from If to facilitate the switch to TryggFörsäkring (GDPR-002).              |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Mohammed is a
+  private customer switching from a competing insurer.
+- [TFF](../actors/external/tff.md) — manages the bonus class transfer between
+  If and TryggFörsäkring.
+- [Insurance Agent (Försäkringsrådgivare)](../actors/internal/insurance-agent.md)
+  — Mohammed prefers completing the switch with an advisor who can explain
+  coverage differences and confirm bonus transfer.
+- [Corporate Customer (Företagskund)](../actors/internal/corporate-customer.md)
+  — Mohammed is also a potential corporate customer for fleet insurance covering
+  his two restaurant delivery vehicles.


### PR DESCRIPTION
## Summary
- Adds new persona **Mohammed Hassan, 42** — a restaurant owner in Jönköping switching from If P&C to TryggFörsäkring
- Covers domestic insurer switching scenario: bonus class transfer via TFF, coverage gap prevention, IPID comparison, and cross-sell opportunity for fleet bundling
- Regulatory touchpoints: FSA-007, FSA-008, FSA-013, IDD-001, IDD-002, GDPR-002

## Changes
- `versioned_docs/version-phase-1/personas/mohammed-hassan.md` — new persona file
- `docs/personas/mohammed-hassan.md` — copy for current docs version
- `versioned_docs/version-phase-1/personas/index.md` — added to persona summary table
- `docs/personas/index.md` — added to Phase 1 persona summary table

## Testing
- [x] markdownlint passes with zero warnings
- [x] prettier check passes
- [x] Docusaurus build succeeds

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)