### PR TITLE
docs(#219): Add persona Maja Andersson, 52 — Dödsboförvaltare (estate executor)

### DIFF
--- a/docs/personas/index.md
+++ b/docs/personas/index.md
@@ -28,6 +28,7 @@ support across all product lines.
 | [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver   |
 | [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
 | [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
+| [Maja Andersson](maja-andersson)                 | 52    | Estate Executor       | Guided estate policy cancellation and refund   |
 | [Oscar Wallin](oscar-wallin)                     | 26    | Gig Economy Driver    | Clarity on coverage for ride-hailing use       |
 | [Karin Ström](karin-strom)                       | 45    | Divorce Transfer      | Smooth ownership transfer with bonus history   |
 

--- a/docs/personas/maja-andersson.md
+++ b/docs/personas/maja-andersson.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 11
+---
+
+# Maja Andersson, 52 — Estate Executor (Dödsboförvaltare)
+
+> _"My father passed away three weeks ago. He had TryggFörsäkring for over 30
+> years and I don't even know exactly what policies he had. I just need someone
+> to guide me through what to cancel, what to keep active, and where the refund
+> goes — without making me explain the situation five times to five different
+> people."_
+
+## Avatar Description
+
+A woman in her early fifties with reading glasses pushed up onto her head,
+sitting at a kitchen table covered with folders of paperwork — estate inventory
+forms, a death certificate, and insurance correspondence. A cup of tea sits
+untouched beside her laptop, which shows a Skatteverket bouppteckning page. She
+looks tired but determined, holding a pen and making notes on a printed list of
+her father's accounts and policies.
+
+## Demographics
+
+| Field      | Details                            |
+| ---------- | ---------------------------------- |
+| Age        | 52                                 |
+| Location   | Karlstad, Sweden                   |
+| Occupation | Nurse at Centralsjukhuset Karlstad |
+| Income     | Middle, public sector salary       |
+
+## Insurance Situation
+
+| Field               | Details                                                                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Estate coverage     | Deceased father Sven (78) held helförsäkring on a 2005 Volvo V70 with TryggFörsäkring for 30+ years                                       |
+| Vehicle             | 2005 Volvo V70 (registered to the estate of Sven Andersson)                                                                               |
+| Bonus class         | 7 (decades claim-free)                                                                                                                    |
+| Estate status       | Maja is appointed boutredningsman; the car is parked at Sven's house pending transfer to her brother Erik, who plans to sell it           |
+| Temporary coverage  | Trafikförsäkring must remain active on the Volvo V70 until the vehicle is formally deregistered at Transportstyrelsen or transferred/sold |
+| Maja's own coverage | Insured with Länsförsäkringar — she is not a TryggFörsäkring customer herself                                                             |
+
+## Goals
+
+- Get a clear, consolidated overview of all policies her father held with
+  TryggFörsäkring so she can cancel or transfer each one without missing
+  anything
+- Understand exactly what documentation is required — death certificate
+  (dödsbevis), estate inventory (bouppteckning), proof of executor role — so she
+  can gather everything in one round rather than being asked for additional
+  documents repeatedly
+- Ensure the prepaid premium is correctly refunded to the estate's bank account,
+  with a transparent calculation of the unused coverage period
+- Keep trafikförsäkring active on her father's Volvo V70 during the estate
+  settlement period so the car remains legally covered while parked, then cancel
+  or transfer the policy when her brother takes ownership
+- Complete the entire process with empathetic, respectful service — she should
+  not have to repeat the circumstances of her father's death to multiple
+  departments or agents
+
+## Frustrations / Pain Points
+
+- **Emotional burden compounded by bureaucracy** — Maja is grieving while
+  simultaneously navigating Skatteverket, banks, Transportstyrelsen, and now
+  insurance; each institution has its own forms, timelines, and requirements,
+  and none of them coordinate with each other
+- **No single point of contact** — she fears being transferred between
+  departments (cancellations, claims, billing) and having to re-explain the
+  death each time, which is both painful and inefficient
+- **Unclear documentation requirements** — she does not know upfront whether
+  TryggFörsäkring needs the original dödsbevis or a copy, whether the
+  bouppteckning must be registered with Skatteverket first, or whether a
+  fullmakt from other heirs is required
+- **Temporary coverage confusion** — Maja knows the car must stay insured but is
+  unsure whether the existing policy automatically continues, whether she needs
+  to sign a new agreement as estate representative, or whether the premium
+  changes during the settlement period
+- **Refund complexity** — she needs the unused premium refunded to the estate
+  account (not her father's now-frozen personal account) and worries the refund
+  will be delayed or sent to the wrong account without clear instructions
+
+## Tech Comfort Level
+
+**Medium.** Maja uses digital tools daily at work (electronic medical records,
+scheduling systems) and for personal banking via BankID. She is comfortable
+navigating online portals and submitting documents digitally. However, for a
+sensitive and unfamiliar process like estate insurance cancellation, she would
+prefer a guided experience — either a step-by-step online flow with clear
+instructions or a single phone call with a knowledgeable agent who can handle
+everything. She does not want to figure out the process through trial and error.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **FSA**    | Trafikförsäkring must remain active on the estate vehicle until it is formally deregistered at Transportstyrelsen or ownership is transferred to a new registered keeper (FSA-007).                          |
+| **FSA**    | The estate is entitled to a fair refund of unused premium for the remaining coverage period after cancellation, calculated pro rata (FSA-004).                                                               |
+| **GDPR**   | The deceased person's personal data is subject to retention rules; the estate representative has the right to access policy and claims information necessary for estate administration (GDPR-001, GDPR-003). |
+| **GDPR**   | Death certificates and estate inventory documents contain sensitive personal data that must be processed with appropriate safeguards and retained only as long as necessary (GDPR-004).                      |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Maja's father Sven
+  was the original policyholder; Maja interacts with TryggFörsäkring as his
+  estate representative, not as a customer herself.
+- [Transportstyrelsen](../actors/external/transportstyrelsen.md) — the estate
+  must coordinate vehicle deregistration or ownership transfer with
+  Transportstyrelsen before the motor policy can be fully cancelled.

--- a/versioned_docs/version-phase-1/personas/index.md
+++ b/versioned_docs/version-phase-1/personas/index.md
@@ -28,6 +28,7 @@ TryggFörsäkring platform must support.
 | [Henrik & Wilma Nilsson](henrik-wilma-nilsson)   | 48/17 | Teen Driver Family    | Safe, affordable coverage for a young driver   |
 | [David Lindgren](david-lindgren)                 | 30    | Leasing Customer      | Best price within leasing constraints          |
 | [Mohammed Hassan](mohammed-hassan)               | 42    | Insurer Switcher      | Seamless bonus transfer when switching insurer |
+| [Maja Andersson](maja-andersson)                 | 52    | Estate Executor       | Guided estate policy cancellation and refund   |
 | [Oscar Wallin](oscar-wallin)                     | 26    | Gig Economy Driver    | Clarity on coverage for ride-hailing use       |
 | [Karin Ström](karin-strom)                       | 45    | Divorce Transfer      | Smooth ownership transfer with bonus history   |
 

--- a/versioned_docs/version-phase-1/personas/maja-andersson.md
+++ b/versioned_docs/version-phase-1/personas/maja-andersson.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 11
+---
+
+# Maja Andersson, 52 — Estate Executor (Dödsboförvaltare)
+
+> _"My father passed away three weeks ago. He had TryggFörsäkring for over 30
+> years and I don't even know exactly what policies he had. I just need someone
+> to guide me through what to cancel, what to keep active, and where the refund
+> goes — without making me explain the situation five times to five different
+> people."_
+
+## Avatar Description
+
+A woman in her early fifties with reading glasses pushed up onto her head,
+sitting at a kitchen table covered with folders of paperwork — estate inventory
+forms, a death certificate, and insurance correspondence. A cup of tea sits
+untouched beside her laptop, which shows a Skatteverket bouppteckning page. She
+looks tired but determined, holding a pen and making notes on a printed list of
+her father's accounts and policies.
+
+## Demographics
+
+| Field      | Details                            |
+| ---------- | ---------------------------------- |
+| Age        | 52                                 |
+| Location   | Karlstad, Sweden                   |
+| Occupation | Nurse at Centralsjukhuset Karlstad |
+| Income     | Middle, public sector salary       |
+
+## Insurance Situation
+
+| Field               | Details                                                                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Estate coverage     | Deceased father Sven (78) held helförsäkring on a 2005 Volvo V70 with TryggFörsäkring for 30+ years                                       |
+| Vehicle             | 2005 Volvo V70 (registered to the estate of Sven Andersson)                                                                               |
+| Bonus class         | 7 (decades claim-free)                                                                                                                    |
+| Estate status       | Maja is appointed boutredningsman; the car is parked at Sven's house pending transfer to her brother Erik, who plans to sell it           |
+| Temporary coverage  | Trafikförsäkring must remain active on the Volvo V70 until the vehicle is formally deregistered at Transportstyrelsen or transferred/sold |
+| Maja's own coverage | Insured with Länsförsäkringar — she is not a TryggFörsäkring customer herself                                                             |
+
+## Goals
+
+- Get a clear, consolidated overview of all policies her father held with
+  TryggFörsäkring so she can cancel or transfer each one without missing
+  anything
+- Understand exactly what documentation is required — death certificate
+  (dödsbevis), estate inventory (bouppteckning), proof of executor role — so she
+  can gather everything in one round rather than being asked for additional
+  documents repeatedly
+- Ensure the prepaid premium is correctly refunded to the estate's bank account,
+  with a transparent calculation of the unused coverage period
+- Keep trafikförsäkring active on her father's Volvo V70 during the estate
+  settlement period so the car remains legally covered while parked, then cancel
+  or transfer the policy when her brother takes ownership
+- Complete the entire process with empathetic, respectful service — she should
+  not have to repeat the circumstances of her father's death to multiple
+  departments or agents
+
+## Frustrations / Pain Points
+
+- **Emotional burden compounded by bureaucracy** — Maja is grieving while
+  simultaneously navigating Skatteverket, banks, Transportstyrelsen, and now
+  insurance; each institution has its own forms, timelines, and requirements,
+  and none of them coordinate with each other
+- **No single point of contact** — she fears being transferred between
+  departments (cancellations, claims, billing) and having to re-explain the
+  death each time, which is both painful and inefficient
+- **Unclear documentation requirements** — she does not know upfront whether
+  TryggFörsäkring needs the original dödsbevis or a copy, whether the
+  bouppteckning must be registered with Skatteverket first, or whether a
+  fullmakt from other heirs is required
+- **Temporary coverage confusion** — Maja knows the car must stay insured but is
+  unsure whether the existing policy automatically continues, whether she needs
+  to sign a new agreement as estate representative, or whether the premium
+  changes during the settlement period
+- **Refund complexity** — she needs the unused premium refunded to the estate
+  account (not her father's now-frozen personal account) and worries the refund
+  will be delayed or sent to the wrong account without clear instructions
+
+## Tech Comfort Level
+
+**Medium.** Maja uses digital tools daily at work (electronic medical records,
+scheduling systems) and for personal banking via BankID. She is comfortable
+navigating online portals and submitting documents digitally. However, for a
+sensitive and unfamiliar process like estate insurance cancellation, she would
+prefer a guided experience — either a step-by-step online flow with clear
+instructions or a single phone call with a knowledgeable agent who can handle
+everything. She does not want to figure out the process through trial and error.
+
+## Regulatory Touchpoints
+
+| Regulation | Relevance                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **FSA**    | Trafikförsäkring must remain active on the estate vehicle until it is formally deregistered at Transportstyrelsen or ownership is transferred to a new registered keeper (FSA-007).                          |
+| **FSA**    | The estate is entitled to a fair refund of unused premium for the remaining coverage period after cancellation, calculated pro rata (FSA-004).                                                               |
+| **GDPR**   | The deceased person's personal data is subject to retention rules; the estate representative has the right to access policy and claims information necessary for estate administration (GDPR-001, GDPR-003). |
+| **GDPR**   | Death certificates and estate inventory documents contain sensitive personal data that must be processed with appropriate safeguards and retained only as long as necessary (GDPR-004).                      |
+
+## Related Actors
+
+- [Customer (Privatkund)](../actors/internal/customer.md) — Maja's father Sven
+  was the original policyholder; Maja interacts with TryggFörsäkring as his
+  estate representative, not as a customer herself.
+- [Transportstyrelsen](../actors/external/transportstyrelsen.md) — the estate
+  must coordinate vehicle deregistration or ownership transfer with
+  Transportstyrelsen before the motor policy can be fully cancelled.


### PR DESCRIPTION
## Summary
- Adds persona for Maja Andersson (52), an estate executor handling her deceased father's TryggFörsäkring policies
- Covers the sensitive death-triggered policy cancellation journey: documentation requirements, temporary coverage during estate settlement, premium refund to estate account
- Regulatory touchpoints: FSA-007 (active trafikförsäkring), FSA-004 (fair refund), GDPR-001/GDPR-003 (deceased data access), GDPR-004 (sensitive documents)

## Changes
- `versioned_docs/version-phase-1/personas/maja-andersson.md` — New persona file
- `docs/personas/maja-andersson.md` — Mirror in docs directory
- `versioned_docs/version-phase-1/personas/index.md` — Added to persona summary table
- `docs/personas/index.md` — Added to Phase 1 persona table

## Testing
- [x] Markdownlint passes with zero warnings
- [x] Prettier formatting check passes
- [x] Docusaurus build succeeds (links, frontmatter validated)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)