### PR TITLE
docs(#221): Add persona David Lindgren, 30 — Leasingkund (leasing customer)

### DIFF
--- a/docs/personas/david-lindgren.md
+++ b/docs/personas/david-lindgren.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 13
+---
+
+# David Lindgren, 30 — Leasingkund (Leasing Customer)
+
+> _"I love the car, but I don't own it — and I have no idea who's actually on the
+> hook if something goes wrong. Me, my insurer, or Volkswagen Financial?"_
+
+## Avatar Description
+
+A man around thirty in a slim-fit jacket and sneakers, standing in an underground
+parking garage next to a white 2024 Volkswagen ID.4. He is leaning against the
+car with his laptop bag slung over one shoulder, scrolling through his phone with
+a slightly puzzled expression as he compares insurance quotes.
+
+## Demographics
+
+| Field      | Details                                  |
+| ---------- | ---------------------------------------- |
+| Age        | 30                                       |
+| Location   | Göteborg, Sweden                         |
+| Occupation | UX designer at a SaaS startup            |
+| Income     | Mid-to-high range, stable monthly salary |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Current coverage | Helförsäkring (mandated by leasing agreement)                                                                      |
+| Vehicle          | 2024 Volkswagen ID.4 Pro (privatleasing via Volkswagen Financial Services, 36-month contract)                      |
+| Bonus class      | 3 (six years driving, started late at age 24)                                                                      |
+| Situation        | Leasing agreement requires helförsäkring with a maximum 3,000 SEK deductible and the leasing company as intressent |
+| Coverage goal    | Find the best price within the constraints imposed by the leasing agreement                                        |
+
+## Goals
+
+- Shop for the most competitive helförsäkring premium while staying within the
+  leasing company's mandatory coverage and deductible requirements
+- Understand the three-party relationship between himself, TryggFörsäkring, and
+  Volkswagen Financial Services — specifically who is responsible for what during
+  a claim
+- Clarify whether he needs separate gap insurance to cover the difference between
+  the car's market value and the remaining lease balance if the vehicle is
+  totalled
+- Ensure the policy correctly names Volkswagen Financial Services as interested
+  party (intressent) so the leasing agreement remains valid
+- Know what happens at end-of-lease — whether excess wear and minor damage are
+  covered by his insurance or if that is his personal liability
+
+## Frustrations / Pain Points
+
+- **Three-party confusion** — David does not understand the division of
+  responsibility between himself, TryggFörsäkring, and the leasing company when
+  a claim occurs; each party seems to point to the other
+- **Constrained choice** — the leasing agreement dictates minimum coverage and
+  maximum deductible, limiting his ability to reduce costs through lower coverage
+  or higher self-risk
+- **Gap insurance uncertainty** — no one has clearly explained whether his
+  helförsäkring covers the gap between market value and remaining lease balance
+  in a total-loss scenario, or whether he needs a separate policy
+- **Interested-party complexity** — adding the leasing company as intressent on
+  the policy is an unfamiliar concept and David worries about getting it wrong
+  and voiding his leasing contract
+- **End-of-lease liability** — David is unsure whether minor paint scratches,
+  kerb rash on wheels, or interior wear at lease return are insurable events or
+  purely his financial responsibility
+
+## Tech Comfort Level
+
+**High.** David is a UX designer who evaluates digital products for a living. He
+expects a fully digital self-service experience — online quotes, BankID signing,
+real-time policy documents, and app-based claims filing. He has little patience
+for phone calls, paper forms, or having to visit a physical office. If the
+digital experience is poor, he will switch insurer without hesitation.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring is the registered keeper's responsibility even for leased vehicles; David as the registered user must ensure valid coverage is in place (FSA-007).                         |
+| **FSA**    | Premium and coverage transparency — David must be able to understand what the mandated helförsäkring includes and how his premium is calculated within the leasing constraints (FSA-004).   |
+| **IDD**    | The demands-and-needs assessment must account for leasing-specific constraints such as mandated coverage levels and deductible caps when recommending a product (IDD-001).                  |
+| **IDD**    | The Insurance Product Information Document (IPID) must clearly describe whether gap coverage is included or excluded, so David can make an informed decision (IDD-002).                     |
+| **GDPR**   | Data sharing between TryggFörsäkring and Volkswagen Financial Services — transferring policy details to the leasing company requires a lawful basis and transparent information (GDPR-001). |
+| **GDPR**   | Data minimization — only the personal data strictly necessary for the leasing company's interested-party role may be shared; no broader profiling or marketing use is permitted (GDPR-004). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — David is a private
+  customer whose insurance choices are constrained by a leasing agreement.
+- [Underwriter (Försäkringsgivare)](../actors/internal/underwriter.md) — the
+  underwriter must apply leasing-specific terms including mandated coverage
+  levels, deductible caps, and interested-party registration.

--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -26,6 +26,7 @@ support across all product lines.
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 | [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
 | [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
+| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints         |
 
 ## Phase 2 — Home & Property
 

--- a/versioned_docs/version-phase-1/personas/david-lindgren.md
+++ b/versioned_docs/version-phase-1/personas/david-lindgren.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 13
+---
+
+# David Lindgren, 30 — Leasingkund (Leasing Customer)
+
+> _"I love the car, but I don't own it — and I have no idea who's actually on the
+> hook if something goes wrong. Me, my insurer, or Volkswagen Financial?"_
+
+## Avatar Description
+
+A man around thirty in a slim-fit jacket and sneakers, standing in an underground
+parking garage next to a white 2024 Volkswagen ID.4. He is leaning against the
+car with his laptop bag slung over one shoulder, scrolling through his phone with
+a slightly puzzled expression as he compares insurance quotes.
+
+## Demographics
+
+| Field      | Details                                  |
+| ---------- | ---------------------------------------- |
+| Age        | 30                                       |
+| Location   | Göteborg, Sweden                         |
+| Occupation | UX designer at a SaaS startup            |
+| Income     | Mid-to-high range, stable monthly salary |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Current coverage | Helförsäkring (mandated by leasing agreement)                                                                      |
+| Vehicle          | 2024 Volkswagen ID.4 Pro (privatleasing via Volkswagen Financial Services, 36-month contract)                      |
+| Bonus class      | 3 (six years driving, started late at age 24)                                                                      |
+| Situation        | Leasing agreement requires helförsäkring with a maximum 3,000 SEK deductible and the leasing company as intressent |
+| Coverage goal    | Find the best price within the constraints imposed by the leasing agreement                                        |
+
+## Goals
+
+- Shop for the most competitive helförsäkring premium while staying within the
+  leasing company's mandatory coverage and deductible requirements
+- Understand the three-party relationship between himself, TryggFörsäkring, and
+  Volkswagen Financial Services — specifically who is responsible for what during
+  a claim
+- Clarify whether he needs separate gap insurance to cover the difference between
+  the car's market value and the remaining lease balance if the vehicle is
+  totalled
+- Ensure the policy correctly names Volkswagen Financial Services as interested
+  party (intressent) so the leasing agreement remains valid
+- Know what happens at end-of-lease — whether excess wear and minor damage are
+  covered by his insurance or if that is his personal liability
+
+## Frustrations / Pain Points
+
+- **Three-party confusion** — David does not understand the division of
+  responsibility between himself, TryggFörsäkring, and the leasing company when
+  a claim occurs; each party seems to point to the other
+- **Constrained choice** — the leasing agreement dictates minimum coverage and
+  maximum deductible, limiting his ability to reduce costs through lower coverage
+  or higher self-risk
+- **Gap insurance uncertainty** — no one has clearly explained whether his
+  helförsäkring covers the gap between market value and remaining lease balance
+  in a total-loss scenario, or whether he needs a separate policy
+- **Interested-party complexity** — adding the leasing company as intressent on
+  the policy is an unfamiliar concept and David worries about getting it wrong
+  and voiding his leasing contract
+- **End-of-lease liability** — David is unsure whether minor paint scratches,
+  kerb rash on wheels, or interior wear at lease return are insurable events or
+  purely his financial responsibility
+
+## Tech Comfort Level
+
+**High.** David is a UX designer who evaluates digital products for a living. He
+expects a fully digital self-service experience — online quotes, BankID signing,
+real-time policy documents, and app-based claims filing. He has little patience
+for phone calls, paper forms, or having to visit a physical office. If the
+digital experience is poor, he will switch insurer without hesitation.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Trafikförsäkring is the registered keeper's responsibility even for leased vehicles; David as the registered user must ensure valid coverage is in place (FSA-007).                         |
+| **FSA**    | Premium and coverage transparency — David must be able to understand what the mandated helförsäkring includes and how his premium is calculated within the leasing constraints (FSA-004).   |
+| **IDD**    | The demands-and-needs assessment must account for leasing-specific constraints such as mandated coverage levels and deductible caps when recommending a product (IDD-001).                  |
+| **IDD**    | The Insurance Product Information Document (IPID) must clearly describe whether gap coverage is included or excluded, so David can make an informed decision (IDD-002).                     |
+| **GDPR**   | Data sharing between TryggFörsäkring and Volkswagen Financial Services — transferring policy details to the leasing company requires a lawful basis and transparent information (GDPR-001). |
+| **GDPR**   | Data minimization — only the personal data strictly necessary for the leasing company's interested-party role may be shared; no broader profiling or marketing use is permitted (GDPR-004). |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — David is a private
+  customer whose insurance choices are constrained by a leasing agreement.
+- [Underwriter (Försäkringsgivare)](../actors/internal/underwriter.md) — the
+  underwriter must apply leasing-specific terms including mandated coverage
+  levels, deductible caps, and interested-party registration.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -26,6 +26,7 @@ TryggFörsäkring platform must support.
 | [Niklas Bergman](niklas-bergman)                 | 35    | Claims Reporter       | Smooth first-time claims experience           |
 | [Lina Eriksson](lina-eriksson)                   | 28    | EV Owner              | Clarity on EV-specific coverage and pricing   |
 | [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver  |
+| [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints         |
 
 ## How Personas Are Used
 


### PR DESCRIPTION
## Summary
- Add new persona David Lindgren, 30, representing the privatleasing (private car leasing) customer segment
- Covers the three-party relationship between customer, insurer, and leasing company (Volkswagen Financial Services)
- Includes leasing-specific themes: mandated coverage, deductible constraints, gap insurance, interested-party registration, end-of-lease liability

## Changes
- `versioned_docs/version-phase-1/personas/david-lindgren.md` — new persona file (sidebar_position: 13)
- `docs/personas/david-lindgren.md` — mirrored copy for next phase
- `versioned_docs/version-phase-1/personas/index.md` — added to persona summary table
- `docs/personas/index.md` — added to Phase 1 persona summary table

## Testing
- [x] markdownlint — zero warnings
- [x] prettier — all files pass
- [x] npm run build — successful, no broken links

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)