### PR TITLE
docs(#220): Add persona Henrik & Wilma Nilsson, 48/17 — Tonårsförare (teen driver)

### DIFF
--- a/docs/personas/henrik-wilma-nilsson.md
+++ b/docs/personas/henrik-wilma-nilsson.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 12
+---
+
+# Henrik & Wilma Nilsson, 48/17 — Tonårsförare (Teen Driver)
+
+> _"I'm happy Wilma got her license, but I'm terrified of what it'll cost — and
+> what happens to my bonus if she has a fender bender on her way to school."_
+
+## Avatar Description
+
+A middle-aged man in work clothes standing in a residential driveway next to a
+dark blue 2019 Kia Ceed, handing car keys to a teenage girl with a backpack over
+one shoulder. She looks excited; he looks proud but slightly worried. A
+gymnasium school bag is visible in the back seat.
+
+## Demographics
+
+| Field      | Details                                           |
+| ---------- | ------------------------------------------------- |
+| Ages       | Henrik 48, Wilma 17                               |
+| Location   | Västerås, Sweden                                  |
+| Occupation | Henrik: production manager at ABB Västerås        |
+| Education  | Wilma: gymnasium student (year 2)                 |
+| Income     | Single-income household (Henrik), upper-mid range |
+
+## Insurance Situation
+
+| Field            | Details                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| Current coverage | Halvförsäkring on the family's secondary car                                                   |
+| Vehicle          | 2019 Kia Ceed (secondary family car, Wilma's daily driver)                                     |
+| Bonus class      | Henrik: class 5 on this vehicle (long claim-free history)                                      |
+| Situation        | Wilma recently obtained her B-körkort and will drive to school and her part-time job           |
+| Coverage goal    | Add Wilma as a named driver; understand premium impact and whether to upgrade to helförsäkring |
+
+## Goals
+
+- Add Wilma as a named driver on the Kia Ceed policy with a clear understanding
+  of the premium increase before confirming the change
+- Understand exactly whose bonus class is at risk if Wilma causes an accident —
+  Henrik wants to protect his class 5 bonus built over many claim-free years
+- Evaluate whether the coverage should be upgraded from halvförsäkring to
+  helförsäkring now that an inexperienced driver will use the car daily
+- Find out if TryggFörsäkring offers any young-driver programmes, telematics
+  discounts, or mileage-based pricing that could reduce the premium impact
+- Keep total insurance costs manageable on a single income while ensuring Wilma
+  has adequate protection for her daily commute
+
+## Frustrations / Pain Points
+
+- **Premium sticker shock** — adding a 17-year-old driver to the policy could
+  double or triple the premium, and Henrik has no way to preview the cost before
+  committing to the change
+- **Bonus class uncertainty** — it is unclear whether Wilma's at-fault accident
+  would reduce Henrik's personal bonus class or only affect the vehicle's policy
+  rating
+- **Coverage gap anxiety** — halvförsäkring does not cover damage to the
+  insured's own vehicle in a single-car accident, which worries Henrik given
+  Wilma's inexperience
+- **Complex process** — adding a named driver requires documentation (Wilma's
+  driving licence, personal data) and Henrik is unsure what is needed and how
+  long it takes
+- **Parental responsibility** — Henrik feels responsible for ensuring Wilma is
+  properly covered but finds it difficult to compare coverage options without
+  clear cost breakdowns
+
+## Tech Comfort Level
+
+**Henrik: Medium.** Henrik uses digital banking and BankID daily but prefers
+phone support for complex insurance questions. He is comfortable navigating a
+web portal for routine tasks such as viewing policy details or downloading
+documents, but would want human guidance when making significant policy changes
+like adding a driver.
+
+**Wilma: High.** Wilma is a digital native who handles everything on her
+smartphone. She expects to be able to view her driving coverage, access her
+digital insurance card, and contact support via chat — not by calling a phone
+number. She would find a mobile app far more natural than a desktop portal.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GDPR**   | Processing Wilma's personal data (driving licence, identity) as a 17-year-old requires consideration of parental consent and age-appropriate data handling (GDPR-001).             |
+| **GDPR**   | Data minimization — only personal data strictly necessary for underwriting the additional driver may be collected and retained (GDPR-004).                                         |
+| **FSA**    | Premium transparency — Henrik must receive a clear explanation of how adding a young driver affects pricing before the change is confirmed (FSA-004).                              |
+| **FSA**    | Trafikförsäkring covers all authorized drivers of the vehicle, not only the policyholder; Wilma is covered by the mandatory liability component as soon as she is added (FSA-007). |
+| **IDD**    | Adding a named driver materially changes the policy's risk profile and triggers a demands-and-needs reassessment to ensure coverage remains suitable (IDD-001).                    |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Henrik is the
+  policyholder adding a family member as a named driver.
+- [Underwriter (Försäkringsgivare)](../actors/internal/underwriter.md) — the
+  underwriter assesses the risk impact of adding a 17-year-old driver and
+  determines the revised premium.

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -25,6 +25,7 @@ support across all product lines.
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 | [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
+| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
 
 ## Phase 2 — Home & Property
 

--- a/versioned_docs/version-phase-1/personas/henrik-wilma-nilsson.md
+++ b/versioned_docs/version-phase-1/personas/henrik-wilma-nilsson.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 12
+---
+
+# Henrik & Wilma Nilsson, 48/17 — Tonårsförare (Teen Driver)
+
+> _"I'm happy Wilma got her license, but I'm terrified of what it'll cost — and
+> what happens to my bonus if she has a fender bender on her way to school."_
+
+## Avatar Description
+
+A middle-aged man in work clothes standing in a residential driveway next to a
+dark blue 2019 Kia Ceed, handing car keys to a teenage girl with a backpack over
+one shoulder. She looks excited; he looks proud but slightly worried. A
+gymnasium school bag is visible in the back seat.
+
+## Demographics
+
+| Field      | Details                                           |
+| ---------- | ------------------------------------------------- |
+| Ages       | Henrik 48, Wilma 17                               |
+| Location   | Västerås, Sweden                                  |
+| Occupation | Henrik: production manager at ABB Västerås        |
+| Education  | Wilma: gymnasium student (year 2)                 |
+| Income     | Single-income household (Henrik), upper-mid range |
+
+## Insurance Situation
+
+| Field            | Details                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| Current coverage | Halvförsäkring on the family's secondary car                                                   |
+| Vehicle          | 2019 Kia Ceed (secondary family car, Wilma's daily driver)                                     |
+| Bonus class      | Henrik: class 5 on this vehicle (long claim-free history)                                      |
+| Situation        | Wilma recently obtained her B-körkort and will drive to school and her part-time job           |
+| Coverage goal    | Add Wilma as a named driver; understand premium impact and whether to upgrade to helförsäkring |
+
+## Goals
+
+- Add Wilma as a named driver on the Kia Ceed policy with a clear understanding
+  of the premium increase before confirming the change
+- Understand exactly whose bonus class is at risk if Wilma causes an accident —
+  Henrik wants to protect his class 5 bonus built over many claim-free years
+- Evaluate whether the coverage should be upgraded from halvförsäkring to
+  helförsäkring now that an inexperienced driver will use the car daily
+- Find out if TryggFörsäkring offers any young-driver programmes, telematics
+  discounts, or mileage-based pricing that could reduce the premium impact
+- Keep total insurance costs manageable on a single income while ensuring Wilma
+  has adequate protection for her daily commute
+
+## Frustrations / Pain Points
+
+- **Premium sticker shock** — adding a 17-year-old driver to the policy could
+  double or triple the premium, and Henrik has no way to preview the cost before
+  committing to the change
+- **Bonus class uncertainty** — it is unclear whether Wilma's at-fault accident
+  would reduce Henrik's personal bonus class or only affect the vehicle's policy
+  rating
+- **Coverage gap anxiety** — halvförsäkring does not cover damage to the
+  insured's own vehicle in a single-car accident, which worries Henrik given
+  Wilma's inexperience
+- **Complex process** — adding a named driver requires documentation (Wilma's
+  driving licence, personal data) and Henrik is unsure what is needed and how
+  long it takes
+- **Parental responsibility** — Henrik feels responsible for ensuring Wilma is
+  properly covered but finds it difficult to compare coverage options without
+  clear cost breakdowns
+
+## Tech Comfort Level
+
+**Henrik: Medium.** Henrik uses digital banking and BankID daily but prefers
+phone support for complex insurance questions. He is comfortable navigating a
+web portal for routine tasks such as viewing policy details or downloading
+documents, but would want human guidance when making significant policy changes
+like adding a driver.
+
+**Wilma: High.** Wilma is a digital native who handles everything on her
+smartphone. She expects to be able to view her driving coverage, access her
+digital insurance card, and contact support via chat — not by calling a phone
+number. She would find a mobile app far more natural than a desktop portal.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GDPR**   | Processing Wilma's personal data (driving licence, identity) as a 17-year-old requires consideration of parental consent and age-appropriate data handling (GDPR-001).             |
+| **GDPR**   | Data minimization — only personal data strictly necessary for underwriting the additional driver may be collected and retained (GDPR-004).                                         |
+| **FSA**    | Premium transparency — Henrik must receive a clear explanation of how adding a young driver affects pricing before the change is confirmed (FSA-004).                              |
+| **FSA**    | Trafikförsäkring covers all authorized drivers of the vehicle, not only the policyholder; Wilma is covered by the mandatory liability component as soon as she is added (FSA-007). |
+| **IDD**    | Adding a named driver materially changes the policy's risk profile and triggers a demands-and-needs reassessment to ensure coverage remains suitable (IDD-001).                    |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Henrik is the
+  policyholder adding a family member as a named driver.
+- [Underwriter (Försäkringsgivare)](../actors/internal/underwriter.md) — the
+  underwriter assesses the risk impact of adding a 17-year-old driver and
+  determines the revised premium.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -25,6 +25,7 @@ TryggFörsäkring platform must support.
 | [Lars Svensson](lars-svensson)                   | 55    | Claims Handler        | Modern tools to replace legacy workarounds    |
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 | [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
+| [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
 
 ## How Personas Are Used
 


### PR DESCRIPTION
## Summary
- Add new persona for Henrik (48) & Wilma (17) Nilsson — a father adding his teenage daughter as a named driver on the family car
- Covers premium impact anxiety, bonus class risk, GDPR considerations for a minor, and coverage upgrade evaluation
- Includes regulatory touchpoints: GDPR-001, GDPR-004, FSA-004, FSA-007, IDD-001

## Changes
- `versioned_docs/version-phase-1/personas/henrik-wilma-nilsson.md` — new persona file (sidebar_position: 12)
- `versioned_docs/version-phase-1/personas/index.md` — added to persona summary table
- `docs/personas/henrik-wilma-nilsson.md` — synced copy for next phase
- `docs/personas/index.md` — added to Phase 1 summary table

## Testing
- [x] `npx markdownlint` — zero warnings
- [x] `npx prettier --check` — all files pass
- [x] `npm run build` — successful, no broken links

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)