### PR TITLE
docs(#222): Add persona Karin Ström, 45 — Frånskild, ägarövergång (divorce, vehicle transfer)

### DIFF
--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -29,6 +29,7 @@ support across all product lines.
 | [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
 | [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
 | [Oscar Wallin](oscar-wallin)                     | 26    | Gig Economy Driver    | Clarity on coverage for ride-hailing use       |
+| [Karin Ström](karin-strom)                       | 45    | Divorce Transfer      | Smooth ownership transfer with bonus history   |
 
 ## Phase 2 — Home & Property
 

--- a/docs/personas/karin-strom.md
+++ b/docs/personas/karin-strom.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 14
+---
+
+# Karin Ström, 45 — Frånskild, ägarövergång (Divorce, Vehicle Transfer)
+
+> _"I drove that car claim-free for twelve years, but because the policy was in
+> my ex-husband's name I have to start from scratch — how is that fair?"_
+
+## Avatar Description
+
+A woman in her mid-forties in a practical autumn jacket, standing outside a
+Transportstyrelsen service point holding a folder of divorce-settlement
+documents. A silver 2021 Volvo XC40 is parked behind her. She looks tired but
+determined, checking her phone for insurance quotes between glances at the
+paperwork.
+
+## Demographics
+
+| Field      | Details                                     |
+| ---------- | ------------------------------------------- |
+| Age        | 45                                          |
+| Location   | Helsingborg, Sweden                         |
+| Occupation | Logistics coordinator at a shipping company |
+| Income     | Mid-range, single-income household          |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Current coverage | None in her own name — previously covered as a named driver on her ex-husband's helförsäkring                                                                                  |
+| Vehicle          | 2021 Volvo XC40 (being transferred to Karin as part of bodelning)                                                                                                              |
+| Bonus class      | 0 (no personal bonus class — twelve years of claim-free driving as a named driver on her ex-husband's policy are not automatically recognised)                                 |
+| Situation        | Ownership transfer is in progress at Transportstyrelsen; Karin must arrange her own policy before the transfer completes to avoid a gap in mandatory trafikförsäkring coverage |
+| Coverage goal    | Helförsäkring at a manageable premium despite starting at bonus class 0, with no coverage gap during the ownership transition                                                  |
+
+## Goals
+
+- Secure her own helförsäkring policy on the Volvo XC40 before the
+  Transportstyrelsen ownership transfer completes, ensuring continuous
+  trafikförsäkring coverage with no gap
+- Obtain recognition for her twelve years of claim-free driving as a named
+  driver so she does not have to start at the lowest bonus class
+- Understand the exact timeline coordination between the ownership transfer at
+  Transportstyrelsen and her new policy start date
+- Keep the premium affordable on a single income, exploring any available
+  discounts or bonus class transfer mechanisms
+- Have her personal data cleanly separated from her ex-husband's policy records
+  so neither party has access to the other's insurance information
+
+## Frustrations / Pain Points
+
+- **Bonus class injustice** — twelve years of claim-free driving count for
+  nothing because the policies were registered in her ex-husband's name; Karin
+  feels punished for a common marital arrangement
+- **Coverage gap risk** — coordinating the exact handover date between her
+  ex-husband's policy ending and her new policy starting is stressful, and a
+  gap would violate trafikförsäkring law
+- **Bureaucratic complexity** — managing simultaneous processes at
+  Transportstyrelsen, the insurance company, and the divorce settlement feels
+  overwhelming during an already difficult life event
+- **Premium shock** — starting at bonus class 0 means significantly higher
+  premiums than she is used to, adding financial strain to an already tight
+  single-income budget
+- **Data privacy concerns** — Karin wants assurance that her ex-husband cannot
+  see or access her new policy details, and that her personal data has been
+  fully separated from his account
+
+## Tech Comfort Level
+
+**Medium.** Karin is comfortable with everyday digital services and uses BankID
+regularly. She prefers handling straightforward tasks online but wants to speak
+with an insurance agent for complex matters like bonus class transfers and
+coverage timing during the ownership transition. She does not want to manage the
+entire process through a self-service portal alone — the stakes feel too high
+for a purely digital experience.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Continuous trafikförsäkring is mandatory — no gap is permitted during the ownership transfer from ex-husband to Karin; the platform must support seamless policy transition (FSA-007).               |
+| **FSA**    | TFF bonus class rules govern whether named-driver history can be recognised when establishing a new policyholder's bonus class; the platform must support bonus class transfer assessment (FSA-008). |
+| **FSA**    | Consumer protection requires fair treatment during life events — Karin must not be disadvantaged by standard marital insurance arrangements when establishing her own policy (FSA-004).              |
+| **IDD**    | A demands-and-needs assessment must be performed for Karin as a new policyholder, considering her specific situation including the ownership transfer timeline and premium sensitivity (IDD-001).    |
+| **GDPR**   | Personal data separation — Karin's data must be fully separated from her ex-husband's policy records, ensuring neither party can access the other's insurance information (GDPR-001).                |
+| **GDPR**   | Right to data portability — if Karin's driving history is held under her ex-husband's policy, she may request extraction of her own data to support a bonus class transfer application (GDPR-003).   |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Karin is a private
+  customer transitioning from named driver on a family policy to independent
+  policyholder.
+- [Transportstyrelsen](../actors/external/transportstyrelsen.md) — the vehicle
+  registry authority processing the ownership transfer from Karin's ex-husband
+  to Karin as part of the divorce settlement.
+- [TFF (Trafikförsäkringsföreningen)](../actors/external/tff.md) — governs
+  bonus class rules and may be involved in assessing whether named-driver
+  history qualifies for bonus class recognition.
+- [Insurance Agent (Försäkringsrådgivare)](../actors/internal/insurance-agent.md) —
+  Karin prefers agent support for complex matters like bonus class transfers and
+  coordinating coverage timing during ownership transition.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -29,6 +29,7 @@ TryggFörsäkring platform must support.
 | [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
 | [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
 | [Oscar Wallin](oscar-wallin)                     | 26    | Gig Economy Driver    | Clarity on coverage for ride-hailing use       |
+| [Karin Ström](karin-strom)                       | 45    | Divorce Transfer      | Smooth ownership transfer with bonus history   |
 
 ## How Personas Are Used
 

--- a/versioned_docs/version-phase-1/personas/karin-strom.md
+++ b/versioned_docs/version-phase-1/personas/karin-strom.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 14
+---
+
+# Karin Ström, 45 — Frånskild, ägarövergång (Divorce, Vehicle Transfer)
+
+> _"I drove that car claim-free for twelve years, but because the policy was in
+> my ex-husband's name I have to start from scratch — how is that fair?"_
+
+## Avatar Description
+
+A woman in her mid-forties in a practical autumn jacket, standing outside a
+Transportstyrelsen service point holding a folder of divorce-settlement
+documents. A silver 2021 Volvo XC40 is parked behind her. She looks tired but
+determined, checking her phone for insurance quotes between glances at the
+paperwork.
+
+## Demographics
+
+| Field      | Details                                     |
+| ---------- | ------------------------------------------- |
+| Age        | 45                                          |
+| Location   | Helsingborg, Sweden                         |
+| Occupation | Logistics coordinator at a shipping company |
+| Income     | Mid-range, single-income household          |
+
+## Insurance Situation
+
+| Field            | Details                                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Current coverage | None in her own name — previously covered as a named driver on her ex-husband's helförsäkring                                                                                  |
+| Vehicle          | 2021 Volvo XC40 (being transferred to Karin as part of bodelning)                                                                                                              |
+| Bonus class      | 0 (no personal bonus class — twelve years of claim-free driving as a named driver on her ex-husband's policy are not automatically recognised)                                 |
+| Situation        | Ownership transfer is in progress at Transportstyrelsen; Karin must arrange her own policy before the transfer completes to avoid a gap in mandatory trafikförsäkring coverage |
+| Coverage goal    | Helförsäkring at a manageable premium despite starting at bonus class 0, with no coverage gap during the ownership transition                                                  |
+
+## Goals
+
+- Secure her own helförsäkring policy on the Volvo XC40 before the
+  Transportstyrelsen ownership transfer completes, ensuring continuous
+  trafikförsäkring coverage with no gap
+- Obtain recognition for her twelve years of claim-free driving as a named
+  driver so she does not have to start at the lowest bonus class
+- Understand the exact timeline coordination between the ownership transfer at
+  Transportstyrelsen and her new policy start date
+- Keep the premium affordable on a single income, exploring any available
+  discounts or bonus class transfer mechanisms
+- Have her personal data cleanly separated from her ex-husband's policy records
+  so neither party has access to the other's insurance information
+
+## Frustrations / Pain Points
+
+- **Bonus class injustice** — twelve years of claim-free driving count for
+  nothing because the policies were registered in her ex-husband's name; Karin
+  feels punished for a common marital arrangement
+- **Coverage gap risk** — coordinating the exact handover date between her
+  ex-husband's policy ending and her new policy starting is stressful, and a
+  gap would violate trafikförsäkring law
+- **Bureaucratic complexity** — managing simultaneous processes at
+  Transportstyrelsen, the insurance company, and the divorce settlement feels
+  overwhelming during an already difficult life event
+- **Premium shock** — starting at bonus class 0 means significantly higher
+  premiums than she is used to, adding financial strain to an already tight
+  single-income budget
+- **Data privacy concerns** — Karin wants assurance that her ex-husband cannot
+  see or access her new policy details, and that her personal data has been
+  fully separated from his account
+
+## Tech Comfort Level
+
+**Medium.** Karin is comfortable with everyday digital services and uses BankID
+regularly. She prefers handling straightforward tasks online but wants to speak
+with an insurance agent for complex matters like bonus class transfers and
+coverage timing during the ownership transition. She does not want to manage the
+entire process through a self-service portal alone — the stakes feel too high
+for a purely digital experience.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                            |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **FSA**    | Continuous trafikförsäkring is mandatory — no gap is permitted during the ownership transfer from ex-husband to Karin; the platform must support seamless policy transition (FSA-007).               |
+| **FSA**    | TFF bonus class rules govern whether named-driver history can be recognised when establishing a new policyholder's bonus class; the platform must support bonus class transfer assessment (FSA-008). |
+| **FSA**    | Consumer protection requires fair treatment during life events — Karin must not be disadvantaged by standard marital insurance arrangements when establishing her own policy (FSA-004).              |
+| **IDD**    | A demands-and-needs assessment must be performed for Karin as a new policyholder, considering her specific situation including the ownership transfer timeline and premium sensitivity (IDD-001).    |
+| **GDPR**   | Personal data separation — Karin's data must be fully separated from her ex-husband's policy records, ensuring neither party can access the other's insurance information (GDPR-001).                |
+| **GDPR**   | Right to data portability — if Karin's driving history is held under her ex-husband's policy, she may request extraction of her own data to support a bonus class transfer application (GDPR-003).   |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Karin is a private
+  customer transitioning from named driver on a family policy to independent
+  policyholder.
+- [Transportstyrelsen](../actors/external/transportstyrelsen.md) — the vehicle
+  registry authority processing the ownership transfer from Karin's ex-husband
+  to Karin as part of the divorce settlement.
+- [TFF (Trafikförsäkringsföreningen)](../actors/external/tff.md) — governs
+  bonus class rules and may be involved in assessing whether named-driver
+  history qualifies for bonus class recognition.
+- [Insurance Agent (Försäkringsrådgivare)](../actors/internal/insurance-agent.md) —
+  Karin prefers agent support for complex matters like bonus class transfers and
+  coordinating coverage timing during ownership transition.


### PR DESCRIPTION
## Summary

- Adds persona Karin Ström, 45 — a recently divorced logistics coordinator navigating vehicle ownership transfer (bodelning) and the challenge of establishing her own insurance policy after 12 years as a named driver
- Covers key themes: bonus class gap for named drivers, coverage continuity during Transportstyrelsen transfer, data separation from ex-spouse, and financial pressure on a single income
- Regulatory touchpoints: FSA-004, FSA-007, FSA-008, IDD-001, GDPR-001, GDPR-003

## Changes

- `versioned_docs/version-phase-1/personas/karin-strom.md` — new persona file
- `docs/personas/karin-strom.md` — mirrored copy for next phase
- `versioned_docs/version-phase-1/personas/index.md` — added Karin to persona summary table
- `docs/personas/index.md` — added Karin to persona summary table

## Testing

- [x] markdownlint passes with zero warnings
- [x] Prettier formatting check passes
- [x] Docusaurus build succeeds (links and frontmatter validated)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)