### PR TITLE
docs(#233): Add analysis section structure for price sensitivity

### DIFF
--- a/docs/analysis/_category_.json
+++ b/docs/analysis/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Analysis",
+  "position": 7
+}

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 1
+---
+
+# Analysis
+
+Strategic business analysis supporting the TryggFörsäkring platform's pricing,
+product, and customer retention strategy. These documents synthesize insights from
+the [personas](../personas/index.md), [user stories](../phase-1-motor/user-stories/index.md),
+and market positioning data to inform platform design decisions.
+
+## Purpose
+
+The analysis section provides data-driven assessments that go beyond functional
+requirements. While user stories and use cases define _what_ the platform must do,
+analysis documents explore _why_ certain capabilities matter commercially and how
+the platform should adapt to competitive market dynamics.
+
+Key questions addressed:
+
+- How sensitive are different customer segments to premium pricing?
+- Where does TryggFörsäkring face the greatest risk of customer churn?
+- Which platform capabilities create the most defensible competitive advantage?
+- How should pricing and product strategy vary across customer segments?
+
+## Documents
+
+| Document      | Description                                        |
+| ------------- | -------------------------------------------------- |
+| _Coming soon_ | Price sensitivity analysis across Phase 1 personas |
+
+## How Analysis Documents Are Used
+
+- **Product owners** use analysis findings to prioritize features and capabilities
+  that drive retention and acquisition.
+- **Underwriters** reference price sensitivity data when calibrating premium
+  structures and discount strategies.
+- **Development teams** understand the business rationale behind prioritization
+  decisions, helping them make better trade-off choices during implementation.
+- **Compliance and legal** verify that pricing strategies and customer
+  segmentation comply with IDD demands-and-needs requirements and FSA consumer
+  protection guidelines.

--- a/versioned_docs/version-phase-1/analysis/_category_.json
+++ b/versioned_docs/version-phase-1/analysis/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Analysis",
+  "position": 7
+}

--- a/versioned_docs/version-phase-1/analysis/index.md
+++ b/versioned_docs/version-phase-1/analysis/index.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 1
+---
+
+# Analysis
+
+Strategic business analysis supporting the TryggFörsäkring platform's pricing,
+product, and customer retention strategy. These documents synthesize insights from
+the [personas](../personas/index.md), [user stories](../phase-1-motor/user-stories/index.md),
+and market positioning data to inform platform design decisions.
+
+## Purpose
+
+The analysis section provides data-driven assessments that go beyond functional
+requirements. While user stories and use cases define _what_ the platform must do,
+analysis documents explore _why_ certain capabilities matter commercially and how
+the platform should adapt to competitive market dynamics.
+
+Key questions addressed:
+
+- How sensitive are different customer segments to premium pricing?
+- Where does TryggFörsäkring face the greatest risk of customer churn?
+- Which platform capabilities create the most defensible competitive advantage?
+- How should pricing and product strategy vary across customer segments?
+
+## Documents
+
+| Document      | Description                                        |
+| ------------- | -------------------------------------------------- |
+| _Coming soon_ | Price sensitivity analysis across Phase 1 personas |
+
+## How Analysis Documents Are Used
+
+- **Product owners** use analysis findings to prioritize features and capabilities
+  that drive retention and acquisition.
+- **Underwriters** reference price sensitivity data when calibrating premium
+  structures and discount strategies.
+- **Development teams** understand the business rationale behind prioritization
+  decisions, helping them make better trade-off choices during implementation.
+- **Compliance and legal** verify that pricing strategies and customer
+  segmentation comply with IDD demands-and-needs requirements and FSA consumer
+  protection guidelines.


### PR DESCRIPTION
## Summary

- Creates the `analysis/` section in Phase 1 documentation with `_category_.json` (sidebar position 7) and `index.md`
- Index page introduces the section purpose: strategic business analysis to inform platform pricing and product strategy
- Mirrored in both `versioned_docs/version-phase-1/` and `docs/`

## Changes

- `versioned_docs/version-phase-1/analysis/_category_.json` — sidebar category config
- `versioned_docs/version-phase-1/analysis/index.md` — section overview with purpose, document table, and usage guide
- `docs/analysis/_category_.json` — mirror for working directory
- `docs/analysis/index.md` — mirror for working directory

## Testing

- [x] `npx markdownlint docs/ versioned_docs/` — zero warnings
- [x] `npx prettier --check .` — all files formatted
- [x] `npm run build` — successful build with no broken links

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)